### PR TITLE
Add unrecognized argument validation to tracking commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 .DS_Store
 config/config.toml
+logs/*
+config/*
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN npm install --omit=dev --ignore-scripts && npm rebuild
 # ---- Stage 3: Runtime image ----
 FROM node:24-alpine
 
-RUN apk add --no-cache curl bash tini
+RUN apk add --no-cache curl bash tini tzdata
 
 WORKDIR /app
 

--- a/alerter/.eslintrc
+++ b/alerter/.eslintrc
@@ -18,6 +18,7 @@
         "no-plusplus": [ "off" ],
         "no-throw-literal": ["off"],
         "no-param-reassign": ["off"],
-        "no-bitwise": ["error", { "allow": ["~"] }]
+        "no-bitwise": ["error", { "allow": ["~"] }],
+        "brace-style": ["error", "1tbs", { "allowSingleLine": true }]
     }
 }

--- a/alerter/package.json
+++ b/alerter/package.json
@@ -46,7 +46,6 @@
     "form-data": "^4.0.5",
     "geo-tz": "^8.1.6",
     "handlebars": "^4.7.8",
-    "hastebin-gen": "^2.0.5",
     "import-fresh": "^3.3.0",
     "json5": "^2.2.3",
     "knex": "^3.1.0",

--- a/alerter/package.json
+++ b/alerter/package.json
@@ -29,7 +29,8 @@
     "migrateV3": "node src/init/migrateV3.js",
     "prepare": "husky",
     "start": "npm run generate && npm run koji && node .",
-    "test": "node test/test"
+    "test": "node test/test",
+    "test:commands": "mocha src/lib/poracleMessage/commands/__tests__/*.test.js --timeout 10000"
   },
   "dependencies": {
     "@budibase/handlebars-helpers": "^0.13.1",

--- a/alerter/src/controllers/maxbattle.js
+++ b/alerter/src/controllers/maxbattle.js
@@ -123,152 +123,151 @@ class Maxbattle extends Controller {
 					const rateLimitTtr = this.getRateLimitTimeToRelease(cares.id)
 					if (rateLimitTtr) {
 						this.log.verbose(`${logReference}: Not creating maxbattle alert (Rate limit) for ${cares.type} ${cares.id} ${cares.name} TTR: ${rateLimitTtr}`)
-						continue
-					}
-
-					const language = cares.language || this.config.general.locale
-					const translator = this.translatorFactory.Translator(language)
-					let [platform] = cares.type.split(':')
-					if (platform === 'webhook') platform = 'discord'
-
-					data.name = translator.translate(data.nameEng)
-					data.formName = translator.translate(data.formNameEng)
-					data.evolutionName = translator.translate(data.evolutionNameEng)
-					data.formNormalisedEng = data.formNameEng === 'Normal' ? '' : data.formNameEng
-					data.formNormalised = translator.translate(data.formNormalisedEng)
-
-					if (data.evolution) {
-						data.fullNameEng = translator.format(this.GameData.utilData.megaName[data.evolution], data.nameEng.concat(data.formNormalisedEng ? ' ' : '', data.formNormalisedEng))
-						data.fullName = translator.translateFormat(this.GameData.utilData.megaName[data.evolution], data.name.concat(data.formNormalised ? ' ' : '', data.formNormalised))
 					} else {
-						data.fullNameEng = data.nameEng.concat(data.formNormalisedEng ? ' ' : '', data.formNormalisedEng)
-						data.fullName = data.name.concat(data.formNormalised ? ' ' : '', data.formNormalised)
-					}
+						const language = cares.language || this.config.general.locale
+						const translator = this.translatorFactory.Translator(language)
+						let [platform] = cares.type.split(':')
+						if (platform === 'webhook') platform = 'discord'
 
-					data.levelName = translator.translateFormat(data.levelNameEng)
-					data.megaName = data.evolution ? translator.translateFormat(this.GameData.utilData.megaName[data.evolution], data.name) : data.name
-					data.quickMoveName = this.GameData.moves[data.move_1] ? translator.translate(this.GameData.moves[data.move_1].name) : ''
-					data.quickMoveEmoji = this.GameData.moves[data.move_1] && this.GameData.moves[data.move_1].type ? translator.translate(this.emojiLookup.lookup(this.GameData.utilData.types[this.GameData.moves[data.move_1].type].emoji, platform)) : ''
-					data.chargeMoveName = this.GameData.moves[data.move_2] ? translator.translate(this.GameData.moves[data.move_2].name) : ''
-					data.chargeMoveEmoji = this.GameData.moves[data.move_2] && this.GameData.moves[data.move_2].type ? translator.translate(this.emojiLookup.lookup(this.GameData.utilData.types[this.GameData.moves[data.move_2].type].emoji, platform)) : ''
-					data.gameWeatherName = data.weather ? translator.translate(data.gameWeatherNameEng) : ''
-					data.gameWeatherEmoji = data.weather ? translator.translate(this.emojiLookup.lookup(this.GameData.utilData.weather[data.weather].emoji, platform)) : ''
-					data.shinyPossibleEmoji = data.shinyPossible ? translator.translate(this.emojiLookup.lookup('shiny', platform)) : ''
-					data.generationName = translator.translate(data.generationNameEng)
+						data.name = translator.translate(data.nameEng)
+						data.formName = translator.translate(data.formNameEng)
+						data.evolutionName = translator.translate(data.evolutionNameEng)
+						data.formNormalisedEng = data.formNameEng === 'Normal' ? '' : data.formNameEng
+						data.formNormalised = translator.translate(data.formNormalisedEng)
 
-					const e = []
-					const n = []
-					monster.types.forEach((type) => {
-						e.push(this.emojiLookup.lookup(this.GameData.utilData.types[type.name].emoji, platform))
-						n.push(type.name)
-					})
-					data.typeNameEng = n
-					data.emoji = e
-					data.typeName = data.typeNameEng.map((type) => translator.translate(type)).join(', ')
-					data.typeEmoji = data.emoji.map((emoji) => translator.translate(emoji)).join('')
-
-					data.boostingWeathers = data.types.map((type) => parseInt(Object.keys(this.GameData.utilData.weatherTypeBoost).find((key) => this.GameData.utilData.weatherTypeBoost[key].includes(type)), 10))
-					data.boostingWeathersEmoji = data.boostingWeathers.map((weather) => translator.translate(this.emojiLookup.lookup(this.GameData.utilData.weather[weather].emoji, platform))).join('')
-					data.boosted = !!data.boostingWeathers.includes(data.weather)
-					data.boostWeatherNameEng = data.boosted ? this.GameData.utilData.weather[data.weather].name : ''
-					data.boostWeatherId = data.boosted ? data.weather : ''
-					data.boostWeatherName = data.boosted ? translator.translate(this.GameData.utilData.weather[data.weather].name) : ''
-					data.boostWeatherEmoji = data.boosted ? translator.translate(this.emojiLookup.lookup(this.GameData.utilData.weather[data.weather].emoji, platform)) : ''
-
-					require('./common/evolutionCalculator').setEvolutions(data, this.GameData, this.log, logReference, translator, this.emojiLookup, platform, monster)
-					require('./common/weather').setNextWeatherText(data, translator, this.GameData, this.emojiLookup, platform)
-
-					/* Weakness calculations */
-					const typeInfo = this.GameData.types
-					const typeData = this.GameData.utilData.types
-					const weaknesses = {}
-
-					for (const type of data.typeNameEng) {
-						typeInfo[type].weaknesses.forEach((x) => {
-							if (!weaknesses[x.typeName]) weaknesses[x.typeName] = 1
-							weaknesses[x.typeName] *= 2
-						})
-						typeInfo[type].resistances.forEach((x) => {
-							if (!weaknesses[x.typeName]) weaknesses[x.typeName] = 1
-							weaknesses[x.typeName] *= 0.5
-						})
-						typeInfo[type].immunes.forEach((x) => {
-							if (!weaknesses[x.typeName]) weaknesses[x.typeName] = 1
-							weaknesses[x.typeName] *= 0.25
-						})
-					}
-
-					const typeObj = {
-						extraWeak: { value: 4, types: [], text: 'Very vulnerable to' },
-						weak: { value: 2, types: [], text: 'Vulnerable to' },
-						resist: { value: 0.5, types: [], text: 'Resistant to' },
-						immune: { value: 0.25, types: [], text: 'Very resistant to' },
-						extraImmune: { value: 0.125, types: [], text: 'Extremely resistant to' },
-					}
-
-					for (const [name, value] of Object.entries(weaknesses)) {
-						const translated = {
-							nameEng: name,
-							name: translator.translate(name),
-							emoji: translator.translate(this.emojiLookup.lookup(typeData[name].emoji, platform)),
+						if (data.evolution) {
+							data.fullNameEng = translator.format(this.GameData.utilData.megaName[data.evolution], data.nameEng.concat(data.formNormalisedEng ? ' ' : '', data.formNormalisedEng))
+							data.fullName = translator.translateFormat(this.GameData.utilData.megaName[data.evolution], data.name.concat(data.formNormalised ? ' ' : '', data.formNormalised))
+						} else {
+							data.fullNameEng = data.nameEng.concat(data.formNormalisedEng ? ' ' : '', data.formNormalisedEng)
+							data.fullName = data.name.concat(data.formNormalised ? ' ' : '', data.formNormalised)
 						}
-						switch (value) {
-							case 0.125: typeObj.extraImmune.types.push(translated); break
-							case 0.25: typeObj.immune.types.push(translated); break
-							case 0.5: typeObj.resist.types.push(translated); break
-							case 2: typeObj.weak.types.push(translated); break
-							case 4: typeObj.extraWeak.types.push(translated); break
-							default: break
+
+						data.levelName = translator.translateFormat(data.levelNameEng)
+						data.megaName = data.evolution ? translator.translateFormat(this.GameData.utilData.megaName[data.evolution], data.name) : data.name
+						data.quickMoveName = this.GameData.moves[data.move_1] ? translator.translate(this.GameData.moves[data.move_1].name) : ''
+						data.quickMoveEmoji = this.GameData.moves[data.move_1] && this.GameData.moves[data.move_1].type ? translator.translate(this.emojiLookup.lookup(this.GameData.utilData.types[this.GameData.moves[data.move_1].type].emoji, platform)) : ''
+						data.chargeMoveName = this.GameData.moves[data.move_2] ? translator.translate(this.GameData.moves[data.move_2].name) : ''
+						data.chargeMoveEmoji = this.GameData.moves[data.move_2] && this.GameData.moves[data.move_2].type ? translator.translate(this.emojiLookup.lookup(this.GameData.utilData.types[this.GameData.moves[data.move_2].type].emoji, platform)) : ''
+						data.gameWeatherName = data.weather ? translator.translate(data.gameWeatherNameEng) : ''
+						data.gameWeatherEmoji = data.weather ? translator.translate(this.emojiLookup.lookup(this.GameData.utilData.weather[data.weather].emoji, platform)) : ''
+						data.shinyPossibleEmoji = data.shinyPossible ? translator.translate(this.emojiLookup.lookup('shiny', platform)) : ''
+						data.generationName = translator.translate(data.generationNameEng)
+
+						const e = []
+						const n = []
+						monster.types.forEach((type) => {
+							e.push(this.emojiLookup.lookup(this.GameData.utilData.types[type.name].emoji, platform))
+							n.push(type.name)
+						})
+						data.typeNameEng = n
+						data.emoji = e
+						data.typeName = data.typeNameEng.map((type) => translator.translate(type)).join(', ')
+						data.typeEmoji = data.emoji.map((emoji) => translator.translate(emoji)).join('')
+
+						data.boostingWeathers = data.types.map((type) => parseInt(Object.keys(this.GameData.utilData.weatherTypeBoost).find((key) => this.GameData.utilData.weatherTypeBoost[key].includes(type)), 10))
+						data.boostingWeathersEmoji = data.boostingWeathers.map((weather) => translator.translate(this.emojiLookup.lookup(this.GameData.utilData.weather[weather].emoji, platform))).join('')
+						data.boosted = !!data.boostingWeathers.includes(data.weather)
+						data.boostWeatherNameEng = data.boosted ? this.GameData.utilData.weather[data.weather].name : ''
+						data.boostWeatherId = data.boosted ? data.weather : ''
+						data.boostWeatherName = data.boosted ? translator.translate(this.GameData.utilData.weather[data.weather].name) : ''
+						data.boostWeatherEmoji = data.boosted ? translator.translate(this.emojiLookup.lookup(this.GameData.utilData.weather[data.weather].emoji, platform)) : ''
+
+						require('./common/evolutionCalculator').setEvolutions(data, this.GameData, this.log, logReference, translator, this.emojiLookup, platform, monster)
+						require('./common/weather').setNextWeatherText(data, translator, this.GameData, this.emojiLookup, platform)
+
+						/* Weakness calculations */
+						const typeInfo = this.GameData.types
+						const typeData = this.GameData.utilData.types
+						const weaknesses = {}
+
+						for (const type of data.typeNameEng) {
+							typeInfo[type].weaknesses.forEach((x) => {
+								if (!weaknesses[x.typeName]) weaknesses[x.typeName] = 1
+								weaknesses[x.typeName] *= 2
+							})
+							typeInfo[type].resistances.forEach((x) => {
+								if (!weaknesses[x.typeName]) weaknesses[x.typeName] = 1
+								weaknesses[x.typeName] *= 0.5
+							})
+							typeInfo[type].immunes.forEach((x) => {
+								if (!weaknesses[x.typeName]) weaknesses[x.typeName] = 1
+								weaknesses[x.typeName] *= 0.25
+							})
 						}
-					}
 
-					let weaknessEmoji = ''
-					for (const info of Object.values(typeObj)) {
-						if (info.types.length) {
-							const typeEmoji = info.types.map((x) => x.emoji).join('')
-							info.typeEmoji = typeEmoji
-							weaknessEmoji = weaknessEmoji.concat(`${info.value}x${typeEmoji} `)
+						const typeObj = {
+							extraWeak: { value: 4, types: [], text: 'Very vulnerable to' },
+							weak: { value: 2, types: [], text: 'Vulnerable to' },
+							resist: { value: 0.5, types: [], text: 'Resistant to' },
+							immune: { value: 0.25, types: [], text: 'Very resistant to' },
+							extraImmune: { value: 0.125, types: [], text: 'Extremely resistant to' },
 						}
+
+						for (const [name, value] of Object.entries(weaknesses)) {
+							const translated = {
+								nameEng: name,
+								name: translator.translate(name),
+								emoji: translator.translate(this.emojiLookup.lookup(typeData[name].emoji, platform)),
+							}
+							switch (value) {
+								case 0.125: typeObj.extraImmune.types.push(translated); break
+								case 0.25: typeObj.immune.types.push(translated); break
+								case 0.5: typeObj.resist.types.push(translated); break
+								case 2: typeObj.weak.types.push(translated); break
+								case 4: typeObj.extraWeak.types.push(translated); break
+								default: break
+							}
+						}
+
+						let weaknessEmoji = ''
+						for (const info of Object.values(typeObj)) {
+							if (info.types.length) {
+								const typeEmoji = info.types.map((x) => x.emoji).join('')
+								info.typeEmoji = typeEmoji
+								weaknessEmoji = weaknessEmoji.concat(`${info.value}x${typeEmoji} `)
+							}
+						}
+
+						data.weaknessList = Object.values(typeObj).filter((x) => x.types.length)
+						data.weaknessEmoji = weaknessEmoji
+
+						const view = {
+							...geoResult,
+							...data,
+							id: data.pokemonId,
+							baseStats: monster.stats,
+							time: data.disappearTime,
+							tthd: data.tth.days,
+							tthh: data.tth.hours,
+							tthm: data.tth.minutes,
+							tths: data.tth.seconds,
+							now: new Date(),
+							nowISO: new Date().toISOString(),
+							genderData: {
+								name: translator.translate(data.genderDataEng.name),
+								emoji: translator.translate(this.emojiLookup.lookup(data.genderDataEng.emoji, platform)),
+							},
+							areas: data.matchedAreas.filter((area) => area.displayInMatches).map((area) => area.name).join(', '),
+						}
+
+						const templateType = 'maxbattle'
+						const message = await this.createMessage(logReference, templateType, platform, cares.template, language, cares.ping, view)
+
+						jobs.push({
+							lat: data.latitude.toString().substring(0, 8),
+							lon: data.longitude.toString().substring(0, 8),
+							message,
+							target: cares.id,
+							type: cares.type,
+							name: cares.name,
+							tth: data.tth,
+							clean: cares.clean,
+							emoji: data.emoji,
+							logReference,
+							language,
+						})
 					}
-
-					data.weaknessList = Object.values(typeObj).filter((x) => x.types.length)
-					data.weaknessEmoji = weaknessEmoji
-
-					const view = {
-						...geoResult,
-						...data,
-						id: data.pokemonId,
-						baseStats: monster.stats,
-						time: data.disappearTime,
-						tthd: data.tth.days,
-						tthh: data.tth.hours,
-						tthm: data.tth.minutes,
-						tths: data.tth.seconds,
-						now: new Date(),
-						nowISO: new Date().toISOString(),
-						genderData: {
-							name: translator.translate(data.genderDataEng.name),
-							emoji: translator.translate(this.emojiLookup.lookup(data.genderDataEng.emoji, platform)),
-						},
-						areas: data.matchedAreas.filter((area) => area.displayInMatches).map((area) => area.name).join(', '),
-					}
-
-					const templateType = 'maxbattle'
-					const message = await this.createMessage(logReference, templateType, platform, cares.template, language, cares.ping, view)
-
-					jobs.push({
-						lat: data.latitude.toString().substring(0, 8),
-						lon: data.longitude.toString().substring(0, 8),
-						message,
-						target: cares.id,
-						type: cares.type,
-						name: cares.name,
-						tth: data.tth,
-						clean: cares.clean,
-						emoji: data.emoji,
-						logReference,
-						language,
-					})
 				}
 				return jobs
 			} catch (e) {

--- a/alerter/src/lib/discord/commando/index.js
+++ b/alerter/src/lib/discord/commando/index.js
@@ -8,7 +8,6 @@ const { EventEmitter } = require('events')
 const fs = require('fs')
 const { S2 } = require('s2-geometry')
 const mustache = require('handlebars')
-const hastebin = require('hastebin-gen')
 const { diff } = require('deep-object-diff')
 
 const emojiStrip = require('../../../util/emojiStrip')
@@ -96,7 +95,6 @@ class DiscordCommando extends EventEmitter {
 			this.client.GameData = this.GameData
 			this.client.PoracleInfo = this.PoracleInfo
 			this.client.mustache = mustache
-			this.client.hastebin = hastebin
 			this.client.translatorFactory = this.translatorFactory
 			this.client.updatedDiff = diff
 			this.client.translator = this.translator

--- a/alerter/src/lib/discord/discordWebhookWorker.js
+++ b/alerter/src/lib/discord/discordWebhookWorker.js
@@ -2,12 +2,12 @@ const path = require('path')
 const axios = require('axios')
 const NodeCache = require('node-cache')
 const fsp = require('fs').promises
-
-const { getConfigDir } = require('../configResolver')
-const CACHE_DIR = path.resolve(getConfigDir(), '.cache')
 const FormData = require('form-data')
 const util = require('util')
 const { performance } = require('perf_hooks')
+const { getConfigDir } = require('../configResolver')
+
+const CACHE_DIR = path.resolve(getConfigDir(), '.cache')
 const FairPromiseQueue = require('../FairPromiseQueue')
 const metrics = require('../metrics')
 

--- a/alerter/src/lib/discord/discordWebhookWorker.js
+++ b/alerter/src/lib/discord/discordWebhookWorker.js
@@ -26,6 +26,7 @@ class DiscordWebhookWorker {
 		this.webhookQueue = []
 		this.rehydrateTimeouts = rehydrateTimeouts
 		this.webhookTimeouts = new NodeCache()
+		this.consecutiveFails = new Map()
 		this.query = query
 
 		this.queueProcessor = new FairPromiseQueue(this.webhookQueue, this.config.tuning.concurrentDiscordWebhookConnections, ((t) => t.target))
@@ -171,11 +172,13 @@ class DiscordWebhookWorker {
 
 			if (res.status < 200 || res.status > 299) {
 				metrics.messagesFailed.inc({ destination_type: 'webhook' })
-				await this.query.incrementQuery('humans', { id: data.target }, 'fails', 1)
+				const fails = (this.consecutiveFails.get(data.target) || 0) + 1
+				this.consecutiveFails.set(data.target, fails)
 				this.logs.discord.warn(`${logReference}: ${data.name} WEBHOOK Got ${res.status} ${res.statusText}`)
 				this.logs.discord.warn(`${logReference}: ${JSON.stringify(data.message)}`)
 			} else {
 				metrics.messagesSent.inc({ destination_type: 'webhook' })
+				this.consecutiveFails.delete(data.target)
 				this.logs.discord.verbose(`${logReference}: ${data.name} WEBHOOK Got ${res.status} ${res.statusText}`)
 			}
 			this.logs.discord.silly(`${logReference}: ${data.name} WEBHOOK results ${data.target} ${res.statusText} ${res.status}`, res.headers)

--- a/alerter/src/lib/discord/discordWorker.js
+++ b/alerter/src/lib/discord/discordWorker.js
@@ -34,6 +34,7 @@ class Worker {
 		this.client = {}
 		this.rehydrateTimeouts = rehydrateTimeouts
 		this.discordMessageTimeouts = new NodeCache()
+		this.consecutiveFails = new Map()
 		this.discordQueue = []
 		this.queueProcessor = new FairPromiseQueue(this.discordQueue, this.config.tuning.concurrentDiscordDestinationsPerBot, ((entry) => entry.target))
 		this.status = statusActivity.status
@@ -187,8 +188,7 @@ class Worker {
 			metrics.discordDeliveryDuration.observe({ destination_type: 'user' }, (endTime - startTime) / 1000)
 			metrics.messagesSent.inc({ destination_type: 'discord:user' })
 
-			// Reset fails counter on successful send
-			await this.query.updateQuery('humans', { fails: 0 }, { id: data.target })
+			this.consecutiveFails.delete(data.target)
 
 			if (data.clean) {
 				setTimeout(async () => {
@@ -203,16 +203,17 @@ class Worker {
 			return true
 		} catch (err) {
 			metrics.messagesFailed.inc({ destination_type: 'discord:user' })
-			await this.query.incrementQuery('humans', { id: data.target }, 'fails', 1)
 			this.logs.discord.error(`${data.logReference}: #${this.id} Failed to send Discord alert to ${data.name}`, err, data)
 			this.logs.discord.error(`${data.logReference}: ${JSON.stringify(data)}`)
 
 			// Disable user after repeated DM failures (they can re-enable with !poracle / /start)
+			const fails = (this.consecutiveFails.get(data.target) || 0) + 1
+			this.consecutiveFails.set(data.target, fails)
 			const maxFails = this.config.tuning.maxSendFailsBeforeDisable || 5
-			const human = await this.query.selectOneQuery('humans', { id: data.target })
-			if (human && human.fails >= maxFails) {
+			if (fails >= maxFails) {
 				await this.query.updateQuery('humans', { enabled: 0 }, { id: data.target })
-				this.logs.discord.warn(`${data.logReference}: #${this.id} Disabled user ${data.name} ${data.target} after ${human.fails} consecutive send failures`)
+				this.logs.discord.warn(`${data.logReference}: #${this.id} Disabled user ${data.name} ${data.target} after ${fails} consecutive send failures`)
+				this.consecutiveFails.delete(data.target)
 			}
 		}
 		return true
@@ -260,7 +261,8 @@ class Worker {
 			return true
 		} catch (err) {
 			metrics.messagesFailed.inc({ destination_type: 'discord:channel' })
-			await this.query.incrementQuery('humans', { id: data.target }, 'fails', 1)
+			const fails = (this.consecutiveFails.get(data.target) || 0) + 1
+			this.consecutiveFails.set(data.target, fails)
 			this.logs.discord.error(`${data.logReference}: #${this.id} -> ${data.name} ${data.target} CHANNEL failed to send Discord alert to `, err)
 			this.logs.discord.error(`${data.logReference}: ${JSON.stringify(data)}`)
 		}

--- a/alerter/src/lib/discord/discordWorker.js
+++ b/alerter/src/lib/discord/discordWorker.js
@@ -7,10 +7,10 @@ const {
 const path = require('path')
 const fsp = require('fs').promises
 const NodeCache = require('node-cache')
-
-const { getConfigDir } = require('../configResolver')
-const CACHE_DIR = path.resolve(getConfigDir(), '.cache')
 const { performance } = require('perf_hooks')
+const { getConfigDir } = require('../configResolver')
+
+const CACHE_DIR = path.resolve(getConfigDir(), '.cache')
 const FairPromiseQueue = require('../FairPromiseQueue')
 const metrics = require('../metrics')
 

--- a/alerter/src/lib/discord/poracleDiscordState.js
+++ b/alerter/src/lib/discord/poracleDiscordState.js
@@ -17,7 +17,6 @@ class PoracleDiscordState {
 		this.translatorFactory = client.translatorFactory
 		this.translator = client.translator
 		this.config = client.config
-		this.hastebin = client.hastebin
 		this.addToMessageQueue = (queueEntries) => client.emit('poracleAddMessageQueue', queueEntries)
 		this.addToMatchedQueue = (payload) => client.emit('poracleAddMatchedQueue', payload)
 		this.triggerReloadAlerts = () => client.emit('poracleReloadAlerts')

--- a/alerter/src/lib/poracleMessage/commandUtil.js
+++ b/alerter/src/lib/poracleMessage/commandUtil.js
@@ -1,0 +1,14 @@
+function reportUnrecognizedArgs(msg, translator, args, consumed) {
+	const unrecognized = args.filter((a) => !consumed.has(a))
+	if (unrecognized.length) {
+		msg.react('🙅')
+		msg.reply(translator.translateFormat(
+			'I do not understand these options: {0}',
+			unrecognized.join(', '),
+		))
+		return true
+	}
+	return false
+}
+
+module.exports = { reportUnrecognizedArgs }

--- a/alerter/src/lib/poracleMessage/commands/__tests__/commandTestHarness.js
+++ b/alerter/src/lib/poracleMessage/commands/__tests__/commandTestHarness.js
@@ -1,0 +1,214 @@
+const regexFactory = require('../../../../util/regex')
+
+function createMockTranslatorFactory() {
+	const factory = {
+		config: {
+			general: {
+				locale: 'en',
+				availableLanguages: { en: 'English' },
+			},
+			locale: { language: 'en' },
+		},
+		translators: {},
+		commandTranslators: null,
+		Translator(locale) {
+			if (!this.translators[locale]) {
+				this.translators[locale] = {
+					translate: (bit) => bit,
+					translateFormat: (bit, ...args) => {
+						let str = bit
+						let i = args.length
+						while (i--) {
+							str = str.replace(new RegExp(`\\{${i}\\}`, 'gm'), args[i])
+						}
+						return str
+					},
+					reverse: (bit) => bit,
+				}
+			}
+			return this.translators[locale]
+		},
+		get default() { return this.Translator('en') },
+		get CommandTranslators() {
+			if (this.commandTranslators) return this.commandTranslators
+			this.commandTranslators = [this.Translator('en')]
+			return this.commandTranslators
+		},
+		reverseTranslateCommand(key) { return key },
+		translateCommand(key) { return [key] },
+	}
+	return factory
+}
+
+function createMockClient(overrides = {}) {
+	const translatorFactory = overrides.translatorFactory || createMockTranslatorFactory()
+	const re = regexFactory(translatorFactory)
+
+	const queries = { inserts: [], deletes: [], selects: [] }
+
+	const client = {
+		re,
+		translatorFactory,
+		translator: translatorFactory.Translator('en'),
+		GameData: overrides.GameData || {
+			monsters: {},
+			moves: {},
+			items: {},
+			grunts: {},
+			utilData: {
+				types: {},
+				teams: {
+					0: { name: 'Harmony' },
+					1: { name: 'Mystic' },
+					2: { name: 'Valor' },
+					3: { name: 'Instinct' },
+					4: { name: 'All' },
+				},
+				lures: {
+					501: { name: 'Normal' },
+					502: { name: 'Glacial' },
+					503: { name: 'Mossy' },
+					504: { name: 'Magnetic' },
+					505: { name: 'Rainy' },
+					506: { name: 'Sparkly' },
+				},
+				raidLevels: {
+					1: 'Normal', 3: 'Rare', 5: 'Legendary', 6: 'Mega', 7: 'Ultra Beast', 8: 'Primal',
+				},
+				maxbattleLevels: {
+					1: '1 Star', 2: '2 Star', 3: '3 Star', 4: '4 Star', 5: '5 Star', 6: '6 Star',
+				},
+				genData: {},
+				rarity: {},
+				size: {},
+				pokestopEvent: {},
+			},
+		},
+		config: overrides.config || {
+			general: {
+				locale: 'en',
+				defaultTemplateName: '1',
+				availableLanguages: { en: 'English' },
+			},
+			tracking: {
+				defaultDistance: 0,
+				maxDistance: 0,
+				everythingFlagPermissions: 'allow-any',
+				defaultUserTrackingLevelCap: 0,
+				enableGymBattle: false,
+			},
+			pvp: {
+				pvpFilterMaxRank: 4096,
+				pvpFilterLittleMinCP: 0,
+				pvpFilterGreatMinCP: 0,
+				pvpFilterUltraMinCP: 0,
+				levelCaps: [50],
+			},
+			discord: {
+				prefix: '!',
+				admins: ['test-user'],
+			},
+			database: {
+				client: 'mysql',
+			},
+		},
+		query: {
+			selectAllQuery: async (table, where) => {
+				queries.selects.push({ table, where })
+				return overrides.existingTracked || []
+			},
+			insertQuery: async (table, rows) => {
+				queries.inserts.push({ table, rows })
+			},
+			deleteWhereInQuery: async (table, where, values, column) => {
+				queries.deletes.push({
+					table, where, values, column,
+				})
+				return values.length
+			},
+			deleteQuery: async (table, where) => {
+				queries.deletes.push({ table, where })
+				return 1
+			},
+			mysteryQuery: async (sql) => {
+				queries.deletes.push({ sql })
+				return { affectedRows: 1 }
+			},
+		},
+		log: {
+			info: () => {},
+			warn: () => {},
+			error: () => {},
+			debug: () => {},
+		},
+		// eslint-disable-next-line no-unused-vars
+		createUtil: (msg, options) => ({
+			prefix: '!',
+			client,
+			buildTarget: async () => ({
+				canContinue: true,
+				target: {
+					id: 'test-user', type: 'discord:user', name: 'TestUser', webhook: false,
+				},
+				userHasLocation: true,
+				userHasArea: true,
+				language: 'en',
+				currentProfileNo: 1,
+			}),
+			commandAllowed: async () => true,
+		}),
+		updatedDiff: (existing, toInsert) => {
+			const diff = { uid: true }
+			for (const key of Object.keys(toInsert)) {
+				if (existing[key] !== undefined && existing[key] !== toInsert[key]) {
+					diff[key] = true
+				}
+			}
+			return diff
+		},
+		triggerReloadAlerts: () => {},
+		scannerQuery: null,
+	}
+
+	return { client, queries }
+}
+
+function createMockMsg() {
+	const replies = []
+	const reactions = []
+
+	const msg = {
+		replies,
+		reactions,
+		reply: async (text, options) => { replies.push({ text, options }) },
+		react: async (emoji) => { reactions.push(emoji) },
+		getPings: () => '',
+		isFromAdmin: true,
+		isDM: false,
+		userId: 'test-user',
+		msg: {
+			author: { id: 'test-user', username: 'TestUser' },
+			channel: {
+				id: 'test-channel',
+				isDMBased: () => false,
+				isTextBased: () => true,
+			},
+		},
+	}
+
+	return msg
+}
+
+async function runCommand(commandFile, args, overrides = {}) {
+	const { client, queries } = createMockClient(overrides)
+	const msg = createMockMsg()
+	const command = require(`../${commandFile}`)
+	await command.run(client, msg, [...args], {})
+	return {
+		replies: msg.replies,
+		reactions: msg.reactions,
+		queries,
+	}
+}
+
+module.exports = { runCommand, createMockClient, createMockMsg }

--- a/alerter/src/lib/poracleMessage/commands/__tests__/egg.test.js
+++ b/alerter/src/lib/poracleMessage/commands/__tests__/egg.test.js
@@ -1,0 +1,64 @@
+const { describe, it } = require('mocha')
+const { expect } = require('chai')
+const { runCommand } = require('./commandTestHarness')
+
+describe('egg command', () => {
+	it('should accept valid args (level5)', async () => {
+		const result = await runCommand('egg', ['level5'])
+		expect(result.reactions).to.not.include('🙅')
+		expect(result.queries.inserts).to.have.lengthOf(1)
+		expect(result.queries.inserts[0].rows[0].level).to.equal(5)
+	})
+
+	it('should accept valid args with clean and team', async () => {
+		const result = await runCommand('egg', ['level5', 'clean', 'mystic'])
+		expect(result.reactions).to.not.include('🙅')
+		expect(result.queries.inserts).to.have.lengthOf(1)
+		const row = result.queries.inserts[0].rows[0]
+		expect(row.level).to.equal(5)
+		expect(row.clean).to.equal(1)
+		expect(row.team).to.equal(1)
+	})
+
+	it('should report unrecognized args (typo)', async () => {
+		const result = await runCommand('egg', ['level5', 'typoword'])
+		expect(result.reactions).to.include('🙅')
+		const errorReply = result.replies.find((r) => r.text.includes('I do not understand'))
+		expect(errorReply).to.not.equal(undefined)
+		expect(errorReply.text).to.include('typoword')
+	})
+
+	it('should report unrecognized args mixed with valid args', async () => {
+		const result = await runCommand('egg', ['level5', 'clean', 'badarg'])
+		expect(result.reactions).to.include('🙅')
+		const errorReply = result.replies.find((r) => r.text.includes('I do not understand'))
+		expect(errorReply).to.not.equal(undefined)
+		expect(errorReply.text).to.include('badarg')
+	})
+
+	it('should report unrecognized args in remove mode', async () => {
+		const result = await runCommand('egg', ['remove', 'level5', 'badarg'])
+		expect(result.reactions).to.include('🙅')
+		const errorReply = result.replies.find((r) => r.text.includes('I do not understand'))
+		expect(errorReply).to.not.equal(undefined)
+		expect(errorReply.text).to.include('badarg')
+	})
+
+	it('should accept everything keyword', async () => {
+		const result = await runCommand('egg', ['everything'])
+		expect(result.reactions).to.not.include('🙅')
+		expect(result.queries.inserts).to.have.lengthOf(1)
+	})
+
+	it('should accept rsvp args', async () => {
+		const result = await runCommand('egg', ['level5', 'rsvp'])
+		expect(result.reactions).to.not.include('🙅')
+		expect(result.queries.inserts[0].rows[0].rsvp_changes).to.equal(1)
+	})
+
+	it('should accept ex keyword', async () => {
+		const result = await runCommand('egg', ['level5', 'ex'])
+		expect(result.reactions).to.not.include('🙅')
+		expect(result.queries.inserts[0].rows[0].exclusive).to.equal(1)
+	})
+})

--- a/alerter/src/lib/poracleMessage/commands/__tests__/fort.test.js
+++ b/alerter/src/lib/poracleMessage/commands/__tests__/fort.test.js
@@ -1,0 +1,32 @@
+const { describe, it } = require('mocha')
+const { expect } = require('chai')
+const { runCommand } = require('./commandTestHarness')
+
+describe('fort command', () => {
+	it('should accept valid args (pokestop location)', async () => {
+		const result = await runCommand('fort', ['pokestop', 'location'])
+		expect(result.reactions).to.not.include('🙅')
+		expect(result.queries.inserts).to.have.lengthOf(1)
+	})
+
+	it('should accept everything with changes', async () => {
+		const result = await runCommand('fort', ['everything', 'name', 'photo'])
+		expect(result.reactions).to.not.include('🙅')
+	})
+
+	it('should report unrecognized args (typo)', async () => {
+		const result = await runCommand('fort', ['pokestop', 'typoword'])
+		expect(result.reactions).to.include('🙅')
+		const errorReply = result.replies.find((r) => r.text.includes('I do not understand'))
+		expect(errorReply).to.not.equal(undefined)
+		expect(errorReply.text).to.include('typoword')
+	})
+
+	it('should report unrecognized args in remove mode', async () => {
+		const result = await runCommand('fort', ['remove', 'everything', 'badarg'])
+		expect(result.reactions).to.include('🙅')
+		const errorReply = result.replies.find((r) => r.text.includes('I do not understand'))
+		expect(errorReply).to.not.equal(undefined)
+		expect(errorReply.text).to.include('badarg')
+	})
+})

--- a/alerter/src/lib/poracleMessage/commands/__tests__/gym.test.js
+++ b/alerter/src/lib/poracleMessage/commands/__tests__/gym.test.js
@@ -1,0 +1,39 @@
+const { describe, it } = require('mocha')
+const { expect } = require('chai')
+const { runCommand } = require('./commandTestHarness')
+
+describe('gym command', () => {
+	it('should accept valid args (mystic)', async () => {
+		const result = await runCommand('gym', ['mystic'])
+		expect(result.reactions).to.not.include('🙅')
+		expect(result.queries.inserts).to.have.lengthOf(1)
+		expect(result.queries.inserts[0].rows[0].team).to.equal(1)
+	})
+
+	it('should accept slot changes', async () => {
+		const result = await runCommand('gym', ['mystic', 'slot changes'])
+		expect(result.reactions).to.not.include('🙅')
+		expect(result.queries.inserts[0].rows[0].slot_changes).to.equal(1)
+	})
+
+	it('should report unrecognized args (typo)', async () => {
+		const result = await runCommand('gym', ['mystic', 'typoword'])
+		expect(result.reactions).to.include('🙅')
+		const errorReply = result.replies.find((r) => r.text.includes('I do not understand'))
+		expect(errorReply).to.not.equal(undefined)
+		expect(errorReply.text).to.include('typoword')
+	})
+
+	it('should report unrecognized args in remove mode', async () => {
+		const result = await runCommand('gym', ['remove', 'everything', 'badarg'])
+		expect(result.reactions).to.include('🙅')
+		const errorReply = result.replies.find((r) => r.text.includes('I do not understand'))
+		expect(errorReply).to.not.equal(undefined)
+		expect(errorReply.text).to.include('badarg')
+	})
+
+	it('should accept everything keyword', async () => {
+		const result = await runCommand('gym', ['everything'])
+		expect(result.reactions).to.not.include('🙅')
+	})
+})

--- a/alerter/src/lib/poracleMessage/commands/__tests__/incident.test.js
+++ b/alerter/src/lib/poracleMessage/commands/__tests__/incident.test.js
@@ -1,0 +1,64 @@
+const { describe, it } = require('mocha')
+const { expect } = require('chai')
+const { runCommand } = require('./commandTestHarness')
+
+describe('incident command', () => {
+	const overrides = {
+		GameData: {
+			monsters: {},
+			moves: {},
+			items: {},
+			grunts: {
+				1: { type: 'dragon' },
+				2: { type: 'fire' },
+				3: { type: 'giovanni' },
+			},
+			utilData: {
+				types: {},
+				teams: {
+					0: { name: 'Harmony' }, 1: { name: 'Mystic' }, 2: { name: 'Valor' }, 3: { name: 'Instinct' }, 4: { name: 'All' },
+				},
+				raidLevels: {},
+				maxbattleLevels: {},
+				genData: {},
+				rarity: {},
+				size: {},
+				pokestopEvent: {},
+			},
+		},
+	}
+
+	it('should accept valid grunt type', async () => {
+		const result = await runCommand('incident', ['dragon'], overrides)
+		expect(result.reactions).to.not.include('🙅')
+		expect(result.queries.inserts).to.have.lengthOf(1)
+		expect(result.queries.inserts[0].rows[0].grunt_type).to.equal('dragon')
+	})
+
+	it('should report unrecognized args (typo)', async () => {
+		const result = await runCommand('incident', ['dragon', 'typoword'], overrides)
+		expect(result.reactions).to.include('🙅')
+		const errorReply = result.replies.find((r) => r.text.includes('I do not understand'))
+		expect(errorReply).to.not.equal(undefined)
+		expect(errorReply.text).to.include('typoword')
+	})
+
+	it('should accept everything keyword', async () => {
+		const result = await runCommand('incident', ['everything'], overrides)
+		expect(result.reactions).to.not.include('🙅')
+	})
+
+	it('should accept gender options', async () => {
+		const result = await runCommand('incident', ['dragon', 'female'], overrides)
+		expect(result.reactions).to.not.include('🙅')
+		expect(result.queries.inserts[0].rows[0].gender).to.equal(2)
+	})
+
+	it('should report unrecognized args in remove mode', async () => {
+		const result = await runCommand('incident', ['remove', 'everything', 'badarg'], overrides)
+		expect(result.reactions).to.include('🙅')
+		const errorReply = result.replies.find((r) => r.text.includes('I do not understand'))
+		expect(errorReply).to.not.equal(undefined)
+		expect(errorReply.text).to.include('badarg')
+	})
+})

--- a/alerter/src/lib/poracleMessage/commands/__tests__/lure.test.js
+++ b/alerter/src/lib/poracleMessage/commands/__tests__/lure.test.js
@@ -1,0 +1,40 @@
+const { describe, it } = require('mocha')
+const { expect } = require('chai')
+const { runCommand } = require('./commandTestHarness')
+
+describe('lure command', () => {
+	it('should accept valid args (mossy)', async () => {
+		const result = await runCommand('lure', ['mossy'])
+		expect(result.reactions).to.not.include('🙅')
+		expect(result.queries.inserts).to.have.lengthOf(1)
+		expect(result.queries.inserts[0].rows[0].lure_id).to.equal(503)
+	})
+
+	it('should accept multiple valid lure types', async () => {
+		const result = await runCommand('lure', ['mossy', 'glacial', 'clean'])
+		expect(result.reactions).to.not.include('🙅')
+		expect(result.queries.inserts).to.have.lengthOf(1)
+		expect(result.queries.inserts[0].rows).to.have.lengthOf(2)
+	})
+
+	it('should report unrecognized args (typo)', async () => {
+		const result = await runCommand('lure', ['mossy', 'typoword'])
+		expect(result.reactions).to.include('🙅')
+		const errorReply = result.replies.find((r) => r.text.includes('I do not understand'))
+		expect(errorReply).to.not.equal(undefined)
+		expect(errorReply.text).to.include('typoword')
+	})
+
+	it('should report unrecognized args in remove mode', async () => {
+		const result = await runCommand('lure', ['remove', 'mossy', 'badarg'])
+		expect(result.reactions).to.include('🙅')
+		const errorReply = result.replies.find((r) => r.text.includes('I do not understand'))
+		expect(errorReply).to.not.equal(undefined)
+		expect(errorReply.text).to.include('badarg')
+	})
+
+	it('should accept everything keyword', async () => {
+		const result = await runCommand('lure', ['everything'])
+		expect(result.reactions).to.not.include('🙅')
+	})
+})

--- a/alerter/src/lib/poracleMessage/commands/__tests__/maxbattle.test.js
+++ b/alerter/src/lib/poracleMessage/commands/__tests__/maxbattle.test.js
@@ -1,0 +1,46 @@
+const { describe, it } = require('mocha')
+const { expect } = require('chai')
+const { runCommand } = require('./commandTestHarness')
+
+describe('maxbattle command', () => {
+	it('should accept valid args (level5)', async () => {
+		const result = await runCommand('maxbattle', ['level5'])
+		expect(result.reactions).to.not.include('🙅')
+		expect(result.queries.inserts).to.have.lengthOf(1)
+	})
+
+	it('should accept gmax keyword', async () => {
+		const result = await runCommand('maxbattle', ['level5', 'gmax'])
+		expect(result.reactions).to.not.include('🙅')
+		expect(result.queries.inserts[0].rows[0].gmax).to.equal(1)
+	})
+
+	it('should report unrecognized args (typo)', async () => {
+		const result = await runCommand('maxbattle', ['level5', 'typoword'])
+		expect(result.reactions).to.include('🙅')
+		const errorReply = result.replies.find((r) => r.text.includes('I do not understand'))
+		expect(errorReply).to.not.equal(undefined)
+		expect(errorReply.text).to.include('typoword')
+	})
+
+	it('should report unrecognized args mixed with valid', async () => {
+		const result = await runCommand('maxbattle', ['level5', 'clean', 'badarg'])
+		expect(result.reactions).to.include('🙅')
+		const errorReply = result.replies.find((r) => r.text.includes('I do not understand'))
+		expect(errorReply).to.not.equal(undefined)
+		expect(errorReply.text).to.include('badarg')
+	})
+
+	it('should report unrecognized args in remove mode', async () => {
+		const result = await runCommand('maxbattle', ['remove', 'level5', 'badarg'])
+		expect(result.reactions).to.include('🙅')
+		const errorReply = result.replies.find((r) => r.text.includes('I do not understand'))
+		expect(errorReply).to.not.equal(undefined)
+		expect(errorReply.text).to.include('badarg')
+	})
+
+	it('should accept everything keyword', async () => {
+		const result = await runCommand('maxbattle', ['everything'])
+		expect(result.reactions).to.not.include('🙅')
+	})
+})

--- a/alerter/src/lib/poracleMessage/commands/__tests__/nest.test.js
+++ b/alerter/src/lib/poracleMessage/commands/__tests__/nest.test.js
@@ -1,0 +1,64 @@
+const { describe, it } = require('mocha')
+const { expect } = require('chai')
+const { runCommand } = require('./commandTestHarness')
+
+describe('nest command', () => {
+	const overrides = {
+		GameData: {
+			monsters: {
+				'1_0': {
+					id: 1, name: 'Bulbasaur', form: { id: 0, name: 'Normal' }, types: [{ name: 'Grass' }, { name: 'Poison' }],
+				},
+			},
+			moves: {},
+			items: {},
+			grunts: {},
+			utilData: {
+				types: { Grass: true, Poison: true },
+				teams: {
+					0: { name: 'Harmony' }, 1: { name: 'Mystic' }, 2: { name: 'Valor' }, 3: { name: 'Instinct' }, 4: { name: 'All' },
+				},
+				raidLevels: {},
+				maxbattleLevels: {},
+				genData: {},
+				rarity: {},
+				size: {},
+				pokestopEvent: {},
+			},
+		},
+	}
+
+	it('should accept valid pokemon name', async () => {
+		const result = await runCommand('nest', ['bulbasaur'], overrides)
+		expect(result.reactions).to.not.include('🙅')
+		expect(result.queries.inserts).to.have.lengthOf(1)
+		expect(result.queries.inserts[0].rows[0].pokemon_id).to.equal(1)
+	})
+
+	it('should report unrecognized args (typo)', async () => {
+		const result = await runCommand('nest', ['bulbasaur', 'typoword'], overrides)
+		expect(result.reactions).to.include('🙅')
+		const errorReply = result.replies.find((r) => r.text.includes('I do not understand'))
+		expect(errorReply).to.not.equal(undefined)
+		expect(errorReply.text).to.include('typoword')
+	})
+
+	it('should accept everything keyword', async () => {
+		const result = await runCommand('nest', ['everything'], overrides)
+		expect(result.reactions).to.not.include('🙅')
+	})
+
+	it('should accept clean keyword', async () => {
+		const result = await runCommand('nest', ['bulbasaur', 'clean'], overrides)
+		expect(result.reactions).to.not.include('🙅')
+		expect(result.queries.inserts[0].rows[0].clean).to.equal(1)
+	})
+
+	it('should report unrecognized args in remove mode', async () => {
+		const result = await runCommand('nest', ['remove', 'bulbasaur', 'badarg'], overrides)
+		expect(result.reactions).to.include('🙅')
+		const errorReply = result.replies.find((r) => r.text.includes('I do not understand'))
+		expect(errorReply).to.not.equal(undefined)
+		expect(errorReply.text).to.include('badarg')
+	})
+})

--- a/alerter/src/lib/poracleMessage/commands/__tests__/quest.test.js
+++ b/alerter/src/lib/poracleMessage/commands/__tests__/quest.test.js
@@ -1,0 +1,54 @@
+const { describe, it } = require('mocha')
+const { expect } = require('chai')
+const { runCommand } = require('./commandTestHarness')
+
+describe('quest command', () => {
+	it('should accept stardust keyword', async () => {
+		const result = await runCommand('quest', ['stardust'])
+		expect(result.reactions).to.not.include('🙅')
+		expect(result.queries.inserts).to.have.lengthOf(1)
+		expect(result.queries.inserts[0].rows[0].reward_type).to.equal(3)
+	})
+
+	it('should accept energy keyword', async () => {
+		const result = await runCommand('quest', ['energy'])
+		expect(result.reactions).to.not.include('🙅')
+		expect(result.queries.inserts).to.have.lengthOf(1)
+		expect(result.queries.inserts[0].rows[0].reward_type).to.equal(12)
+	})
+
+	it('should accept candy keyword', async () => {
+		const result = await runCommand('quest', ['candy'])
+		expect(result.reactions).to.not.include('🙅')
+		expect(result.queries.inserts).to.have.lengthOf(1)
+		expect(result.queries.inserts[0].rows[0].reward_type).to.equal(4)
+	})
+
+	it('should report unrecognized args (typo)', async () => {
+		const result = await runCommand('quest', ['stardust', 'typoword'])
+		expect(result.reactions).to.include('🙅')
+		const errorReply = result.replies.find((r) => r.text.includes('I do not understand'))
+		expect(errorReply).to.not.equal(undefined)
+		expect(errorReply.text).to.include('typoword')
+	})
+
+	it('should report unrecognized args in remove mode', async () => {
+		const result = await runCommand('quest', ['remove', 'stardust', 'badarg'])
+		expect(result.reactions).to.include('🙅')
+		const errorReply = result.replies.find((r) => r.text.includes('I do not understand'))
+		expect(errorReply).to.not.equal(undefined)
+		expect(errorReply.text).to.include('badarg')
+	})
+
+	it('should accept shiny keyword', async () => {
+		const result = await runCommand('quest', ['stardust', 'shiny'])
+		expect(result.reactions).to.not.include('🙅')
+		expect(result.queries.inserts[0].rows[0].shiny).to.equal(1)
+	})
+
+	it('should accept clean keyword', async () => {
+		const result = await runCommand('quest', ['stardust', 'clean'])
+		expect(result.reactions).to.not.include('🙅')
+		expect(result.queries.inserts[0].rows[0].clean).to.equal(1)
+	})
+})

--- a/alerter/src/lib/poracleMessage/commands/__tests__/raid.test.js
+++ b/alerter/src/lib/poracleMessage/commands/__tests__/raid.test.js
@@ -1,0 +1,61 @@
+const { describe, it } = require('mocha')
+const { expect } = require('chai')
+const { runCommand } = require('./commandTestHarness')
+
+describe('raid command', () => {
+	it('should accept valid args (level5)', async () => {
+		const result = await runCommand('raid', ['level5'])
+		expect(result.reactions).to.not.include('🙅')
+		expect(result.queries.inserts).to.have.lengthOf(1)
+	})
+
+	it('should accept level with team and clean', async () => {
+		const result = await runCommand('raid', ['level5', 'valor', 'clean'])
+		expect(result.reactions).to.not.include('🙅')
+		expect(result.queries.inserts).to.have.lengthOf(1)
+		const row = result.queries.inserts[0].rows[0]
+		expect(row.team).to.equal(2)
+		expect(row.clean).to.equal(1)
+	})
+
+	it('should report unrecognized args (typo)', async () => {
+		const result = await runCommand('raid', ['level5', 'artcuno'])
+		expect(result.reactions).to.include('🙅')
+		const errorReply = result.replies.find((r) => r.text.includes('I do not understand'))
+		expect(errorReply).to.not.equal(undefined)
+		expect(errorReply.text).to.include('artcuno')
+	})
+
+	it('should report unrecognized args mixed with valid', async () => {
+		const result = await runCommand('raid', ['level5', 'clean', 'badarg'])
+		expect(result.reactions).to.include('🙅')
+		const errorReply = result.replies.find((r) => r.text.includes('I do not understand'))
+		expect(errorReply).to.not.equal(undefined)
+		expect(errorReply.text).to.include('badarg')
+	})
+
+	it('should report unrecognized args in remove mode', async () => {
+		const result = await runCommand('raid', ['remove', 'level5', 'badarg'])
+		expect(result.reactions).to.include('🙅')
+		const errorReply = result.replies.find((r) => r.text.includes('I do not understand'))
+		expect(errorReply).to.not.equal(undefined)
+		expect(errorReply.text).to.include('badarg')
+	})
+
+	it('should accept everything keyword', async () => {
+		const result = await runCommand('raid', ['everything'])
+		expect(result.reactions).to.not.include('🙅')
+	})
+
+	it('should accept rsvp args', async () => {
+		const result = await runCommand('raid', ['level5', 'rsvp'])
+		expect(result.reactions).to.not.include('🙅')
+		expect(result.queries.inserts[0].rows[0].rsvp_changes).to.equal(1)
+	})
+
+	it('should accept ex keyword', async () => {
+		const result = await runCommand('raid', ['level5', 'ex'])
+		expect(result.reactions).to.not.include('🙅')
+		expect(result.queries.inserts[0].rows[0].exclusive).to.equal(1)
+	})
+})

--- a/alerter/src/lib/poracleMessage/commands/egg.js
+++ b/alerter/src/lib/poracleMessage/commands/egg.js
@@ -1,5 +1,6 @@
 const helpCommand = require('./help')
 const trackedCommand = require('./tracked')
+const { reportUnrecognizedArgs } = require('../commandUtil')
 
 exports.run = async (client, msg, args, options) => {
 	const logReference = Math.random().toString().slice(2, 11)
@@ -48,22 +49,53 @@ exports.run = async (client, msg, args, options) => {
 		let rsvpChanges = 0
 		const levelSet = new Set()
 		const pings = msg.getPings()
+		const consumed = new Set()
 
 		args.forEach((element) => {
-			if (element === 'ex') exclusive = 1
-			else if (element.match(client.re.levelRe)) levelSet.add(+element.match(client.re.levelRe)[2])
-			else if (element.match(client.re.templateRe)) [,, template] = element.match(client.re.templateRe)
-			else if (element.match(client.re.dRe)) [,, distance] = element.match(client.re.dRe)
-			else if (element === 'instinct' || element === 'yellow') team = 3
-			else if (element === 'valor' || element === 'red') team = 2
-			else if (element === 'mystic' || element === 'blue') team = 1
-			else if (element === 'harmony' || element === 'gray') team = 0
-			else if (element === 'everything') Object.keys(client.GameData.utilData.raidLevels).forEach((x) => levelSet.add(+x))
-			else if (element === 'clean') clean = true
-			else if (element === 'no rsvp') rsvpChanges = 0
-			else if (element === 'rsvp') rsvpChanges = 1
-			else if (element === 'rsvp only') rsvpChanges = 2
+			if (element === 'ex') {
+				exclusive = 1
+				consumed.add(element)
+			} else if (element.match(client.re.levelRe)) {
+				levelSet.add(+element.match(client.re.levelRe)[2])
+				consumed.add(element)
+			} else if (element.match(client.re.templateRe)) {
+				[,, template] = element.match(client.re.templateRe)
+				consumed.add(element)
+			} else if (element.match(client.re.dRe)) {
+				[,, distance] = element.match(client.re.dRe)
+				consumed.add(element)
+			} else if (element === 'instinct' || element === 'yellow') {
+				team = 3
+				consumed.add(element)
+			} else if (element === 'valor' || element === 'red') {
+				team = 2
+				consumed.add(element)
+			} else if (element === 'mystic' || element === 'blue') {
+				team = 1
+				consumed.add(element)
+			} else if (element === 'harmony' || element === 'gray') {
+				team = 0
+				consumed.add(element)
+			} else if (element === 'everything') {
+				Object.keys(client.GameData.utilData.raidLevels).forEach((x) => levelSet.add(+x))
+				consumed.add(element)
+			} else if (element === 'clean') {
+				clean = true
+				consumed.add(element)
+			} else if (element === 'no rsvp') {
+				rsvpChanges = 0
+				consumed.add(element)
+			} else if (element === 'rsvp') {
+				rsvpChanges = 1
+				consumed.add(element)
+			} else if (element === 'rsvp only') {
+				rsvpChanges = 2
+				consumed.add(element)
+			}
 		})
+
+		if (remove) consumed.add('remove')
+		if (reportUnrecognizedArgs(msg, translator, args, consumed)) return
 		if (client.config.tracking.defaultDistance !== 0 && distance === 0 && !msg.isFromAdmin) distance = client.config.tracking.defaultDistance
 		if (client.config.tracking.maxDistance !== 0 && distance > client.config.tracking.maxDistance && !msg.isFromAdmin) distance = client.config.tracking.maxDistance
 		if (distance > 0 && !userHasLocation && !remove) {

--- a/alerter/src/lib/poracleMessage/commands/fort.js
+++ b/alerter/src/lib/poracleMessage/commands/fort.js
@@ -1,5 +1,6 @@
 const helpCommand = require('./help')
 const trackedCommand = require('./tracked')
+const { reportUnrecognizedArgs } = require('../commandUtil')
 
 exports.run = async (client, msg, args, options) => {
 	const logReference = Math.random().toString().slice(2, 11)
@@ -46,23 +47,49 @@ exports.run = async (client, msg, args, options) => {
 		let includeEmpty = false
 		const changes = []
 		const pings = msg.getPings()
+		const consumed = new Set()
 
 		let fortType
 
 		args.forEach((element) => {
-			if (element.match(client.re.templateRe)) [,, template] = element.match(client.re.templateRe)
-			else if (element.match(client.re.dRe)) [,, distance] = element.match(client.re.dRe)
-			else if (element === 'pokestop') fortType = 'pokestop'
-			else if (element === 'gym') fortType = 'gym'
-			else if (element === 'everything') fortType = 'everything'
-
-			else if (element === 'include empty') includeEmpty = true
-			else if (element === 'location') changes.push('location')
-			else if (element === 'name') changes.push('name')
-			else if (element === 'photo') changes.push('image_url')
-			else if (element === 'removal') changes.push('removal')
-			else if (element === 'new') changes.push('new')
+			if (element.match(client.re.templateRe)) {
+				[,, template] = element.match(client.re.templateRe)
+				consumed.add(element)
+			} else if (element.match(client.re.dRe)) {
+				[,, distance] = element.match(client.re.dRe)
+				consumed.add(element)
+			} else if (element === 'pokestop') {
+				fortType = 'pokestop'
+				consumed.add(element)
+			} else if (element === 'gym') {
+				fortType = 'gym'
+				consumed.add(element)
+			} else if (element === 'everything') {
+				fortType = 'everything'
+				consumed.add(element)
+			} else if (element === 'include empty') {
+				includeEmpty = true
+				consumed.add(element)
+			} else if (element === 'location') {
+				changes.push('location')
+				consumed.add(element)
+			} else if (element === 'name') {
+				changes.push('name')
+				consumed.add(element)
+			} else if (element === 'photo') {
+				changes.push('image_url')
+				consumed.add(element)
+			} else if (element === 'removal') {
+				changes.push('removal')
+				consumed.add(element)
+			} else if (element === 'new') {
+				changes.push('new')
+				consumed.add(element)
+			}
 		})
+
+		if (remove) consumed.add('remove')
+		if (reportUnrecognizedArgs(msg, translator, args, consumed)) return
 		if (client.config.tracking.defaultDistance !== 0 && distance === 0 && !msg.isFromAdmin) distance = client.config.tracking.defaultDistance
 		if (client.config.tracking.maxDistance !== 0 && distance > client.config.tracking.maxDistance && !msg.isFromAdmin) distance = client.config.tracking.maxDistance
 		if (distance > 0 && !userHasLocation && !remove) {

--- a/alerter/src/lib/poracleMessage/commands/gym.js
+++ b/alerter/src/lib/poracleMessage/commands/gym.js
@@ -1,5 +1,6 @@
 const helpCommand = require('./help')
 const trackedCommand = require('./tracked')
+const { reportUnrecognizedArgs } = require('../commandUtil')
 
 exports.run = async (client, msg, args, options) => {
 	const logReference = Math.random().toString().slice(2, 11)
@@ -60,20 +61,47 @@ exports.run = async (client, msg, args, options) => {
 		let battleChanges = false
 		const teams = []
 		const pings = msg.getPings()
+		const consumed = new Set()
 
 		args.forEach((element) => {
-			if (element === 'normal') teams.push(501)
-			else if (element.match(client.re.templateRe)) [,, template] = element.match(client.re.templateRe)
-			else if (element.match(client.re.dRe)) [,, distance] = element.match(client.re.dRe)
-			else if (element === 'instinct' || element === 'yellow') teams.push(3)
-			else if (element === 'valor' || element === 'red') teams.push(2)
-			else if (element === 'mystic' || element === 'blue') teams.push(1)
-			else if (element === 'harmony' || element === 'gray' || element === 'uncontested') teams.push(0)
-			else if (element === 'everything') teams.push(...[0, 1, 2, 3])
-			else if (element === 'clean') clean = true
-			else if (element === 'slot changes') slotChanges = true
-			else if (element === 'battle changes') battleChanges = true
+			if (element === 'normal') {
+				teams.push(501)
+				consumed.add(element)
+			} else if (element.match(client.re.templateRe)) {
+				[,, template] = element.match(client.re.templateRe)
+				consumed.add(element)
+			} else if (element.match(client.re.dRe)) {
+				[,, distance] = element.match(client.re.dRe)
+				consumed.add(element)
+			} else if (element === 'instinct' || element === 'yellow') {
+				teams.push(3)
+				consumed.add(element)
+			} else if (element === 'valor' || element === 'red') {
+				teams.push(2)
+				consumed.add(element)
+			} else if (element === 'mystic' || element === 'blue') {
+				teams.push(1)
+				consumed.add(element)
+			} else if (element === 'harmony' || element === 'gray' || element === 'uncontested') {
+				teams.push(0)
+				consumed.add(element)
+			} else if (element === 'everything') {
+				teams.push(...[0, 1, 2, 3])
+				consumed.add(element)
+			} else if (element === 'clean') {
+				clean = true
+				consumed.add(element)
+			} else if (element === 'slot changes') {
+				slotChanges = true
+				consumed.add(element)
+			} else if (element === 'battle changes') {
+				battleChanges = true
+				consumed.add(element)
+			}
 		})
+
+		if (remove) consumed.add('remove')
+		if (reportUnrecognizedArgs(msg, translator, args, consumed)) return
 		if (client.config.tracking.defaultDistance !== 0 && distance === 0 && !msg.isFromAdmin) distance = client.config.tracking.defaultDistance
 		if (client.config.tracking.maxDistance !== 0 && distance > client.config.tracking.maxDistance && !msg.isFromAdmin) distance = client.config.tracking.maxDistance
 		if (distance > 0 && !userHasLocation && !remove) {

--- a/alerter/src/lib/poracleMessage/commands/incident.js
+++ b/alerter/src/lib/poracleMessage/commands/incident.js
@@ -1,5 +1,6 @@
 const helpCommand = require('./help')
 const trackedCommand = require('./tracked')
+const { reportUnrecognizedArgs } = require('../commandUtil')
 
 exports.run = async (client, msg, args, options) => {
 	const logReference = Math.random().toString().slice(2, 11)
@@ -48,16 +49,35 @@ exports.run = async (client, msg, args, options) => {
 		let clean = false
 		const types = [] // args.filter((arg) => typeArray.includes(arg))
 		const pings = msg.getPings()
+		const consumed = new Set()
 
 		for (const element of args) {
-			if (element.match(client.re.templateRe)) [,, template] = element.match(client.re.templateRe)
-			else if (element.match(client.re.dRe)) [,, distance] = element.match(client.re.dRe)
-			else if (element === 'female') gender = 2
-			else if (element === 'male') gender = 1
-			else if (element === 'clean') clean = true
-			else if (typeArray.includes(element) || element === 'everything') types.push(element)
-			else if (eventArray.includes(element)) types.push(element)
+			if (element.match(client.re.templateRe)) {
+				[,, template] = element.match(client.re.templateRe)
+				consumed.add(element)
+			} else if (element.match(client.re.dRe)) {
+				[,, distance] = element.match(client.re.dRe)
+				consumed.add(element)
+			} else if (element === 'female') {
+				gender = 2
+				consumed.add(element)
+			} else if (element === 'male') {
+				gender = 1
+				consumed.add(element)
+			} else if (element === 'clean') {
+				clean = true
+				consumed.add(element)
+			} else if (typeArray.includes(element) || element === 'everything') {
+				types.push(element)
+				consumed.add(element)
+			} else if (eventArray.includes(element)) {
+				types.push(element)
+				consumed.add(element)
+			}
 		}
+
+		if (remove) consumed.add('remove')
+		if (reportUnrecognizedArgs(msg, translator, args, consumed)) return
 		if (client.config.tracking.defaultDistance !== 0 && distance === 0 && !msg.isFromAdmin) distance = client.config.tracking.defaultDistance
 		if (client.config.tracking.maxDistance !== 0 && distance > client.config.tracking.maxDistance && !msg.isFromAdmin) distance = client.config.tracking.maxDistance
 		if (distance > 0 && !userHasLocation && !remove) {

--- a/alerter/src/lib/poracleMessage/commands/lure.js
+++ b/alerter/src/lib/poracleMessage/commands/lure.js
@@ -1,5 +1,6 @@
 const helpCommand = require('./help')
 const trackedCommand = require('./tracked')
+const { reportUnrecognizedArgs } = require('../commandUtil')
 
 exports.run = async (client, msg, args, options) => {
 	const logReference = Math.random().toString().slice(2, 11)
@@ -45,19 +46,44 @@ exports.run = async (client, msg, args, options) => {
 		let clean = false
 		const lures = []
 		const pings = msg.getPings()
+		const consumed = new Set()
 
 		args.forEach((element) => {
-			if (element === 'normal') lures.push(501)
-			else if (element.match(client.re.templateRe)) [,, template] = element.match(client.re.templateRe)
-			else if (element.match(client.re.dRe)) [,, distance] = element.match(client.re.dRe)
-			else if (element === 'glacial') lures.push(502)
-			else if (element === 'mossy') lures.push(503)
-			else if (element === 'magnetic') lures.push(504)
-			else if (element === 'rainy') lures.push(505)
-			else if (element === 'sparkly') lures.push(506)
-			else if (element === 'everything') lures.push(0)
-			else if (element === 'clean') clean = true
+			if (element === 'normal') {
+				lures.push(501)
+				consumed.add(element)
+			} else if (element.match(client.re.templateRe)) {
+				[,, template] = element.match(client.re.templateRe)
+				consumed.add(element)
+			} else if (element.match(client.re.dRe)) {
+				[,, distance] = element.match(client.re.dRe)
+				consumed.add(element)
+			} else if (element === 'glacial') {
+				lures.push(502)
+				consumed.add(element)
+			} else if (element === 'mossy') {
+				lures.push(503)
+				consumed.add(element)
+			} else if (element === 'magnetic') {
+				lures.push(504)
+				consumed.add(element)
+			} else if (element === 'rainy') {
+				lures.push(505)
+				consumed.add(element)
+			} else if (element === 'sparkly') {
+				lures.push(506)
+				consumed.add(element)
+			} else if (element === 'everything') {
+				lures.push(0)
+				consumed.add(element)
+			} else if (element === 'clean') {
+				clean = true
+				consumed.add(element)
+			}
 		})
+
+		if (remove) consumed.add('remove')
+		if (reportUnrecognizedArgs(msg, translator, args, consumed)) return
 		if (client.config.tracking.defaultDistance !== 0 && distance === 0 && !msg.isFromAdmin) distance = client.config.tracking.defaultDistance
 		if (client.config.tracking.maxDistance !== 0 && distance > client.config.tracking.maxDistance && !msg.isFromAdmin) distance = client.config.tracking.maxDistance
 		if (distance > 0 && !userHasLocation && !remove) {

--- a/alerter/src/lib/poracleMessage/commands/maxbattle.js
+++ b/alerter/src/lib/poracleMessage/commands/maxbattle.js
@@ -1,5 +1,6 @@
 const helpCommand = require('./help')
 const trackedCommand = require('./tracked')
+const { reportUnrecognizedArgs } = require('../commandUtil')
 
 exports.run = async (client, msg, args, options) => {
 	const logReference = Math.random().toString().slice(2, 11)
@@ -52,14 +53,22 @@ exports.run = async (client, msg, args, options) => {
 		let move = 9000
 		const levelSet = new Set()
 		const pings = msg.getPings()
-		const formNames = args.filter((arg) => arg.match(client.re.formRe)).map((arg) => client.translatorFactory.reverseTranslateCommand(arg.match(client.re.formRe)[2], true).toLowerCase())
-		const argTypes = args.filter((arg) => typeArray.includes(arg))
+		const consumed = new Set()
+		const formNames = args.filter((arg) => arg.match(client.re.formRe)).map((arg) => {
+			consumed.add(arg)
+			return client.translatorFactory.reverseTranslateCommand(arg.match(client.re.formRe)[2], true).toLowerCase()
+		})
+		const argTypes = args.filter((arg) => {
+			if (typeArray.includes(arg)) { consumed.add(arg); return true }
+			return false
+		})
 
 		// Substitute aliases
 		const pokemonAlias = require('../../pokemonAlias').getPokemonAlias()
 		for (let i = args.length - 1; i >= 0; i--) {
 			let alias = pokemonAlias[args[i]]
 			if (alias) {
+				consumed.add(args[i])
 				if (!Array.isArray(alias)) alias = [alias]
 				args.splice(i, 1, ...alias.map((x) => x.toString()))
 			}
@@ -76,17 +85,36 @@ exports.run = async (client, msg, args, options) => {
 				|| mon.types.map((t) => t.name.toLowerCase()).find((t) => argTypes.includes(t))) && !mon.form.id)
 		}
 
-		const genCommand = args.filter((arg) => arg.match(client.re.genRe))
+		// Mark matched monster names/ids as consumed
+		for (const element of args) {
+			if (Object.values(client.GameData.monsters).some((mon) => mon.name.toLowerCase() === element || mon.id.toString() === element)) {
+				consumed.add(element)
+			}
+		}
+
+		const genCommand = args.filter((arg) => {
+			if (arg.match(client.re.genRe)) { consumed.add(arg); return true }
+			return false
+		})
 		const gen = genCommand.length ? client.GameData.utilData.genData[+genCommand[0].replace(client.translator.translate('gen'), '')] : 0
 
 		if (gen) monsters = monsters.filter((mon) => mon.id >= gen.min && mon.id <= gen.max)
 
 		for (const element of args) {
-			if (element === 'gmax') gmax = 1
-			else if (element.match(client.re.levelRe)) levelSet.add(+element.match(client.re.levelRe)[2])
-			else if (element.match(client.re.templateRe)) [,, template] = element.match(client.re.templateRe)
-			else if (element.match(client.re.dRe)) [,, distance] = element.match(client.re.dRe)
-			else if (element.match(client.re.moveRe)) {
+			if (element === 'gmax') {
+				gmax = 1
+				consumed.add(element)
+			} else if (element.match(client.re.levelRe)) {
+				levelSet.add(+element.match(client.re.levelRe)[2])
+				consumed.add(element)
+			} else if (element.match(client.re.templateRe)) {
+				[,, template] = element.match(client.re.templateRe)
+				consumed.add(element)
+			} else if (element.match(client.re.dRe)) {
+				[,, distance] = element.match(client.re.dRe)
+				consumed.add(element)
+			} else if (element.match(client.re.moveRe)) {
+				consumed.add(element)
 				const [,, moveText] = element.match(client.re.moveRe)
 				const [moveName, typeName] = moveText.split('/')
 				const englishMoveName = client.translatorFactory.reverseTranslateCommand(moveName, true).toLowerCase()
@@ -97,9 +125,18 @@ exports.run = async (client, msg, args, options) => {
 					return msg.reply(translator.translateFormat('Unrecognised move name {0}', typeName ? `${moveName}/${typeName}` : moveName))
 				}
 				[move] = moveData
-			} else if (element === 'everything') Object.keys(client.GameData.utilData.maxbattleLevels).forEach((x) => levelSet.add(+x))
-			else if (element === 'clean') clean = true
+			} else if (element === 'everything') {
+				Object.keys(client.GameData.utilData.maxbattleLevels).forEach((x) => levelSet.add(+x))
+				consumed.add(element)
+			} else if (element === 'clean') {
+				clean = true
+				consumed.add(element)
+			}
 		}
+
+		if (remove) consumed.add('remove')
+		if (commandEverything) consumed.add('everything')
+		if (reportUnrecognizedArgs(msg, translator, args, consumed)) return
 		if (client.config.tracking.defaultDistance !== 0 && distance === 0 && !msg.isFromAdmin) distance = client.config.tracking.defaultDistance
 		if (client.config.tracking.maxDistance !== 0 && distance > client.config.tracking.maxDistance && !msg.isFromAdmin) distance = client.config.tracking.maxDistance
 		if (distance > 0 && !userHasLocation && !remove) {

--- a/alerter/src/lib/poracleMessage/commands/nest.js
+++ b/alerter/src/lib/poracleMessage/commands/nest.js
@@ -1,5 +1,6 @@
 const helpCommand = require('./help')
 const trackedCommand = require('./tracked')
+const { reportUnrecognizedArgs } = require('../commandUtil')
 
 exports.run = async (client, msg, args, options) => {
 	const logReference = Math.random().toString().slice(2, 11)
@@ -49,14 +50,22 @@ exports.run = async (client, msg, args, options) => {
 		let template = client.config.general.defaultTemplateName
 		let clean = false
 		const pings = msg.getPings()
-		const formNames = args.filter((arg) => arg.match(client.re.formRe)).map((arg) => client.translatorFactory.reverseTranslateCommand(arg.match(client.re.formRe)[2], true).toLowerCase())
-		const argTypes = args.filter((arg) => typeArray.includes(arg))
+		const consumed = new Set()
+		const formNames = args.filter((arg) => arg.match(client.re.formRe)).map((arg) => {
+			consumed.add(arg)
+			return client.translatorFactory.reverseTranslateCommand(arg.match(client.re.formRe)[2], true).toLowerCase()
+		})
+		const argTypes = args.filter((arg) => {
+			if (typeArray.includes(arg)) { consumed.add(arg); return true }
+			return false
+		})
 
 		// Substitute aliases
 		const pokemonAlias = require('../../pokemonAlias').getPokemonAlias()
 		for (let i = args.length - 1; i >= 0; i--) {
 			let alias = pokemonAlias[args[i]]
 			if (alias) {
+				consumed.add(args[i])
 				if (!Array.isArray(alias)) alias = [alias]
 				args.splice(i, 1, ...alias.map((x) => x.toString()))
 			}
@@ -73,18 +82,43 @@ exports.run = async (client, msg, args, options) => {
 				|| mon.types.map((t) => t.name.toLowerCase()).find((t) => argTypes.includes(t))) && !mon.form.id)
 		}
 
-		const genCommand = args.filter((arg) => arg.match(client.re.genRe))
+		// Mark matched monster names/ids as consumed
+		for (const element of args) {
+			if (Object.values(client.GameData.monsters).some((mon) => mon.name.toLowerCase() === element || mon.id.toString() === element)) {
+				consumed.add(element)
+			}
+		}
+
+		const genCommand = args.filter((arg) => {
+			if (arg.match(client.re.genRe)) { consumed.add(arg); return true }
+			return false
+		})
 		const gen = genCommand.length ? client.GameData.utilData.genData[+genCommand[0].replace(client.translator.translate('gen'), '')] : 0
 
 		if (gen) monsters = monsters.filter((mon) => mon.id >= gen.min && mon.id <= gen.max)
 
 		args.forEach((element) => {
-			if (element.match(client.re.templateRe)) [,, template] = element.match(client.re.templateRe)
-			else if (element.match(client.re.dRe)) [,, distance] = element.match(client.re.dRe)
-			else if (element.match(client.re.minspawnRe)) [,, minSpawn] = element.match(client.re.minspawnRe)
-			else if (element === 'everything' && !formNames.length) monsters.push({ id: 0, form: { id: 0 } })
-			else if (element === 'clean') clean = true
+			if (element.match(client.re.templateRe)) {
+				[,, template] = element.match(client.re.templateRe)
+				consumed.add(element)
+			} else if (element.match(client.re.dRe)) {
+				[,, distance] = element.match(client.re.dRe)
+				consumed.add(element)
+			} else if (element.match(client.re.minspawnRe)) {
+				[,, minSpawn] = element.match(client.re.minspawnRe)
+				consumed.add(element)
+			} else if (element === 'everything' && !formNames.length) {
+				monsters.push({ id: 0, form: { id: 0 } })
+				consumed.add(element)
+			} else if (element === 'clean') {
+				clean = true
+				consumed.add(element)
+			}
 		})
+
+		if (remove) consumed.add('remove')
+		if (commandEverything) consumed.add('everything')
+		if (reportUnrecognizedArgs(msg, translator, args, consumed)) return
 		if (client.config.tracking.defaultDistance !== 0 && distance === 0 && !msg.isFromAdmin) distance = client.config.tracking.defaultDistance
 		if (client.config.tracking.maxDistance !== 0 && distance > client.config.tracking.maxDistance && !msg.isFromAdmin) distance = client.config.tracking.maxDistance
 		if (distance > 0 && !userHasLocation && !remove) {

--- a/alerter/src/lib/poracleMessage/commands/quest.js
+++ b/alerter/src/lib/poracleMessage/commands/quest.js
@@ -1,5 +1,6 @@
 const helpCommand = require('./help')
 const trackedCommand = require('./tracked')
+const { reportUnrecognizedArgs } = require('../commandUtil')
 
 exports.run = async (client, msg, args, options) => {
 	const logReference = Math.random().toString().slice(2, 11)
@@ -70,11 +71,20 @@ exports.run = async (client, msg, args, options) => {
 			}
 		}
 
+		const consumed = new Set()
+
 		// Check for monsters or forms
 		const formArgs = args.filter((arg) => arg.match(client.re.formRe))
+		formArgs.forEach((arg) => consumed.add(arg))
 		const formNames = formArgs ? formArgs.map((arg) => client.translatorFactory.reverseTranslateCommand(arg.match(client.re.formRe)[2], true).toLowerCase()) : []
-		const argTypes = args.filter((arg) => typeArray.includes(arg))
-		const genCommand = args.filter((arg) => arg.match(client.re.genRe))
+		const argTypes = args.filter((arg) => {
+			if (typeArray.includes(arg)) { consumed.add(arg); return true }
+			return false
+		})
+		const genCommand = args.filter((arg) => {
+			if (arg.match(client.re.genRe)) { consumed.add(arg); return true }
+			return false
+		})
 		const gen = genCommand.length ? client.GameData.utilData.genData[+(genCommand[0].match(client.re.genRe)[2])] : 0
 
 		if (formNames.length) {
@@ -91,46 +101,81 @@ exports.run = async (client, msg, args, options) => {
 				|| (args.includes('all pokemon') || args.includes('everything')) && msg.isFromAdmin) && !mon.form.id)
 		}
 		if (gen) fullMonsters = fullMonsters.filter((mon) => mon.id >= gen.min && mon.id <= gen.max)
-		//		monsters = fullMonsters.map((mon) => mon.id)
-		items = Object.keys(client.GameData.items).filter((key) => args.includes(translator.translate(client.GameData.items[key].name.toLowerCase())) || args.includes('all items'))
+
+		// Mark matched monster names/ids as consumed
+		for (const element of args) {
+			if (Object.values(client.GameData.monsters).some((mon) => mon.name.toLowerCase() === element || mon.id.toString() === element)) {
+				consumed.add(element)
+			}
+		}
+
+		// Mark matched item names as consumed
+		items = Object.keys(client.GameData.items).filter((key) => {
+			const itemName = translator.translate(client.GameData.items[key].name.toLowerCase())
+			if (args.includes(itemName)) { consumed.add(itemName); return true }
+			if (args.includes('all items')) return true
+			return false
+		})
+		if (args.includes('all items')) consumed.add('all items')
+		if (args.includes('all pokemon')) consumed.add('all pokemon')
+
 		if (args.includes('everything') && (!disableEverythingTracking || args.includes('remove') || msg.isFromAdmin)) {
-			// monsters = Object.values(client.GameData.monsters).filter((mon) => !mon.form.id).map((m) => m.id)
 			items = Object.keys(client.GameData.items)
 			minDust = 0
 			stardustTracking = -1
 			energyMonsters.push('0')
 			candyMonsters.push('0')
 			commandEverything = 1
+			consumed.add('everything')
 		}
 		args.forEach((element) => {
-			if (element.match(client.re.templateRe)) [,, template] = element.match(client.re.templateRe)
-			else if (element.match(client.re.stardustRe)) {
+			if (element.match(client.re.templateRe)) {
+				[,, template] = element.match(client.re.templateRe)
+				consumed.add(element)
+			} else if (element.match(client.re.stardustRe)) {
 				minDust = +element.match(client.re.stardustRe)[2]
 				stardustTracking = -1
-			} else if (element.match(client.re.dRe)) [,, distance] = element.match(client.re.dRe)
-			else if (element === 'stardust') {
+				consumed.add(element)
+			} else if (element.match(client.re.dRe)) {
+				[,, distance] = element.match(client.re.dRe)
+				consumed.add(element)
+			} else if (element === 'stardust') {
 				minDust = 0
 				stardustTracking = -1
+				consumed.add(element)
 			} else if (element.match(client.re.energyRe)) {
 				[,, energyMonster] = element.match(client.re.energyRe)
 				energyMonster = translator.reverse(energyMonster.toLowerCase(), true).toLowerCase()
 				energyMonster = Object.values(client.GameData.monsters).find((mon) => energyMonster.includes(mon.name.toLowerCase()) && mon.form.id === 0)
 				energyMonster = energyMonster ? energyMonster.id : 0
 				if (+energyMonster > 0) energyMonsters.push(energyMonster)
+				consumed.add(element)
 			} else if (element === 'energy') {
 				energyMonsters.push('0')
+				consumed.add(element)
 			} else if (element.match(client.re.candyRe)) {
 				[,, candyMonster] = element.match(client.re.candyRe)
 				candyMonster = translator.reverse(candyMonster.toLowerCase(), true).toLowerCase()
 				candyMonster = Object.values(client.GameData.monsters).find((mon) => candyMonster.includes(mon.name.toLowerCase()) && mon.form.id === 0)
 				candyMonster = candyMonster ? candyMonster.id : 0
 				if (+candyMonster > 0) candyMonsters.push(candyMonster)
+				consumed.add(element)
 			} else if (element === 'candy') {
 				candyMonsters.push('0')
-			} else if (element === 'shiny') mustShiny = 1
-			else if (element === 'remove') remove = true
-			else if (element === 'clean') clean = true
+				consumed.add(element)
+			} else if (element === 'shiny') {
+				mustShiny = 1
+				consumed.add(element)
+			} else if (element === 'remove') {
+				remove = true
+				consumed.add(element)
+			} else if (element === 'clean') {
+				clean = true
+				consumed.add(element)
+			}
 		})
+
+		if (reportUnrecognizedArgs(msg, translator, args, consumed)) return
 		if (client.config.tracking.defaultDistance !== 0 && distance === 0 && !msg.isFromAdmin) distance = client.config.tracking.defaultDistance
 		if (client.config.tracking.maxDistance !== 0 && distance > client.config.tracking.maxDistance && !msg.isFromAdmin) distance = client.config.tracking.maxDistance
 		if (distance > 0 && !userHasLocation && !remove) {

--- a/alerter/src/lib/poracleMessage/commands/raid.js
+++ b/alerter/src/lib/poracleMessage/commands/raid.js
@@ -1,5 +1,6 @@
 const helpCommand = require('./help')
 const trackedCommand = require('./tracked')
+const { reportUnrecognizedArgs } = require('../commandUtil')
 
 exports.run = async (client, msg, args, options) => {
 	const logReference = Math.random().toString().slice(2, 11)
@@ -54,14 +55,22 @@ exports.run = async (client, msg, args, options) => {
 		let rsvpChanges = 0
 		const levelSet = new Set()
 		const pings = msg.getPings()
-		const formNames = args.filter((arg) => arg.match(client.re.formRe)).map((arg) => client.translatorFactory.reverseTranslateCommand(arg.match(client.re.formRe)[2], true).toLowerCase())
-		const argTypes = args.filter((arg) => typeArray.includes(arg))
+		const consumed = new Set()
+		const formNames = args.filter((arg) => arg.match(client.re.formRe)).map((arg) => {
+			consumed.add(arg)
+			return client.translatorFactory.reverseTranslateCommand(arg.match(client.re.formRe)[2], true).toLowerCase()
+		})
+		const argTypes = args.filter((arg) => {
+			if (typeArray.includes(arg)) { consumed.add(arg); return true }
+			return false
+		})
 
 		// Substitute aliases
 		const pokemonAlias = require('../../pokemonAlias').getPokemonAlias()
 		for (let i = args.length - 1; i >= 0; i--) {
 			let alias = pokemonAlias[args[i]]
 			if (alias) {
+				consumed.add(args[i])
 				if (!Array.isArray(alias)) alias = [alias]
 				args.splice(i, 1, ...alias.map((x) => x.toString()))
 			}
@@ -78,17 +87,36 @@ exports.run = async (client, msg, args, options) => {
 				|| mon.types.map((t) => t.name.toLowerCase()).find((t) => argTypes.includes(t))) && !mon.form.id)
 		}
 
-		const genCommand = args.filter((arg) => arg.match(client.re.genRe))
+		// Mark matched monster names/ids as consumed
+		for (const element of args) {
+			if (Object.values(client.GameData.monsters).some((mon) => mon.name.toLowerCase() === element || mon.id.toString() === element)) {
+				consumed.add(element)
+			}
+		}
+
+		const genCommand = args.filter((arg) => {
+			if (arg.match(client.re.genRe)) { consumed.add(arg); return true }
+			return false
+		})
 		const gen = genCommand.length ? client.GameData.utilData.genData[+genCommand[0].replace(client.translator.translate('gen'), '')] : 0
 
 		if (gen) monsters = monsters.filter((mon) => mon.id >= gen.min && mon.id <= gen.max)
 
 		for (const element of args) {
-			if (element === 'ex') exclusive = 1
-			else if (element.match(client.re.levelRe)) levelSet.add(+element.match(client.re.levelRe)[2])
-			else if (element.match(client.re.templateRe)) [,, template] = element.match(client.re.templateRe)
-			else if (element.match(client.re.dRe)) [,, distance] = element.match(client.re.dRe)
-			else if (element.match(client.re.moveRe)) {
+			if (element === 'ex') {
+				exclusive = 1
+				consumed.add(element)
+			} else if (element.match(client.re.levelRe)) {
+				levelSet.add(+element.match(client.re.levelRe)[2])
+				consumed.add(element)
+			} else if (element.match(client.re.templateRe)) {
+				[,, template] = element.match(client.re.templateRe)
+				consumed.add(element)
+			} else if (element.match(client.re.dRe)) {
+				[,, distance] = element.match(client.re.dRe)
+				consumed.add(element)
+			} else if (element.match(client.re.moveRe)) {
+				consumed.add(element)
 				const [,, moveText] = element.match(client.re.moveRe)
 				const [moveName, typeName] = moveText.split('/')
 				const englishMoveName = client.translatorFactory.reverseTranslateCommand(moveName, true).toLowerCase()
@@ -99,16 +127,39 @@ exports.run = async (client, msg, args, options) => {
 					return msg.reply(translator.translateFormat('Unrecognised move name {0}', typeName ? `${moveName}/${typeName}` : moveName))
 				}
 				[move] = moveData
-			} else if (element === 'instinct' || element === 'yellow') team = 3
-			else if (element === 'valor' || element === 'red') team = 2
-			else if (element === 'mystic' || element === 'blue') team = 1
-			else if (element === 'harmony' || element === 'gray') team = 0
-			else if (element === 'everything') Object.keys(client.GameData.utilData.raidLevels).forEach((x) => levelSet.add(+x))
-			else if (element === 'clean') clean = true
-			else if (element === 'no rsvp') rsvpChanges = 0
-			else if (element === 'rsvp') rsvpChanges = 1
-			else if (element === 'rsvp only') rsvpChanges = 2
+			} else if (element === 'instinct' || element === 'yellow') {
+				team = 3
+				consumed.add(element)
+			} else if (element === 'valor' || element === 'red') {
+				team = 2
+				consumed.add(element)
+			} else if (element === 'mystic' || element === 'blue') {
+				team = 1
+				consumed.add(element)
+			} else if (element === 'harmony' || element === 'gray') {
+				team = 0
+				consumed.add(element)
+			} else if (element === 'everything') {
+				Object.keys(client.GameData.utilData.raidLevels).forEach((x) => levelSet.add(+x))
+				consumed.add(element)
+			} else if (element === 'clean') {
+				clean = true
+				consumed.add(element)
+			} else if (element === 'no rsvp') {
+				rsvpChanges = 0
+				consumed.add(element)
+			} else if (element === 'rsvp') {
+				rsvpChanges = 1
+				consumed.add(element)
+			} else if (element === 'rsvp only') {
+				rsvpChanges = 2
+				consumed.add(element)
+			}
 		}
+
+		if (remove) consumed.add('remove')
+		if (commandEverything) consumed.add('everything')
+		if (reportUnrecognizedArgs(msg, translator, args, consumed)) return
 		if (client.config.tracking.defaultDistance !== 0 && distance === 0 && !msg.isFromAdmin) distance = client.config.tracking.defaultDistance
 		if (client.config.tracking.maxDistance !== 0 && distance > client.config.tracking.maxDistance && !msg.isFromAdmin) distance = client.config.tracking.maxDistance
 		if (distance > 0 && !userHasLocation && !remove) {

--- a/alerter/src/lib/poracleMessage/commands/script.js
+++ b/alerter/src/lib/poracleMessage/commands/script.js
@@ -374,15 +374,6 @@ exports.run = async (client, msg, args, options) => {
 			return await msg.reply(translator.translate('The script specified is empty'))
 		}
 
-		if (args.includes('link')) {
-			try {
-				const hastelink = await client.hastebin(message)
-				return await msg.reply(`${translator.translate('Your backup is at')} ${hastelink}`)
-			} catch (e) {
-				await msg.reply(translator.translate('Hastebin seems down'))
-			}
-		}
-
 		const filepath = path.join(__dirname, `./${target.name}.txt`)
 		fs.writeFileSync(filepath, message)
 		await msg.replyWithAttachment(translator.translate('Your backup'), filepath)

--- a/alerter/src/lib/poracleMessage/commands/tracked.js
+++ b/alerter/src/lib/poracleMessage/commands/tracked.js
@@ -454,16 +454,10 @@ exports.run = async (client, msg, args, options) => {
 			return await msg.reply(message, { style: 'markdown' })
 		}
 
-		try {
-			const hastelink = await client.hastebin(message)
-			return await msg.reply(`${translator.translate('Tracking list is quite long. Have a look at')} ${hastelink}`)
-		} catch (e) {
-			const filepath = path.join(__dirname, `./${target.name}.txt`)
-			fs.writeFileSync(filepath, message)
-			await msg.replyWithAttachment(`${translator.translate('Tracking list is long, but Hastebin is also down. ☹️ \nTracking list made into a file:')}`, filepath)
-			fs.unlinkSync(filepath)
-			client.log.warn('Hastebin seems down, got error: ', e)
-		}
+		const filepath = path.join(__dirname, `./${target.name}.txt`)
+		fs.writeFileSync(filepath, message)
+		await msg.replyWithAttachment(translator.translate('Tracking list is quite long. Here it is as a file:'), filepath)
+		fs.unlinkSync(filepath)
 	} catch (err) {
 		client.log.error(`${msg.content} command unhappy: `, err)
 	}

--- a/alerter/src/lib/telegram/Telegram.js
+++ b/alerter/src/lib/telegram/Telegram.js
@@ -32,6 +32,8 @@ class Telegram extends EventEmitter {
 		this.client = {}
 		this.rehydrateTimeouts = rehydrateTimeouts
 		this.telegramMessageTimeouts = new NodeCache()
+		this.consecutiveFails = new Map()
+		this.query = query
 		this.commandFiles = fs.readdirSync(`${__dirname}/commands`)
 		this.bot = telegraf
 		this.id = id
@@ -329,6 +331,7 @@ class Telegram extends EventEmitter {
 			(this.config.logger.timingStats ? this.logs.telegram.verbose : this.logs.telegram.debug)(`${logReference}: #${this.id} -> ${data.name} ${data.target} ${dataType} (${endTime - startTime} ms)`)
 			metrics.telegramDeliveryDuration.observe({ destination_type: dataType.toLowerCase() }, durationSec)
 			metrics.messagesSent.inc({ destination_type: `telegram:${dataType.toLowerCase()}` })
+			this.consecutiveFails.delete(data.target)
 
 			if (data.clean) {
 				for (const id of messageIds) {
@@ -344,6 +347,15 @@ class Telegram extends EventEmitter {
 		} catch (err) {
 			metrics.messagesFailed.inc({ destination_type: `telegram:${dataType.toLowerCase()}` })
 			this.logs.telegram.error(`${data.logReference}: #${this.id} -> ${data.name} ${data.target}  Failed to send Telegram alert`, err)
+
+			const fails = (this.consecutiveFails.get(data.target) || 0) + 1
+			this.consecutiveFails.set(data.target, fails)
+			const maxFails = this.config.tuning.maxSendFailsBeforeDisable || 5
+			if (fails >= maxFails) {
+				await this.query.updateQuery('humans', { enabled: 0 }, { id: data.target })
+				this.logs.telegram.warn(`${data.logReference}: #${this.id} Disabled user ${data.name} ${data.target} after ${fails} consecutive send failures`)
+				this.consecutiveFails.delete(data.target)
+			}
 			return false
 		}
 	}

--- a/alerter/src/lib/telegram/Telegram.js
+++ b/alerter/src/lib/telegram/Telegram.js
@@ -2,12 +2,12 @@ const { EventEmitter } = require('events')
 const path = require('path')
 const fs = require('fs')
 const fsp = require('fs').promises
-
-const { getConfigDir } = require('../configResolver')
-const CACHE_DIR = path.resolve(getConfigDir(), '.cache')
 const NodeCache = require('node-cache')
 const mustache = require('handlebars')
 const { performance } = require('perf_hooks')
+const { getConfigDir } = require('../configResolver')
+
+const CACHE_DIR = path.resolve(getConfigDir(), '.cache')
 const emojiStrip = require('../../util/emojiStrip')
 const FairPromiseQueue = require('../FairPromiseQueue')
 const metrics = require('../metrics')

--- a/alerter/src/lib/telegram/poracleTelegramState.js
+++ b/alerter/src/lib/telegram/poracleTelegramState.js
@@ -1,6 +1,5 @@
 const { diff } = require('deep-object-diff')
 const mustache = require('handlebars')
-const hastebin = require('hastebin-gen')
 const PoracleTelegramUtil = require('./poracleTelegramUtil')
 const PoracleTelegramMessage = require('./poracleTelegramMessage')
 
@@ -19,7 +18,6 @@ class PoracleTelegramState {
 		this.translatorFactory = ctx.state.controller.translatorFactory
 		this.config = ctx.state.controller.config
 		this.mustache = mustache
-		this.hastebin = hastebin
 		this.updatedDiff = diff
 		this.addToMessageQueue = ctx.poracleAddMessageQueue
 		this.addToMatchedQueue = ctx.poracleAddMatchedQueue

--- a/alerter/src/routes/apiTrackingMaxbattle.js
+++ b/alerter/src/routes/apiTrackingMaxbattle.js
@@ -104,38 +104,17 @@ module.exports = async (fastify, options) => {
 		})
 
 		try {
-			const tracked = await fastify.query.selectAllQuery('maxbattle', { id, profile_no: currentProfileNo })
-
-			const updates = []
-			const alreadyPresent = []
-
 			let message = ''
 
-			if ((alreadyPresent.length + updates.length + insert.length) > 50) {
+			if (insert.length > 50) {
 				message = translator.translateFormat('I have made a lot of changes. See {0}{1} for details', '!', translator.translate('tracked'))
 			} else {
-				for (const i of alreadyPresent) {
-					message = message.concat(translator.translate('Unchanged: '), await trackedCommand.maxbattleRowText(fastify.config, translator, fastify.GameData, i, fastify.scannerQuery), '\n')
-				}
-				for (const i of updates) {
-					message = message.concat(translator.translate('Updated: '), await trackedCommand.maxbattleRowText(fastify.config, translator, fastify.GameData, i, fastify.scannerQuery), '\n')
-				}
 				for (const i of insert) {
 					message = message.concat(translator.translate('New: '), await trackedCommand.maxbattleRowText(fastify.config, translator, fastify.GameData, i, fastify.scannerQuery), '\n')
 				}
 			}
 
-			await fastify.query.deleteWhereInQuery(
-				'maxbattle',
-				{
-					id,
-					profile_no: currentProfileNo,
-				},
-				updates.map((x) => x.uid),
-				'uid',
-			)
-
-			const insertResult = await fastify.query.insertQuery('maxbattle', [...insert, ...updates], 'uid')
+			const insertResult = await fastify.query.insertQuery('maxbattle', insert, 'uid')
 			const newUids = Array.isArray(insertResult) ? insertResult.map((r) => (typeof r === 'object' ? r.uid : r)) : []
 
 			// Send message to user
@@ -165,8 +144,6 @@ module.exports = async (fastify, options) => {
 				status: 'ok',
 				message: silent ? '' : message,
 				newUids,
-				alreadyPresent: alreadyPresent.length,
-				updates: updates.length,
 				insert: insert.length,
 			}
 		} catch (err) {

--- a/processor/.gitignore
+++ b/processor/.gitignore
@@ -1,3 +1,4 @@
 config.toml
 logs/*
 /processor
+/poracle-processor

--- a/processor/cmd/processor/main.go
+++ b/processor/cmd/processor/main.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	_ "net/http/pprof"
 	"os"
+	_ "time/tzdata" // embed IANA timezone database as fallback
 	"os/signal"
 	"sync"
 	"syscall"


### PR DESCRIPTION
## Summary

- Tracking commands (egg, raid, lure, gym, fort, incident, nest, maxbattle, quest) now **report unrecognized arguments** instead of silently ignoring them. Previously, a typo like `!raid level5 artcuno clean` would silently drop "artcuno" — now it replies with "I do not understand these options: artcuno".
- Each command tracks which args were consumed during parsing via a `Set`, then a shared `reportUnrecognizedArgs()` utility flags anything left over before the command proceeds.
- The `!track` command already had this validation (via its `parameterDefinition` approach); this brings the other 9 commands to parity.

## What changed

- **New:** `commandUtil.js` — shared `reportUnrecognizedArgs(msg, translator, args, consumed)` utility
- **New:** Test harness + 53 tests across all 9 commands (valid args accepted, typos caught, remove mode works)
- **Modified:** 9 command files — added consumed-set tracking to each arg-parsing loop
- **Modified:** `.eslintrc` — added `brace-style` override to prevent `--fix` from collapsing multi-line if/else blocks

## Test plan

- [x] `npx mocha 'src/lib/poracleMessage/commands/__tests__/*.test.js'` — 53 passing
- [x] `npm run lint` — no new errors
- [ ] Manual test: `!egg level5 typo_word` should reply with error mentioning "typo word"
- [ ] Manual test: `!raid level5 artcuno clean` should reply with error mentioning "artcuno"
- [ ] Manual test: valid commands (`!egg level5 clean`, `!raid everything`) still work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)