### PR TITLE
Add ?full=true flag to GET /api/config/templates

### DIFF
--- a/alerter/src/routes/apiConfig.js
+++ b/alerter/src/routes/apiConfig.js
@@ -62,8 +62,23 @@ module.exports = async (fastify, options) => {
 			return { status: 'authError', reason: 'incorrect or missing api secret' }
 		}
 
+		const full = req.query.full === 'true'
+
 		const typesForPlatform = (platform) => [...new Set(fastify.dts.filter((x) => !x.hidden && x.platform === platform).map((x) => x.type))]
 		const languagesForType = (platform, type) => [...new Set(fastify.dts.filter((x) => !x.hidden && x.platform === platform && x.type === type).map((x) => x.language || '%'))]
+
+		if (full) {
+			const templatesForLanguage = (platform, type, language) => fastify.dts
+				.filter((x) => !x.hidden && x.platform === platform && x.type === type && ((language === '%' && x.language === undefined) || x.language === language))
+				.map(({ hidden, ...rest }) => rest)
+
+			return {
+				status: 'ok',
+				discord: Object.fromEntries(typesForPlatform('discord').map((x) => [x, Object.fromEntries(languagesForType('discord', x).map((y) => [y, templatesForLanguage('discord', x, y)]))])),
+				telegram: Object.fromEntries(typesForPlatform('telegram').map((x) => [x, Object.fromEntries(languagesForType('telegram', x).map((y) => [y, templatesForLanguage('telegram', x, y)]))])),
+			}
+		}
+
 		const templatesForLanguage = (platform, type, language) => [...new Set(fastify.dts.filter((x) => !x.hidden && x.platform === platform && x.type === type && ((language === '%' && x.language === undefined) || x.language === language)).map((x) => x.id))]
 
 		return {


### PR DESCRIPTION
Allow API consumers to retrieve full DTS template content (embed bodies, text fields, etc.) instead of just template IDs. The existing default behavior is unchanged — only when ?full=true is passed does the endpoint return complete template objects (with the hidden field stripped).