### PR TITLE
Fix Discord clean-message timeout crash when tth is undefined

### DIFF
--- a/alerter/src/lib/discord/discordWorker.js
+++ b/alerter/src/lib/discord/discordWorker.js
@@ -154,7 +154,11 @@ class Worker {
 
 	async userAlert(data) {
 		let user = this.client.users.cache.get(data.target)
-		const msgDeletionMs = ((data.tth.days * 86400) + (data.tth.hours * 3600) + (data.tth.minutes * 60) + data.tth.seconds) * 1000
+		let msgDeletionMs = 0
+		if (data.clean) {
+			const tth = data.tth || { days: 0, hours: 0, minutes: 0, seconds: 0 }
+			msgDeletionMs = ((tth.days * 86400) + (tth.hours * 3600) + (tth.minutes * 60) + tth.seconds) * 1000
+		}
 
 		try {
 			const logReference = data.logReference ? data.logReference : 'Unknown'
@@ -236,7 +240,11 @@ class Worker {
 
 			this.logs.discord.info(`${logReference}: #${this.id} -> ${data.name} ${data.target} CHANNEL Sending discord message${data.clean ? ' (clean)' : ''}`)
 			const channel = await this.client.channels.fetch(data.target)
-			const msgDeletionMs = ((data.tth.days * 86400) + (data.tth.hours * 3600) + (data.tth.minutes * 60) + data.tth.seconds) * 1000 + this.config.discord.messageDeleteDelay
+			let msgDeletionMs = this.config.discord.messageDeleteDelay || 0
+			if (data.clean) {
+				const tth = data.tth || { days: 0, hours: 0, minutes: 0, seconds: 0 }
+				msgDeletionMs += ((tth.days * 86400) + (tth.hours * 3600) + (tth.minutes * 60) + tth.seconds) * 1000
+			}
 			if (!channel) return this.logs.discord.warn(`${logReference}: #${this.id} -> ${data.name} ${data.target} CHANNEL not found`)
 			this.logs.discord.debug(`${logReference}: #${this.id} -> ${data.name} ${data.target} CHANNEL Sending discord message`, data.message)
 


### PR DESCRIPTION
## ✅ PR description guidance (for this fix)

Great news: your fix is complete and precise.
Now add a concise PR summary so reviewers can easily verify behavior and intent.

### 1) Title
- `Fix Discord clean-message timeout crash when tth is undefined`

### 2) Problem statement
- “`discordWorker.channelAlert` / `userAlert` assumed `data.tth` always exists and used `data.tth.days`, causing:
  - `TypeError: Cannot read properties of undefined (reading 'days')` for poi/fort update alerts where `tth` may not be present.”

### 3) Root cause
- In discordWorker.js:
  - `msgDeletionMs` calculation uses `data.tth.days/hours/minutes/seconds` unguarded.
  - For non-time-limited alerts or missing enrichment, `data.tth === undefined`.

### 4) Fix
- Introduced safe fallback:
  - `const tth = data.tth || {days:0,hours:0,minutes:0,seconds:0}`
- In `userAlert`:
  - only compute delete timeout when `data.clean`
- In `channelAlert`:
  - always start from `config.discord.messageDeleteDelay` and add tth when `data.clean`.

### 5) Behavior change / risk mitigation
- `clean=false` won’t try to compute tth.
- `clean=true` still supports existing deletion schedule; now robust to missing `tth`.
- No functional change for valid `tth`.
- Avoids crashing alert worker and keeps alert processing healthy even on malformed/missing tth.

### 6) Validation notes
- TODO for reviewer:
  - test with:
    1. `fortupdate` payload (no data.tth) - tested by @unseenmagik (see image below)
    2. regular monster payload (has data.tth)
  - ensure both produce sent message and conditional cleanup works.
- validate by running local:
  - `npm install`
  - `npm run lint`
  - (optional) `npm test`

### 7) Optional extra in PR text
- “This resolves reported issue in logs:
  - `poi-updates-city-of-casey ... Cannot read properties of undefined (reading 'days')`”
- “No additional DB or config changes needed.”

---
<img width="496" height="359" alt="image" src="https://github.com/user-attachments/assets/d867b614-50f4-435d-9033-148fb1f9ceb0" />