### PR TITLE
Docker migration: copy scripts into image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,9 @@ COPY config/config.example.toml config/config.example.toml
 COPY start.sh start.sh
 RUN chmod +x start.sh processor/poracle-processor
 
+# Scripts for PoracleJS migration
+COPY scripts/ scripts/
+
 # Create runtime directories (processor downloads resources at startup)
 RUN mkdir -p config/.cache/geofences resources/data resources/rawdata resources/locale resources/gamelocale alerter/logs alerter/nominatimData logs backups
 


### PR DESCRIPTION
Copy the scripts folder into the image for use with PoracleJS - PoracleNG migration and perhaps other scripts later on.


Config migration process with docker would be something along these lines:

```
docker run --rm -it \
-v /<old-poracle-location>:/oldporacle \
-v /<poracleng-config-location>:/app/config \
ghcr.io/jfberry/poracleng:main \
node scripts/migrate-from-poracle.js
```

When prompted for existing PoracleJS installation you input `/oldporacle`
Keep in mind configs could be owned by root(depending on the setup) and just have to `chown` them.