### PR TITLE
Add API changes from PoracleJS PRs #910 and #930

### DIFF
--- a/alerter/src/controllers/controller.js
+++ b/alerter/src/controllers/controller.js
@@ -403,10 +403,12 @@ class Controller extends EventEmitter {
 		}
 	}
 
-	async insertQuery(table, values) {
-		if (Array.isArray(values) && !values.length) return
+	async insertQuery(table, values, returning) {
+		if (Array.isArray(values) && !values.length) return []
 		try {
-			return await this.db.insert(values).into(table)
+			const q = this.db.insert(values).into(table)
+			if (returning) q.returning(returning)
+			return await q
 		} catch (err) {
 			throw { source: 'insertQuery', error: err }
 		}

--- a/alerter/src/routes/apiHumans.js
+++ b/alerter/src/routes/apiHumans.js
@@ -512,6 +512,102 @@ module.exports = async (fastify, options) => {
 		}
 	})
 
+	fastify.post('/api/humans', options, async (req) => {
+		fastify.logger.info(`API: ${req.ip} ${req.routeOptions.method} ${req.routeOptions.url}`)
+
+		if (fastify.config.server.ipWhitelist.length && !fastify.config.server.ipWhitelist.includes(req.ip)) return { webserver: 'unhappy', reason: `ip ${req.ip} not in whitelist` }
+		if (fastify.config.server.ipBlacklist.length && fastify.config.server.ipBlacklist.includes(req.ip)) return { webserver: 'unhappy', reason: `ip ${req.ip} in blacklist` }
+
+		const secret = req.headers['x-poracle-secret']
+		if (!secret || !fastify.config.server.apiSecret || secret !== fastify.config.server.apiSecret) {
+			return { status: 'authError', reason: 'incorrect or missing api secret' }
+		}
+
+		const body = req.body || {}
+		if (!body.id || !body.name) {
+			return { status: 'error', message: 'id and name are required' }
+		}
+
+		const existing = await fastify.query.selectOneQuery('humans', { id: body.id })
+		if (existing) {
+			return { status: 'error', message: 'User already exists' }
+		}
+
+		const human = {
+			id: body.id,
+			name: body.name,
+			type: body.type || 'discord:user',
+			enabled: body.enabled !== undefined ? +body.enabled : 1,
+			area: body.area || '[]',
+			latitude: body.latitude || 0.0,
+			longitude: body.longitude || 0.0,
+			admin_disable: body.admin_disable !== undefined ? +body.admin_disable : 0,
+			language: body.language || fastify.config.general.locale || 'en',
+			current_profile_no: 1,
+		}
+
+		if (body.community) {
+			human.community_membership = JSON.stringify(Array.isArray(body.community) ? body.community : [body.community])
+			const communityAreas = communityLogic.filterAreas(
+				fastify.config,
+				Array.isArray(body.community) ? body.community : [body.community],
+				fastify.geofence.geofence.map((x) => x.name.toLowerCase()),
+			)
+			human.area_restriction = JSON.stringify(communityAreas)
+		}
+
+		if (body.notes) human.notes = body.notes
+
+		await fastify.query.insertQuery('humans', human)
+
+		// Create default profile
+		const profile = {
+			id: body.id,
+			profile_no: 1,
+			name: body.profile_name || 'Default',
+			area: human.area,
+			latitude: human.latitude,
+			longitude: human.longitude,
+		}
+		await fastify.query.insertQuery('profiles', profile)
+
+		return {
+			status: 'ok',
+			message: 'User created successfully',
+			human,
+		}
+	})
+
+	fastify.post('/api/humans/:id/adminDisabled', options, async (req) => {
+		fastify.logger.info(`API: ${req.ip} ${req.routeOptions.method} ${req.routeOptions.url}`)
+
+		if (fastify.config.server.ipWhitelist.length && !fastify.config.server.ipWhitelist.includes(req.ip)) return { webserver: 'unhappy', reason: `ip ${req.ip} not in whitelist` }
+		if (fastify.config.server.ipBlacklist.length && fastify.config.server.ipBlacklist.includes(req.ip)) return { webserver: 'unhappy', reason: `ip ${req.ip} in blacklist` }
+
+		const secret = req.headers['x-poracle-secret']
+		if (!secret || !fastify.config.server.apiSecret || secret !== fastify.config.server.apiSecret) {
+			return { status: 'authError', reason: 'incorrect or missing api secret' }
+		}
+
+		const human = await fastify.query.selectOneQuery('humans', { id: req.params.id })
+		if (!human) {
+			return { status: 'error', message: 'User not found' }
+		}
+
+		const body = req.body || {}
+		if (body.state === undefined) {
+			return { status: 'error', message: 'state is required (true/false)' }
+		}
+
+		const adminDisable = body.state ? 1 : 0
+		await fastify.query.updateQuery('humans', { admin_disable: adminDisable }, { id: req.params.id })
+
+		return {
+			status: 'ok',
+			admin_disabled: adminDisable,
+		}
+	})
+
 	fastify.get('/api/humans/one/:id', options, async (req) => {
 		fastify.logger.info(`API: ${req.ip} ${req.routeOptions.method} ${req.routeOptions.url}`)
 

--- a/alerter/src/routes/apiTracking.js
+++ b/alerter/src/routes/apiTracking.js
@@ -19,7 +19,7 @@ module.exports = async (fastify, options) => {
 				message: 'User not found',
 			}
 		}
-		const currentProfileNo = human.current_profile_no
+		const currentProfileNo = req.query.profile_no || human.current_profile_no
 		const { id } = req.params
 
 		const pokemon = await fastify.query.selectAllQuery('monsters', { id, profile_no: currentProfileNo })

--- a/alerter/src/routes/apiTrackingEgg.js
+++ b/alerter/src/routes/apiTrackingEgg.js
@@ -26,7 +26,7 @@ module.exports = async (fastify, options) => {
 		const language = human.language || fastify.config.general.locale
 		const translator = fastify.translatorFactory.Translator(language)
 
-		const eggs = await fastify.query.selectAllQuery('egg', { id: req.params.id, profile_no: human.current_profile_no })
+		const eggs = await fastify.query.selectAllQuery('egg', { id: req.params.id, profile_no: req.query.profile_no || human.current_profile_no })
 
 		const eggWithDesc = await Promise.all(eggs.map(async (row) => ({ ...row, description: await trackedCommand.eggRowText(fastify.config, translator, fastify.GameData, row, fastify.scannerQuery) })))
 
@@ -78,32 +78,38 @@ module.exports = async (fastify, options) => {
 		const language = human.language || fastify.config.general.locale
 		const translator = fastify.translatorFactory.Translator(language)
 		const { id } = req.params
-		const currentProfileNo = human.current_profile_no
+		const currentProfileNo = req.query.profile_no || human.current_profile_no
+		const silent = req.query.silent || req.query.suppressMessage
 
 		let insertReq = req.body
 		if (!Array.isArray(insertReq)) insertReq = [insertReq]
 
 		const defaultTo = ((value, x) => ((value === undefined) ? x : value))
 
-		const insert = insertReq.map((row) => {
-			const level = +row.level
-			if (row.level === undefined || level < 1 || (level > Math.max(...Object.keys(raidLevels).map((k) => +k)) && level !== 90)) {
-				throw new Error('Invalid level')
+		const insert = []
+		for (const row of insertReq) {
+			// level accepts int or int[] — expand arrays into one row per level
+			const levels = Array.isArray(row.level) ? row.level : [row.level]
+			for (const lvl of levels) {
+				const level = +lvl
+				if (lvl === undefined || level < 1 || (level > Math.max(...Object.keys(raidLevels).map((k) => +k)) && level !== 90)) {
+					throw new Error('Invalid level')
+				}
+				insert.push({
+					id,
+					profile_no: currentProfileNo,
+					ping: '',
+					template: (row.template || fastify.config.general.defaultTemplateName).toString(),
+					exclusive: +defaultTo(row.exclusive, 0),
+					distance: +defaultTo(row.distance, 0),
+					team: row.team >= 0 && row.team <= 4 ? row.team : 4,
+					clean: +defaultTo(row.clean, 0),
+					level: +level,
+					gym_id: row.gym_id ? row.gym_id : null,
+					rsvp_changes: row.rsvp_changes >= 0 && row.rsvp_changes <= 2 ? row.rsvp_changes : 0,
+				})
 			}
-			return {
-				id,
-				profile_no: currentProfileNo,
-				ping: '',
-				template: (row.template || fastify.config.general.defaultTemplateName).toString(),
-				exclusive: +defaultTo(row.exclusive, 0),
-				distance: +defaultTo(row.distance, 0),
-				team: row.team >= 0 && row.team <= 4 ? row.team : 4, // carefully chosen to get nulls/undefined to 4 but allow 0
-				clean: +defaultTo(row.clean, 0),
-				level: +level,
-				gym_id: row.gym_id ? row.gym_id : null,
-				rsvp_changes: row.rsvp_changes >= 0 && row.rsvp_changes <= 2 ? row.rsvp_changes : 0,
-			}
-		})
+		}
 
 		try {
 			const tracked = await fastify.query.selectAllQuery('egg', { id, profile_no: currentProfileNo })
@@ -164,33 +170,40 @@ module.exports = async (fastify, options) => {
 				'uid',
 			)
 
-			await fastify.query.insertQuery('egg', [...insert, ...updates])
+			const insertResult = await fastify.query.insertQuery('egg', [...insert, ...updates], 'uid')
+			const newUids = Array.isArray(insertResult) ? insertResult.map((r) => (typeof r === 'object' ? r.uid : r)) : []
 			if (fastify.triggerReloadAlerts) fastify.triggerReloadAlerts()
 
 			// Send message to user
 
-			const data = [{
-				lat: 0,
-				lon: 0,
-				message: { content: message },
-				target: human.id,
-				type: human.type,
-				name: human.name,
-				tth: { hours: 1, minutes: 0, seconds: 0 },
-				clean: false,
-				emoji: '',
-				logReference: 'WebApi',
-				language,
-			}]
+			if (!silent) {
+				const data = [{
+					lat: 0,
+					lon: 0,
+					message: { content: message },
+					target: human.id,
+					type: human.type,
+					name: human.name,
+					tth: { hours: 1, minutes: 0, seconds: 0 },
+					clean: false,
+					emoji: '',
+					logReference: 'WebApi',
+					language,
+				}]
 
-			data.forEach((job) => {
-				if (['discord:user', 'discord:channel', 'webhook'].includes(job.type)) fastify.discordQueue.push(job)
-				if (['telegram:user', 'telegram:channel'].includes(job.type)) fastify.telegramQueue.push(job)
-			})
+				data.forEach((job) => {
+					if (['discord:user', 'discord:channel', 'webhook'].includes(job.type)) fastify.discordQueue.push(job)
+					if (['telegram:user', 'telegram:channel'].includes(job.type)) fastify.telegramQueue.push(job)
+				})
+			}
 
 			return {
 				status: 'ok',
-				message,
+				message: silent ? '' : message,
+				newUids,
+				alreadyPresent: alreadyPresent.length,
+				updates: updates.length,
+				insert: insert.length,
 			}
 		} catch (err) {
 			fastify.logger.error(`API: ${req.ip} ${req.routeOptions.method} ${req.routeOptions.url}`, err)

--- a/alerter/src/routes/apiTrackingGym.js
+++ b/alerter/src/routes/apiTrackingGym.js
@@ -24,7 +24,7 @@ module.exports = async (fastify, options) => {
 		const language = human.language || fastify.config.general.locale
 		const translator = fastify.translatorFactory.Translator(language)
 
-		const gyms = await fastify.query.selectAllQuery('gym', { id: req.params.id, profile_no: human.current_profile_no })
+		const gyms = await fastify.query.selectAllQuery('gym', { id: req.params.id, profile_no: req.query.profile_no || human.current_profile_no })
 
 		const gymWithDesc = await Promise.all(gyms.map(async (row) => ({ ...row, description: await trackedCommand.gymRowText(fastify.config, translator, fastify.GameData, row, fastify.scannerQuery) })))
 
@@ -75,7 +75,8 @@ module.exports = async (fastify, options) => {
 		const language = human.language || fastify.config.general.locale
 		const translator = fastify.translatorFactory.Translator(language)
 		const { id } = req.params
-		const currentProfileNo = human.current_profile_no
+		const currentProfileNo = req.query.profile_no || human.current_profile_no
+		const silent = req.query.silent || req.query.suppressMessage
 
 		let insertReq = req.body
 		if (!Array.isArray(insertReq)) insertReq = [insertReq]
@@ -160,32 +161,39 @@ module.exports = async (fastify, options) => {
 				'uid',
 			)
 
-			await fastify.query.insertQuery('gym', [...insert, ...updates])
+			const insertResult = await fastify.query.insertQuery('gym', [...insert, ...updates], 'uid')
+			const newUids = Array.isArray(insertResult) ? insertResult.map((r) => (typeof r === 'object' ? r.uid : r)) : []
 
 			// Send message to user
 
-			const data = [{
-				lat: 0,
-				lon: 0,
-				message: { content: message },
-				target: human.id,
-				type: human.type,
-				name: human.name,
-				tth: { hours: 1, minutes: 0, seconds: 0 },
-				clean: false,
-				emoji: '',
-				logReference: 'WebApi',
-				language,
-			}]
+			if (!silent) {
+				const data = [{
+					lat: 0,
+					lon: 0,
+					message: { content: message },
+					target: human.id,
+					type: human.type,
+					name: human.name,
+					tth: { hours: 1, minutes: 0, seconds: 0 },
+					clean: false,
+					emoji: '',
+					logReference: 'WebApi',
+					language,
+				}]
 
-			data.forEach((job) => {
-				if (['discord:user', 'discord:channel', 'webhook'].includes(job.type)) fastify.discordQueue.push(job)
-				if (['telegram:user', 'telegram:channel'].includes(job.type)) fastify.telegramQueue.push(job)
-			})
+				data.forEach((job) => {
+					if (['discord:user', 'discord:channel', 'webhook'].includes(job.type)) fastify.discordQueue.push(job)
+					if (['telegram:user', 'telegram:channel'].includes(job.type)) fastify.telegramQueue.push(job)
+				})
+			}
 
 			return {
 				status: 'ok',
-				message,
+				message: silent ? '' : message,
+				newUids,
+				alreadyPresent: alreadyPresent.length,
+				updates: updates.length,
+				insert: insert.length,
 			}
 		} catch (err) {
 			fastify.logger.error(`API: ${req.ip} ${req.routeOptions.method} ${req.routeOptions.url}`, err)

--- a/alerter/src/routes/apiTrackingInvasion.js
+++ b/alerter/src/routes/apiTrackingInvasion.js
@@ -22,7 +22,7 @@ module.exports = async (fastify, options) => {
 			}
 		}
 
-		const invasion = await fastify.query.selectAllQuery('invasion', { id: req.params.id, profile_no: human.current_profile_no })
+		const invasion = await fastify.query.selectAllQuery('invasion', { id: req.params.id, profile_no: req.query.profile_no || human.current_profile_no })
 
 		return {
 			status: 'ok',
@@ -71,7 +71,8 @@ module.exports = async (fastify, options) => {
 		const language = human.language || fastify.config.general.locale
 		const translator = fastify.translatorFactory.Translator(language)
 		const { id } = req.params
-		const currentProfileNo = human.current_profile_no
+		const currentProfileNo = req.query.profile_no || human.current_profile_no
+		const silent = req.query.silent || req.query.suppressMessage
 
 		let insertReq = req.body
 		if (!Array.isArray(insertReq)) insertReq = [insertReq]
@@ -153,32 +154,39 @@ module.exports = async (fastify, options) => {
 				'uid',
 			)
 
-			await fastify.query.insertQuery('invasion', [...insert, ...updates])
+			const insertResult = await fastify.query.insertQuery('invasion', [...insert, ...updates], 'uid')
+			const newUids = Array.isArray(insertResult) ? insertResult.map((r) => (typeof r === 'object' ? r.uid : r)) : []
 
 			// Send message to user
 
-			const data = [{
-				lat: 0,
-				lon: 0,
-				message: { content: message },
-				target: human.id,
-				type: human.type,
-				name: human.name,
-				tth: { hours: 1, minutes: 0, seconds: 0 },
-				clean: false,
-				emoji: '',
-				logReference: 'WebApi',
-				language,
-			}]
+			if (!silent) {
+				const data = [{
+					lat: 0,
+					lon: 0,
+					message: { content: message },
+					target: human.id,
+					type: human.type,
+					name: human.name,
+					tth: { hours: 1, minutes: 0, seconds: 0 },
+					clean: false,
+					emoji: '',
+					logReference: 'WebApi',
+					language,
+				}]
 
-			data.forEach((job) => {
-				if (['discord:user', 'discord:channel', 'webhook'].includes(job.type)) fastify.discordQueue.push(job)
-				if (['telegram:user', 'telegram:channel'].includes(job.type)) fastify.telegramQueue.push(job)
-			})
+				data.forEach((job) => {
+					if (['discord:user', 'discord:channel', 'webhook'].includes(job.type)) fastify.discordQueue.push(job)
+					if (['telegram:user', 'telegram:channel'].includes(job.type)) fastify.telegramQueue.push(job)
+				})
+			}
 
 			return {
 				status: 'ok',
-				message,
+				message: silent ? '' : message,
+				newUids,
+				alreadyPresent: alreadyPresent.length,
+				updates: updates.length,
+				insert: insert.length,
 			}
 		} catch (err) {
 			fastify.logger.error(`API: ${req.ip} ${req.routeOptions.method} ${req.routeOptions.url}`, err)

--- a/alerter/src/routes/apiTrackingLure.js
+++ b/alerter/src/routes/apiTrackingLure.js
@@ -22,7 +22,7 @@ module.exports = async (fastify, options) => {
 			}
 		}
 
-		const lure = await fastify.query.selectAllQuery('lures', { id: req.params.id, profile_no: human.current_profile_no })
+		const lure = await fastify.query.selectAllQuery('lures', { id: req.params.id, profile_no: req.query.profile_no || human.current_profile_no })
 
 		return {
 			status: 'ok',
@@ -71,7 +71,8 @@ module.exports = async (fastify, options) => {
 		const language = human.language || fastify.config.general.locale
 		const translator = fastify.translatorFactory.Translator(language)
 		const { id } = req.params
-		const currentProfileNo = human.current_profile_no
+		const currentProfileNo = req.query.profile_no || human.current_profile_no
+		const silent = req.query.silent || req.query.suppressMessage
 
 		let insertReq = req.body
 		if (!Array.isArray(insertReq)) insertReq = [insertReq]
@@ -153,32 +154,39 @@ module.exports = async (fastify, options) => {
 				'uid',
 			)
 
-			await fastify.query.insertQuery('lures', [...insert, ...updates])
+			const insertResult = await fastify.query.insertQuery('lures', [...insert, ...updates], 'uid')
+			const newUids = Array.isArray(insertResult) ? insertResult.map((r) => (typeof r === 'object' ? r.uid : r)) : []
 
 			// Send message to user
 
-			const data = [{
-				lat: 0,
-				lon: 0,
-				message: { content: message },
-				target: human.id,
-				type: human.type,
-				name: human.name,
-				tth: { hours: 1, minutes: 0, seconds: 0 },
-				clean: false,
-				emoji: '',
-				logReference: 'WebApi',
-				language,
-			}]
+			if (!silent) {
+				const data = [{
+					lat: 0,
+					lon: 0,
+					message: { content: message },
+					target: human.id,
+					type: human.type,
+					name: human.name,
+					tth: { hours: 1, minutes: 0, seconds: 0 },
+					clean: false,
+					emoji: '',
+					logReference: 'WebApi',
+					language,
+				}]
 
-			data.forEach((job) => {
-				if (['discord:user', 'discord:channel', 'webhook'].includes(job.type)) fastify.discordQueue.push(job)
-				if (['telegram:user', 'telegram:channel'].includes(job.type)) fastify.telegramQueue.push(job)
-			})
+				data.forEach((job) => {
+					if (['discord:user', 'discord:channel', 'webhook'].includes(job.type)) fastify.discordQueue.push(job)
+					if (['telegram:user', 'telegram:channel'].includes(job.type)) fastify.telegramQueue.push(job)
+				})
+			}
 
 			return {
 				status: 'ok',
-				message,
+				message: silent ? '' : message,
+				newUids,
+				alreadyPresent: alreadyPresent.length,
+				updates: updates.length,
+				insert: insert.length,
 			}
 		} catch (err) {
 			fastify.logger.error(`API: ${req.ip} ${req.routeOptions.method} ${req.routeOptions.url}`, err)

--- a/alerter/src/routes/apiTrackingMonster.js
+++ b/alerter/src/routes/apiTrackingMonster.js
@@ -25,7 +25,7 @@ module.exports = async (fastify, options) => {
 			}
 		}
 
-		const monsters = await fastify.query.selectAllQuery('monsters', { id: req.params.id, profile_no: human.current_profile_no })
+		const monsters = await fastify.query.selectAllQuery('monsters', { id: req.params.id, profile_no: req.query.profile_no || human.current_profile_no })
 
 		return {
 			status: 'ok',
@@ -101,7 +101,8 @@ module.exports = async (fastify, options) => {
 		const language = human.language || fastify.config.general.locale
 		const translator = fastify.translatorFactory.Translator(language)
 		const { id } = req.params
-		const currentProfileNo = human.current_profile_no
+		const currentProfileNo = req.query.profile_no || human.current_profile_no
+		const silent = req.query.silent || req.query.suppressMessage
 
 		let insertReq = req.body
 		if (!Array.isArray(insertReq)) insertReq = [insertReq]
@@ -216,39 +217,49 @@ module.exports = async (fastify, options) => {
 			// 'uid')
 			// await fastify.query.insertQuery('monsters', [...insert, ...updates])
 
+			const newUids = []
+
 			if (insert.length) {
-				await fastify.query.insertQuery('monsters', insert)
+				const insertResult = await fastify.query.insertQuery('monsters', insert, 'uid')
+				if (Array.isArray(insertResult)) newUids.push(...insertResult.map((r) => (typeof r === 'object' ? r.uid : r)))
 			}
 			for (const row of updates) {
 				await fastify.query.updateQuery('monsters', row, { uid: row.uid })
+				newUids.push(row.uid)
 			}
 
 			// Send message to user
 
-			const data = [{
-				lat: 0,
-				lon: 0,
-				message: { content: message },
-				target: human.id,
-				type: human.type,
-				name: human.name,
-				tth: { hours: 1, minutes: 0, seconds: 0 },
-				clean: false,
-				emoji: '',
-				logReference: 'WebApi',
-				language,
-			}]
+			if (!silent) {
+				const data = [{
+					lat: 0,
+					lon: 0,
+					message: { content: message },
+					target: human.id,
+					type: human.type,
+					name: human.name,
+					tth: { hours: 1, minutes: 0, seconds: 0 },
+					clean: false,
+					emoji: '',
+					logReference: 'WebApi',
+					language,
+				}]
 
-			data.forEach((job) => {
-				if (['discord:user', 'discord:channel', 'webhook'].includes(job.type)) fastify.discordQueue.push(job)
-				if (['telegram:user', 'telegram:channel'].includes(job.type)) fastify.telegramQueue.push(job)
-			})
+				data.forEach((job) => {
+					if (['discord:user', 'discord:channel', 'webhook'].includes(job.type)) fastify.discordQueue.push(job)
+					if (['telegram:user', 'telegram:channel'].includes(job.type)) fastify.telegramQueue.push(job)
+				})
+			}
 
 			if (fastify.triggerReloadAlerts) fastify.triggerReloadAlerts()
 
 			return {
 				status: 'ok',
-				message,
+				message: silent ? '' : message,
+				newUids,
+				alreadyPresent: alreadyPresent.length,
+				updates: updates.length,
+				insert: insert.length,
 			}
 		} catch (err) {
 			fastify.logger.error(`API: ${req.ip} ${req.routeOptions.method} ${req.routeOptions.url}`, err)

--- a/alerter/src/routes/apiTrackingNest.js
+++ b/alerter/src/routes/apiTrackingNest.js
@@ -22,7 +22,7 @@ module.exports = async (fastify, options) => {
 			}
 		}
 
-		const nest = await fastify.query.selectAllQuery('nests', { id: req.params.id, profile_no: human.current_profile_no })
+		const nest = await fastify.query.selectAllQuery('nests', { id: req.params.id, profile_no: req.query.profile_no || human.current_profile_no })
 
 		return {
 			status: 'ok',
@@ -71,7 +71,8 @@ module.exports = async (fastify, options) => {
 		const language = human.language || fastify.config.general.locale
 		const translator = fastify.translatorFactory.Translator(language)
 		const { id } = req.params
-		const currentProfileNo = human.current_profile_no
+		const currentProfileNo = req.query.profile_no || human.current_profile_no
+		const silent = req.query.silent || req.query.suppressMessage
 
 		let insertReq = req.body
 		if (!Array.isArray(insertReq)) insertReq = [insertReq]
@@ -149,32 +150,39 @@ module.exports = async (fastify, options) => {
 				'uid',
 			)
 
-			await fastify.query.insertQuery('nests', [...insert, ...updates])
+			const insertResult = await fastify.query.insertQuery('nests', [...insert, ...updates], 'uid')
+			const newUids = Array.isArray(insertResult) ? insertResult.map((r) => (typeof r === 'object' ? r.uid : r)) : []
 
 			// Send message to user
 
-			const data = [{
-				lat: 0,
-				lon: 0,
-				message: { content: message },
-				target: human.id,
-				type: human.type,
-				name: human.name,
-				tth: { hours: 1, minutes: 0, seconds: 0 },
-				clean: false,
-				emoji: '',
-				logReference: 'WebApi',
-				language,
-			}]
+			if (!silent) {
+				const data = [{
+					lat: 0,
+					lon: 0,
+					message: { content: message },
+					target: human.id,
+					type: human.type,
+					name: human.name,
+					tth: { hours: 1, minutes: 0, seconds: 0 },
+					clean: false,
+					emoji: '',
+					logReference: 'WebApi',
+					language,
+				}]
 
-			data.forEach((job) => {
-				if (['discord:user', 'discord:channel', 'webhook'].includes(job.type)) fastify.discordQueue.push(job)
-				if (['telegram:user', 'telegram:channel'].includes(job.type)) fastify.telegramQueue.push(job)
-			})
+				data.forEach((job) => {
+					if (['discord:user', 'discord:channel', 'webhook'].includes(job.type)) fastify.discordQueue.push(job)
+					if (['telegram:user', 'telegram:channel'].includes(job.type)) fastify.telegramQueue.push(job)
+				})
+			}
 
 			return {
 				status: 'ok',
-				message,
+				message: silent ? '' : message,
+				newUids,
+				alreadyPresent: alreadyPresent.length,
+				updates: updates.length,
+				insert: insert.length,
 			}
 		} catch (err) {
 			fastify.logger.error(`API: ${req.ip} ${req.routeOptions.method} ${req.routeOptions.url}`, err)

--- a/alerter/src/routes/apiTrackingQuest.js
+++ b/alerter/src/routes/apiTrackingQuest.js
@@ -22,7 +22,7 @@ module.exports = async (fastify, options) => {
 			}
 		}
 
-		const quest = await fastify.query.selectAllQuery('quest', { id: req.params.id, profile_no: human.current_profile_no })
+		const quest = await fastify.query.selectAllQuery('quest', { id: req.params.id, profile_no: req.query.profile_no || human.current_profile_no })
 
 		return {
 			status: 'ok',
@@ -71,7 +71,8 @@ module.exports = async (fastify, options) => {
 		const language = human.language || fastify.config.general.locale
 		const translator = fastify.translatorFactory.Translator(language)
 		const { id } = req.params
-		const currentProfileNo = human.current_profile_no
+		const currentProfileNo = req.query.profile_no || human.current_profile_no
+		const silent = req.query.silent || req.query.suppressMessage
 
 		let insertReq = req.body
 		if (!Array.isArray(insertReq)) insertReq = [insertReq]
@@ -156,32 +157,39 @@ module.exports = async (fastify, options) => {
 				'uid',
 			)
 
-			await fastify.query.insertQuery('quest', [...insert, ...updates])
+			const insertResult = await fastify.query.insertQuery('quest', [...insert, ...updates], 'uid')
+			const newUids = Array.isArray(insertResult) ? insertResult.map((r) => (typeof r === 'object' ? r.uid : r)) : []
 
 			// Send message to user
 
-			const data = [{
-				lat: 0,
-				lon: 0,
-				message: { content: message },
-				target: human.id,
-				type: human.type,
-				name: human.name,
-				tth: { hours: 1, minutes: 0, seconds: 0 },
-				clean: false,
-				emoji: '',
-				logReference: 'WebApi',
-				language,
-			}]
+			if (!silent) {
+				const data = [{
+					lat: 0,
+					lon: 0,
+					message: { content: message },
+					target: human.id,
+					type: human.type,
+					name: human.name,
+					tth: { hours: 1, minutes: 0, seconds: 0 },
+					clean: false,
+					emoji: '',
+					logReference: 'WebApi',
+					language,
+				}]
 
-			data.forEach((job) => {
-				if (['discord:user', 'discord:channel', 'webhook'].includes(job.type)) fastify.discordQueue.push(job)
-				if (['telegram:user', 'telegram:channel'].includes(job.type)) fastify.telegramQueue.push(job)
-			})
+				data.forEach((job) => {
+					if (['discord:user', 'discord:channel', 'webhook'].includes(job.type)) fastify.discordQueue.push(job)
+					if (['telegram:user', 'telegram:channel'].includes(job.type)) fastify.telegramQueue.push(job)
+				})
+			}
 
 			return {
 				status: 'ok',
-				message,
+				message: silent ? '' : message,
+				newUids,
+				alreadyPresent: alreadyPresent.length,
+				updates: updates.length,
+				insert: insert.length,
 			}
 		} catch (err) {
 			fastify.logger.error(`API: ${req.ip} ${req.routeOptions.method} ${req.routeOptions.url}`, err)

--- a/alerter/src/routes/apiTrackingRaid.js
+++ b/alerter/src/routes/apiTrackingRaid.js
@@ -24,7 +24,7 @@ module.exports = async (fastify, options) => {
 		const language = human.language || fastify.config.general.locale
 		const translator = fastify.translatorFactory.Translator(language)
 
-		const raids = await fastify.query.selectAllQuery('raid', { id: req.params.id, profile_no: human.current_profile_no })
+		const raids = await fastify.query.selectAllQuery('raid', { id: req.params.id, profile_no: req.query.profile_no || human.current_profile_no })
 
 		const raidWithDesc = await Promise.all(raids.map(async (row) => ({ ...row, description: await trackedCommand.raidRowText(fastify.config, translator, fastify.GameData, row, fastify.scannerQuery) })))
 
@@ -76,40 +76,71 @@ module.exports = async (fastify, options) => {
 		const language = human.language || fastify.config.general.locale
 		const translator = fastify.translatorFactory.Translator(language)
 		const { id } = req.params
-		const currentProfileNo = human.current_profile_no
+		const currentProfileNo = req.query.profile_no || human.current_profile_no
+		const silent = req.query.silent || req.query.suppressMessage
 
 		let insertReq = req.body
 		if (!Array.isArray(insertReq)) insertReq = [insertReq]
 
 		const defaultTo = ((value, x) => ((value === undefined) ? x : value))
 
-		const insert = insertReq.map((row) => {
-			let level = 9000
-			if (row.pokemon_id === 9000) {
-				level = +row.level
-				if (row.level === undefined || level < 1 || (level > Math.max(...Object.keys(fastify.GameData.utilData.raidLevels).map((k) => +k)) && level !== 90)) {
-					throw new Error('Invalid level (must be specified if no pokemon_id')
+		const insert = []
+		for (const row of insertReq) {
+			// pokemon_form: array of {pokemon_id, form} — each becomes a separate row with level=9000
+			if (row.pokemon_form && Array.isArray(row.pokemon_form)) {
+				for (const pf of row.pokemon_form) {
+					insert.push({
+						id,
+						profile_no: currentProfileNo,
+						ping: '',
+						template: (row.template || fastify.config.general.defaultTemplateName).toString(),
+						pokemon_id: +pf.pokemon_id,
+						exclusive: +defaultTo(row.exclusive, 0),
+						distance: +defaultTo(row.distance, 0),
+						team: row.team >= 0 && row.team <= 4 ? row.team : 4,
+						clean: +defaultTo(+row.clean, 0),
+						level: 9000,
+						form: +defaultTo(pf.form, 0),
+						move: +defaultTo(row.move, 9000),
+						evolution: +defaultTo(row.evolution, 9000),
+						gym_id: row.gym_id ? row.gym_id : null,
+						rsvp_changes: row.rsvp_changes >= 0 && row.rsvp_changes <= 2 ? row.rsvp_changes : 0,
+					})
 				}
+				continue
 			}
 
-			return {
-				id,
-				profile_no: currentProfileNo,
-				ping: '',
-				template: (row.template || fastify.config.general.defaultTemplateName).toString(),
-				pokemon_id: +defaultTo(row.pokemon_id, 9000),
-				exclusive: +defaultTo(row.exclusive, 0),
-				distance: +defaultTo(row.distance, 0),
-				team: row.team >= 0 && row.team <= 4 ? row.team : 4, // carefully chosen to get nulls/undefined to 4 but allow 0
-				clean: +defaultTo(+row.clean, 0),
-				level: +level,
-				form: +defaultTo(row.form, 0),
-				move: +defaultTo(row.move, 9000),
-				evolution: +defaultTo(row.evolution, 9000),
-				gym_id: row.gym_id ? row.gym_id : null,
-				rsvp_changes: row.rsvp_changes >= 0 && row.rsvp_changes <= 2 ? row.rsvp_changes : 0,
+			// level accepts int or int[] — expand arrays into one row per level
+			const levels = Array.isArray(row.level) ? row.level : [row.level]
+
+			for (const lvl of levels) {
+				let level = 9000
+				if (+defaultTo(row.pokemon_id, 9000) === 9000) {
+					level = +lvl
+					if (lvl === undefined || level < 1 || (level > Math.max(...Object.keys(fastify.GameData.utilData.raidLevels).map((k) => +k)) && level !== 90)) {
+						throw new Error('Invalid level (must be specified if no pokemon_id)')
+					}
+				}
+
+				insert.push({
+					id,
+					profile_no: currentProfileNo,
+					ping: '',
+					template: (row.template || fastify.config.general.defaultTemplateName).toString(),
+					pokemon_id: +defaultTo(row.pokemon_id, 9000),
+					exclusive: +defaultTo(row.exclusive, 0),
+					distance: +defaultTo(row.distance, 0),
+					team: row.team >= 0 && row.team <= 4 ? row.team : 4,
+					clean: +defaultTo(+row.clean, 0),
+					level: +level,
+					form: +defaultTo(row.form, 0),
+					move: +defaultTo(row.move, 9000),
+					evolution: +defaultTo(row.evolution, 9000),
+					gym_id: row.gym_id ? row.gym_id : null,
+					rsvp_changes: row.rsvp_changes >= 0 && row.rsvp_changes <= 2 ? row.rsvp_changes : 0,
+				})
 			}
-		})
+		}
 
 		try {
 			const tracked = await fastify.query.selectAllQuery('raid', { id, profile_no: currentProfileNo })
@@ -170,33 +201,40 @@ module.exports = async (fastify, options) => {
 				'uid',
 			)
 
-			await fastify.query.insertQuery('raid', [...insert, ...updates])
+			const insertResult = await fastify.query.insertQuery('raid', [...insert, ...updates], 'uid')
+			const newUids = Array.isArray(insertResult) ? insertResult.map((r) => (typeof r === 'object' ? r.uid : r)) : []
 			if (fastify.triggerReloadAlerts) fastify.triggerReloadAlerts()
 
 			// Send message to user
 
-			const data = [{
-				lat: 0,
-				lon: 0,
-				message: { content: message },
-				target: human.id,
-				type: human.type,
-				name: human.name,
-				tth: { hours: 1, minutes: 0, seconds: 0 },
-				clean: false,
-				emoji: '',
-				logReference: 'WebApi',
-				language,
-			}]
+			if (!silent) {
+				const data = [{
+					lat: 0,
+					lon: 0,
+					message: { content: message },
+					target: human.id,
+					type: human.type,
+					name: human.name,
+					tth: { hours: 1, minutes: 0, seconds: 0 },
+					clean: false,
+					emoji: '',
+					logReference: 'WebApi',
+					language,
+				}]
 
-			data.forEach((job) => {
-				if (['discord:user', 'discord:channel', 'webhook'].includes(job.type)) fastify.discordQueue.push(job)
-				if (['telegram:user', 'telegram:channel'].includes(job.type)) fastify.telegramQueue.push(job)
-			})
+				data.forEach((job) => {
+					if (['discord:user', 'discord:channel', 'webhook'].includes(job.type)) fastify.discordQueue.push(job)
+					if (['telegram:user', 'telegram:channel'].includes(job.type)) fastify.telegramQueue.push(job)
+				})
+			}
 
 			return {
 				status: 'ok',
-				message,
+				message: silent ? '' : message,
+				newUids,
+				alreadyPresent: alreadyPresent.length,
+				updates: updates.length,
+				insert: insert.length,
 			}
 		} catch (err) {
 			fastify.logger.error(`API: ${req.ip} ${req.routeOptions.method} ${req.routeOptions.url}`, err)


### PR DESCRIPTION
## Summary

- **New `POST /api/humans`** endpoint to create users with optional community membership and default profile
- **New `POST /api/humans/:id/adminDisabled`** endpoint to set/clear the admin_disable flag
- **`?profile_no` query param** on all tracking GET and POST routes to override the user's current_profile_no
- **`?silent` / `?suppressMessage` query param** on all tracking POST routes to suppress Discord/Telegram confirmation messages
- **Richer POST responses** with `newUids`, `alreadyPresent`, `updates`, and `insert` counts
- **Egg and raid `level` accepts `int | int[]`** — one DB row created per level value
- **Raid `pokemon_form` field** — array of `{pokemon_id, form}` for pokemon-specific raid tracking
- **`insertQuery` supports `returning`** parameter for `RETURNING uid` clause

Based on upstream [PoracleJS#910](https://github.com/KartulUdus/PoracleJS/pull/910) and [PoracleJS#930](https://github.com/KartulUdus/PoracleJS/pull/930).

## Test plan

- [ ] `POST /api/humans` creates a user and default profile
- [ ] `POST /api/humans/:id/adminDisabled` toggles the flag
- [ ] Tracking GET routes respect `?profile_no`
- [ ] Tracking POST routes respect `?profile_no`, `?silent`, `?suppressMessage`
- [ ] POST responses include `newUids`, `alreadyPresent`, `updates`, `insert`
- [ ] Egg/raid POST with `level: [1,3,5]` creates one row per level
- [ ] Raid POST with `pokemon_form` creates pokemon-specific tracking rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)