### PR TITLE
Add !ask command with NLP parser

### DIFF
--- a/AI.md
+++ b/AI.md
@@ -1,212 +1,114 @@
-# AI Command Assistant
+# !ask Command — Natural Language Tracking
 
-PoracleNG includes an optional AI assistant that translates natural language into Poracle tracking commands. Users type `!ask` followed by what they want in plain English, and the AI suggests the correct command(s).
+PoracleNG includes an `!ask` command that translates natural language into Poracle tracking commands. Users type `!ask` followed by what they want in plain English, and the bot suggests the correct command(s).
 
 ```
-User: !ask track shiny pikachu with good great league PVP
-Bot:  AI suggests:
-      `!track pikachu iv0 great100`
+User: !ask perfect dragonite nearby
+Bot:  Suggested command(s):
+      `!track dragonite iv100 d1000`
 
       Copy and paste to run.
 ```
 
 ## How It Works
 
-The `!ask` command sends the user's text to a local or cloud AI model via the OpenAI-compatible chat completions API. The model uses a system prompt containing the full Poracle command reference to generate correct commands. The bot shows the suggestion for the user to copy and run.
+The `!ask` command uses a built-in NLP parser — no external AI service or API key needed. The parser:
 
-The AI is **never given access** to user data, tracking rules, or the database. It only translates text → commands.
+1. Normalizes input (lowercase, strips filler like "notify me about", "I want")
+2. Detects command intent (raid, quest, invasion, etc.)
+3. Matches tokens against vocabularies built from game data (pokemon names, items, types, forms, moves)
+4. Applies synonym expansion (hundo→iv100, nearby→d1000, pvp→great5)
+5. Assembles the Poracle command(s)
+
+Vocabularies are built at startup from the same game data the processor uses for matching. No external calls, zero latency, zero cost.
 
 ## Setup
-
-### 1. Choose a Provider
-
-Any service that supports the OpenAI chat completions API (`/v1/chat/completions`) works:
-
-| Provider | Cost | Speed | Setup |
-|----------|------|-------|-------|
-| **Ollama** (local) | Free | 1-5s | Install on your server |
-| **OpenRouter** | Pay-per-token | 1-3s | API key only |
-| **Groq** | Free tier available | <1s | API key only |
-| **OpenAI** | Pay-per-token | 1-2s | API key only |
-| **LM Studio** (local) | Free | 1-5s | Desktop app |
-
-### 2. Configure
 
 Add to `config/config.toml`:
 
 ```toml
 [ai]
 enabled = true
-provider_url = "http://localhost:11434/v1"  # Your provider URL
-api_key = ""                                 # Empty for local Ollama
-model = "gemma3:12b"                         # Model name
 ```
 
-### 3. Provider-Specific Setup
+That's it. Restart the processor and alerter.
 
-#### Ollama (Recommended — Free, Local)
+## What It Understands
 
-[Ollama](https://ollama.ai) runs models locally on your server. Models are loaded into RAM only when processing a request and unloaded after idle (default 5 minutes), so there's zero RAM cost between requests.
+**Pokemon tracking:**
+- "perfect dragonite" → `!track dragonite iv100`
+- "nundo pokemon within 1km" → `!track everything iv0 maxiv0 d1000`
+- "alolan vulpix" → `!track vulpix form:alolan`
+- "shadow pokemon with good IVs" → `!track everything form:shadow iv80`
+- "great league rank 1 azumarill" → `!track azumarill great1`
+- "XXL pokemon" → `!track everything size:xxl`
+- "hundos for pikachu eevee and dragonite" → 3 separate `!track` commands
 
-```bash
-# Install Ollama
-curl -fsSL https://ollama.ai/install.sh | sh
+**Raids:** "mega raids", "level 5 raids nearby", "mewtwo raids with psystrike"
 
-# Pull a model (choose one)
-ollama pull gemma3:4b      # 3GB, good balance of quality and speed
-ollama pull gemma3:12b     # 8GB, best quality for local use
-ollama pull llama3.1:8b    # 4.5GB, good alternative
-```
+**Quests:** "stardust quests", "golden razz berry quests", "rare candy quests"
 
-Config:
+**Invasions:** "team rocket water female", "kecleon pokestop"
+
+**Other:** lures, nests, gyms, forts, max battles
+
+**Removal:** "stop tracking dragonite" → `!untrack dragonite`
+
+**Pokemon names are fuzzy-matched:** "mr mime", "mrmime", and "mr. mime" all resolve correctly. Same for "farfetchd"→"farfetch'd", "hooh"→"ho-oh", etc.
+
+**Existing Poracle syntax passes through:** if you type "iv95-99" or "d2000" or "great5", the parser recognizes and preserves them.
+
+## AI Fallback (Optional)
+
+If the NLP parser can't understand an input, it can optionally fall back to an AI model. This requires an OpenAI-compatible API:
+
 ```toml
 [ai]
 enabled = true
-provider_url = "http://localhost:11434/v1"
-api_key = ""
-model = "gemma3:12b"
-```
-
-Docker users — add Ollama as a sidecar:
-```yaml
-services:
-  ollama:
-    image: ollama/ollama
-    volumes:
-      - ollama_data:/root/.ollama
-    # GPU support (optional):
-    # deploy:
-    #   resources:
-    #     reservations:
-    #       devices:
-    #         - capabilities: [gpu]
-
-  poracle:
-    image: ghcr.io/jfberry/poracleng:main
-    environment:
-      # Point AI at the Ollama container
-      - AI_PROVIDER_URL=http://ollama:11434/v1
-    # ... rest of your config
-
-volumes:
-  ollama_data:
-```
-
-After starting, pull a model inside the container:
-```bash
-docker exec -it ollama ollama pull gemma3:12b
-```
-
-#### OpenRouter (Many Models, One API Key)
-
-[OpenRouter](https://openrouter.ai) provides access to hundreds of models from different providers through a single API key. Good for experimentation.
-
-1. Sign up at https://openrouter.ai
-2. Create an API key in your account settings
-3. Add credits (even $1 is enough for thousands of requests)
-
-Config:
-```toml
-[ai]
-enabled = true
-provider_url = "https://openrouter.ai/api/v1"
+fallback_to_ai = true
+provider_url = "https://openrouter.ai/api/v1"   # or Ollama, Groq, OpenAI
 api_key = "sk-or-v1-..."
 model = "google/gemma-3-12b-it"
-# Other options:
-# model = "meta-llama/llama-3.1-8b-instruct"
-# model = "mistralai/mistral-small-3.1-24b-instruct"
 ```
 
-#### Groq (Fast, Free Tier)
+The NLP parser handles 90%+ of requests. The AI fallback catches edge cases like creative phrasing the parser doesn't recognize.
 
-[Groq](https://groq.com) offers very fast inference with a generous free tier.
+### Provider Options
 
-1. Sign up at https://console.groq.com
-2. Create an API key
+| Provider | Setup |
+|----------|-------|
+| **Ollama** (local, free) | `provider_url = "http://localhost:11434/v1"`, no api_key needed |
+| **OpenRouter** | `provider_url = "https://openrouter.ai/api/v1"`, requires api_key + credits |
+| **Groq** (free tier) | `provider_url = "https://api.groq.com/openai/v1"`, requires api_key |
+| **OpenAI** | `provider_url = "https://api.openai.com/v1"`, requires api_key |
 
-Config:
-```toml
-[ai]
-enabled = true
-provider_url = "https://api.groq.com/openai/v1"
-api_key = "gsk_..."
-model = "llama-3.1-8b-instant"
-```
-
-#### OpenAI
-
-```toml
-[ai]
-enabled = true
-provider_url = "https://api.openai.com/v1"
-api_key = "sk-..."
-model = "gpt-4o-mini"
-```
-
-## Recommended Models
-
-The system prompt is ~8KB and requires a model that reliably follows system instructions. Models below 7B parameters may ignore the system prompt and generate irrelevant output.
-
-| Use Case | Model | Size | Notes |
-|----------|-------|------|-------|
-| **Best local** | `gemma3:12b` (Ollama) | 8GB | Excellent accuracy, recommended |
-| **Good local** | `gemma3:4b` (Ollama) | 3GB | Good balance of speed and quality |
-| **Good local** | `llama3.1:8b` (Ollama) | 4.5GB | Reliable alternative |
-| **Best cloud** | `google/gemma-3-12b-it` (OpenRouter) | — | Best tested, ~$0.07/M tokens |
-| **Good cloud** | `meta-llama/llama-3.1-8b-instruct` (OpenRouter) | — | Slightly cheaper |
-| **Fast cloud** | Groq `llama-3.1-8b-instant` | — | Very fast, free tier |
-| **Reliable cloud** | OpenAI `gpt-4o-mini` | — | Most reliable, ~$0.15/M tokens |
-
-**Avoid**: `qwen/qwen-2.5-7b-instruct` — intermittently ignores the system prompt and returns SQL or unrelated content.
+Recommended model: `google/gemma-3-12b-it` (tested, reliable with the Poracle system prompt).
 
 ## Testing
 
-Test the AI endpoint directly:
-
 ```bash
+# Test the NLP parser directly
 curl -X POST http://localhost:4200/api/ai/translate \
   -H "Content-Type: application/json" \
   -H "X-Poracle-Secret: your-secret" \
-  -d '{"message": "track shiny pikachu with good great league PVP"}'
-```
+  -d '{"message": "track perfect dragonite nearby"}'
 
-Expected response:
-```json
-{"status": "ok", "command": "!track pikachu iv0 great100"}
+# Expected: {"status":"ok","command":"!track dragonite iv100 d1000"}
 ```
 
 Then test via Discord/Telegram:
 ```
 !ask track perfect dragonite
-!ask notify me about level 5 raids nearby
-!ask I want water team rocket invasions
-!ask track 0% attack pokemon for ultra league PVP
+!ask level 5 raids nearby
+!ask stardust quests
+!ask team rocket water invasions
+!ask stop tracking bulbasaur
 ```
 
 ## Troubleshooting
 
-**"AI assistant is not configured"**
-→ Set `[ai] enabled = true` in config.toml and restart.
+**"!ask is not configured"** → Set `[ai] enabled = true` in config.toml and restart.
 
-**Timeout errors**
-��� Local models may take a few seconds on first request (cold start). Increase timeout or use a faster model.
+**Wrong command generated** → The NLP parser uses keyword matching, so very creative phrasings may not work. Try rephrasing, or enable `fallback_to_ai = true` with an AI provider.
 
-**Wrong commands generated (SQL, generic advice, etc.)**
-→ Your model is too small or unreliable with system prompts. Switch to `google/gemma-3-12b-it` or `meta-llama/llama-3.1-8b-instruct`. The system prompt requires 7B+ parameter models that reliably follow system instructions.
-
-**Ollama not responding**
-→ Check `ollama serve` is running. Test with `curl http://localhost:11434/v1/models`.
-
-**OpenRouter/Groq auth errors**
-→ Verify your API key. Check provider dashboard for quota/rate limits.
-
-## Customising the System Prompt
-
-The system prompt is embedded in `processor/internal/ai/prompt.go`. It contains the full Poracle command reference. If you add custom commands or aliases, update the prompt to include them.
-
-The prompt is designed to work with 7B+ models by being explicit and example-heavy. Key principles:
-- Low temperature (0.1) for deterministic output
-- Max 256 tokens (commands are short)
-- User message wrapper reinforces "commands only" instruction
-- Post-processing extracts `!` command lines from noisy model output
-- Many examples cover common phrasings
+**Pokemon name not recognized** → The parser uses game data translations. If a pokemon was recently added, restart the processor to re-download game data.

--- a/AI.md
+++ b/AI.md
@@ -1,0 +1,207 @@
+# AI Command Assistant
+
+PoracleNG includes an optional AI assistant that translates natural language into Poracle tracking commands. Users type `!ask` followed by what they want in plain English, and the AI suggests the correct command(s).
+
+```
+User: !ask track shiny pikachu with good great league PVP
+Bot:  AI suggests:
+      !track pikachu iv0 great100
+      React ✅ to run, or ❌ to cancel.
+```
+
+## How It Works
+
+The `!ask` command sends the user's text to a local or cloud AI model via the OpenAI-compatible chat completions API. The model uses a system prompt containing the full Poracle command reference to generate correct commands. The bot shows the suggestion and waits for user confirmation before executing.
+
+The AI is **never given access** to user data, tracking rules, or the database. It only translates text → commands.
+
+## Setup
+
+### 1. Choose a Provider
+
+Any service that supports the OpenAI chat completions API (`/v1/chat/completions`) works:
+
+| Provider | Cost | Speed | Setup |
+|----------|------|-------|-------|
+| **Ollama** (local) | Free | 1-5s | Install on your server |
+| **OpenRouter** | Pay-per-token | 1-3s | API key only |
+| **Groq** | Free tier available | <1s | API key only |
+| **OpenAI** | Pay-per-token | 1-2s | API key only |
+| **LM Studio** (local) | Free | 1-5s | Desktop app |
+
+### 2. Configure
+
+Add to `config/config.toml`:
+
+```toml
+[ai]
+enabled = true
+provider_url = "http://localhost:11434/v1"  # Your provider URL
+api_key = ""                                 # Empty for local Ollama
+model = "qwen2.5:1.5b"                      # Model name
+```
+
+### 3. Provider-Specific Setup
+
+#### Ollama (Recommended — Free, Local)
+
+[Ollama](https://ollama.ai) runs models locally on your server. Models are loaded into RAM only when processing a request and unloaded after idle (default 5 minutes), so there's zero RAM cost between requests.
+
+```bash
+# Install Ollama
+curl -fsSL https://ollama.ai/install.sh | sh
+
+# Pull a model (choose one)
+ollama pull qwen2.5:1.5b    # 1GB, fast, good for structured tasks
+ollama pull qwen2.5:3b      # 2GB, better quality
+ollama pull phi3:mini        # 2.2GB, Microsoft, good reasoning
+ollama pull gemma2:2b        # 1.5GB, Google
+```
+
+Config:
+```toml
+[ai]
+enabled = true
+provider_url = "http://localhost:11434/v1"
+api_key = ""
+model = "qwen2.5:1.5b"
+```
+
+Docker users — add Ollama as a sidecar:
+```yaml
+services:
+  ollama:
+    image: ollama/ollama
+    volumes:
+      - ollama_data:/root/.ollama
+    # GPU support (optional):
+    # deploy:
+    #   resources:
+    #     reservations:
+    #       devices:
+    #         - capabilities: [gpu]
+
+  poracle:
+    image: ghcr.io/jfberry/poracleng:main
+    environment:
+      # Point AI at the Ollama container
+      - AI_PROVIDER_URL=http://ollama:11434/v1
+    # ... rest of your config
+
+volumes:
+  ollama_data:
+```
+
+After starting, pull a model inside the container:
+```bash
+docker exec -it ollama ollama pull qwen2.5:1.5b
+```
+
+#### OpenRouter (Many Models, One API Key)
+
+[OpenRouter](https://openrouter.ai) provides access to hundreds of models from different providers through a single API key. Good for experimentation.
+
+1. Sign up at https://openrouter.ai
+2. Create an API key in your account settings
+3. Browse models at https://openrouter.ai/models
+
+Config:
+```toml
+[ai]
+enabled = true
+provider_url = "https://openrouter.ai/api/v1"
+api_key = "sk-or-v1-..."
+model = "qwen/qwen-2.5-7b-instruct"
+# Other options:
+# model = "google/gemma-2-2b-it"          # Free
+# model = "meta-llama/llama-3.1-8b-instruct"  # Free
+# model = "anthropic/claude-3.5-haiku"    # Fast, cheap
+```
+
+#### Groq (Fast, Free Tier)
+
+[Groq](https://groq.com) offers very fast inference with a generous free tier.
+
+1. Sign up at https://console.groq.com
+2. Create an API key
+
+Config:
+```toml
+[ai]
+enabled = true
+provider_url = "https://api.groq.com/openai/v1"
+api_key = "gsk_..."
+model = "llama-3.1-8b-instant"
+```
+
+#### OpenAI
+
+```toml
+[ai]
+enabled = true
+provider_url = "https://api.openai.com/v1"
+api_key = "sk-..."
+model = "gpt-4o-mini"
+```
+
+## Recommended Models
+
+| Use Case | Model | Size | Notes |
+|----------|-------|------|-------|
+| **Budget local** | `qwen2.5:1.5b` | 1GB | Good enough for simple commands |
+| **Quality local** | `qwen2.5:3b` | 2GB | Better at complex multi-filter commands |
+| **Best local** | `qwen2.5:7b` | 4.5GB | Excellent, needs more RAM |
+| **Free cloud** | Groq `llama-3.1-8b-instant` | — | Very fast, free tier |
+| **Cheap cloud** | OpenAI `gpt-4o-mini` | — | Reliable, ~$0.0001 per request |
+| **Best cloud** | Any large model via OpenRouter | — | For complex edge cases |
+
+## Testing
+
+Test the AI endpoint directly:
+
+```bash
+curl -X POST http://localhost:3030/api/ai/translate \
+  -H "Content-Type: application/json" \
+  -H "X-Poracle-Secret: your-secret" \
+  -d '{"message": "track shiny pikachu with good great league PVP"}'
+```
+
+Expected response:
+```json
+{"status": "ok", "command": "!track pikachu iv0 great100"}
+```
+
+Then test via Discord/Telegram:
+```
+!ask track perfect dragonite
+!ask notify me about level 5 raids nearby
+!ask I want water team rocket invasions
+!ask track 0% attack pokemon for ultra league PVP
+```
+
+## Troubleshooting
+
+**"AI assistant is not configured"**
+→ Set `[ai] enabled = true` in config.toml and restart.
+
+**Timeout errors**
+→ Local models may take a few seconds on first request (cold start). Increase timeout or use a faster model.
+
+**Wrong commands generated**
+→ Try a larger model. The system prompt works best with 3B+ parameter models. Smaller models may miss nuances.
+
+**Ollama not responding**
+→ Check `ollama serve` is running. Test with `curl http://localhost:11434/v1/models`.
+
+**OpenRouter/Groq auth errors**
+→ Verify your API key. Check provider dashboard for quota/rate limits.
+
+## Customising the System Prompt
+
+The system prompt is embedded in `processor/internal/ai/client.go`. It contains the full Poracle command reference. If you add custom commands or aliases, update the prompt to include them.
+
+The prompt is designed to work with small models (1.5B+) by being explicit and example-heavy. Key principles:
+- Low temperature (0.1) for deterministic output
+- Max 256 tokens (commands are short)
+- "Return ONLY the command" instruction prevents explanations
+- Many examples cover common phrasings

--- a/AI.md
+++ b/AI.md
@@ -5,13 +5,14 @@ PoracleNG includes an optional AI assistant that translates natural language int
 ```
 User: !ask track shiny pikachu with good great league PVP
 Bot:  AI suggests:
-      !track pikachu iv0 great100
-      React ✅ to run, or ❌ to cancel.
+      `!track pikachu iv0 great100`
+
+      Copy and paste to run.
 ```
 
 ## How It Works
 
-The `!ask` command sends the user's text to a local or cloud AI model via the OpenAI-compatible chat completions API. The model uses a system prompt containing the full Poracle command reference to generate correct commands. The bot shows the suggestion and waits for user confirmation before executing.
+The `!ask` command sends the user's text to a local or cloud AI model via the OpenAI-compatible chat completions API. The model uses a system prompt containing the full Poracle command reference to generate correct commands. The bot shows the suggestion for the user to copy and run.
 
 The AI is **never given access** to user data, tracking rules, or the database. It only translates text → commands.
 
@@ -38,7 +39,7 @@ Add to `config/config.toml`:
 enabled = true
 provider_url = "http://localhost:11434/v1"  # Your provider URL
 api_key = ""                                 # Empty for local Ollama
-model = "qwen2.5:1.5b"                      # Model name
+model = "gemma3:12b"                         # Model name
 ```
 
 ### 3. Provider-Specific Setup
@@ -52,10 +53,9 @@ model = "qwen2.5:1.5b"                      # Model name
 curl -fsSL https://ollama.ai/install.sh | sh
 
 # Pull a model (choose one)
-ollama pull qwen2.5:1.5b    # 1GB, fast, good for structured tasks
-ollama pull qwen2.5:3b      # 2GB, better quality
-ollama pull phi3:mini        # 2.2GB, Microsoft, good reasoning
-ollama pull gemma2:2b        # 1.5GB, Google
+ollama pull gemma3:4b      # 3GB, good balance of quality and speed
+ollama pull gemma3:12b     # 8GB, best quality for local use
+ollama pull llama3.1:8b    # 4.5GB, good alternative
 ```
 
 Config:
@@ -64,7 +64,7 @@ Config:
 enabled = true
 provider_url = "http://localhost:11434/v1"
 api_key = ""
-model = "qwen2.5:1.5b"
+model = "gemma3:12b"
 ```
 
 Docker users — add Ollama as a sidecar:
@@ -94,7 +94,7 @@ volumes:
 
 After starting, pull a model inside the container:
 ```bash
-docker exec -it ollama ollama pull qwen2.5:1.5b
+docker exec -it ollama ollama pull gemma3:12b
 ```
 
 #### OpenRouter (Many Models, One API Key)
@@ -103,7 +103,7 @@ docker exec -it ollama ollama pull qwen2.5:1.5b
 
 1. Sign up at https://openrouter.ai
 2. Create an API key in your account settings
-3. Browse models at https://openrouter.ai/models
+3. Add credits (even $1 is enough for thousands of requests)
 
 Config:
 ```toml
@@ -111,11 +111,10 @@ Config:
 enabled = true
 provider_url = "https://openrouter.ai/api/v1"
 api_key = "sk-or-v1-..."
-model = "qwen/qwen-2.5-7b-instruct"
+model = "google/gemma-3-12b-it"
 # Other options:
-# model = "google/gemma-2-2b-it"          # Free
-# model = "meta-llama/llama-3.1-8b-instruct"  # Free
-# model = "anthropic/claude-3.5-haiku"    # Fast, cheap
+# model = "meta-llama/llama-3.1-8b-instruct"
+# model = "mistralai/mistral-small-3.1-24b-instruct"
 ```
 
 #### Groq (Fast, Free Tier)
@@ -146,21 +145,26 @@ model = "gpt-4o-mini"
 
 ## Recommended Models
 
+The system prompt is ~8KB and requires a model that reliably follows system instructions. Models below 7B parameters may ignore the system prompt and generate irrelevant output.
+
 | Use Case | Model | Size | Notes |
 |----------|-------|------|-------|
-| **Budget local** | `qwen2.5:1.5b` | 1GB | Good enough for simple commands |
-| **Quality local** | `qwen2.5:3b` | 2GB | Better at complex multi-filter commands |
-| **Best local** | `qwen2.5:7b` | 4.5GB | Excellent, needs more RAM |
-| **Free cloud** | Groq `llama-3.1-8b-instant` | — | Very fast, free tier |
-| **Cheap cloud** | OpenAI `gpt-4o-mini` | — | Reliable, ~$0.0001 per request |
-| **Best cloud** | Any large model via OpenRouter | — | For complex edge cases |
+| **Best local** | `gemma3:12b` (Ollama) | 8GB | Excellent accuracy, recommended |
+| **Good local** | `gemma3:4b` (Ollama) | 3GB | Good balance of speed and quality |
+| **Good local** | `llama3.1:8b` (Ollama) | 4.5GB | Reliable alternative |
+| **Best cloud** | `google/gemma-3-12b-it` (OpenRouter) | — | Best tested, ~$0.07/M tokens |
+| **Good cloud** | `meta-llama/llama-3.1-8b-instruct` (OpenRouter) | — | Slightly cheaper |
+| **Fast cloud** | Groq `llama-3.1-8b-instant` | — | Very fast, free tier |
+| **Reliable cloud** | OpenAI `gpt-4o-mini` | — | Most reliable, ~$0.15/M tokens |
+
+**Avoid**: `qwen/qwen-2.5-7b-instruct` — intermittently ignores the system prompt and returns SQL or unrelated content.
 
 ## Testing
 
 Test the AI endpoint directly:
 
 ```bash
-curl -X POST http://localhost:3030/api/ai/translate \
+curl -X POST http://localhost:4200/api/ai/translate \
   -H "Content-Type: application/json" \
   -H "X-Poracle-Secret: your-secret" \
   -d '{"message": "track shiny pikachu with good great league PVP"}'
@@ -185,10 +189,10 @@ Then test via Discord/Telegram:
 → Set `[ai] enabled = true` in config.toml and restart.
 
 **Timeout errors**
-→ Local models may take a few seconds on first request (cold start). Increase timeout or use a faster model.
+��� Local models may take a few seconds on first request (cold start). Increase timeout or use a faster model.
 
-**Wrong commands generated**
-→ Try a larger model. The system prompt works best with 3B+ parameter models. Smaller models may miss nuances.
+**Wrong commands generated (SQL, generic advice, etc.)**
+→ Your model is too small or unreliable with system prompts. Switch to `google/gemma-3-12b-it` or `meta-llama/llama-3.1-8b-instruct`. The system prompt requires 7B+ parameter models that reliably follow system instructions.
 
 **Ollama not responding**
 → Check `ollama serve` is running. Test with `curl http://localhost:11434/v1/models`.
@@ -198,10 +202,11 @@ Then test via Discord/Telegram:
 
 ## Customising the System Prompt
 
-The system prompt is embedded in `processor/internal/ai/client.go`. It contains the full Poracle command reference. If you add custom commands or aliases, update the prompt to include them.
+The system prompt is embedded in `processor/internal/ai/prompt.go`. It contains the full Poracle command reference. If you add custom commands or aliases, update the prompt to include them.
 
-The prompt is designed to work with small models (1.5B+) by being explicit and example-heavy. Key principles:
+The prompt is designed to work with 7B+ models by being explicit and example-heavy. Key principles:
 - Low temperature (0.1) for deterministic output
 - Max 256 tokens (commands are short)
-- "Return ONLY the command" instruction prevents explanations
+- User message wrapper reinforces "commands only" instruction
+- Post-processing extracts `!` command lines from noisy model output
 - Many examples cover common phrasings

--- a/alerter/src/lib/configAdapter.js
+++ b/alerter/src/lib/configAdapter.js
@@ -80,6 +80,13 @@ function adaptConfig(toml) {
 		headers: processorSecret ? { 'X-Poracle-Secret': processorSecret } : {},
 	}
 
+	// ---- ai (!ask / NLP suggestion) ----
+	const aiConfig = toml.ai || {}
+	config.ai = {
+		enabled: !!aiConfig.enabled,
+		suggestOnDm: !!aiConfig.suggest_on_dm,
+	}
+
 	// ---- database ----
 	const db = toml.database || {}
 	if (!db.user || !db.database) {

--- a/alerter/src/lib/discord/commando/commands/ask.js
+++ b/alerter/src/lib/discord/commando/commands/ask.js
@@ -1,0 +1,11 @@
+const PoracleDiscordMessage = require('../../poracleDiscordMessage')
+const PoracleDiscordState = require('../../poracleDiscordState')
+
+const commandLogic = require('../../../poracleMessage/commands/ask')
+
+exports.run = async (client, msg, command) => {
+	const pdm = new PoracleDiscordMessage(client, msg)
+	const pds = new PoracleDiscordState(client)
+
+	await commandLogic.run(pds, pdm, command[0])
+}

--- a/alerter/src/lib/discord/commando/events/messageCreate.js
+++ b/alerter/src/lib/discord/commando/events/messageCreate.js
@@ -1,3 +1,5 @@
+const suggestCommand = require('../../../poracleMessage/suggestCommand')
+
 module.exports = async (client, msg) => {
 	try {
 		// Ignore all bots
@@ -85,8 +87,22 @@ module.exports = async (client, msg) => {
 				}
 			}
 		}
-		if (msg.channel.isDMBased() && !recognisedCommand && client.config.discord.unrecognisedCommandMessage) {
-			msg.reply(client.config.discord.unrecognisedCommandMessage)
+
+		// DM with unrecognised or no command: try NLP suggestion if enabled
+		if (msg.channel.isDMBased() && !recognisedCommand) {
+			if (client.config.ai && client.config.ai.suggestOnDm) {
+				const text = msg.content.startsWith(client.config.discord.prefix)
+					? msg.content.slice(client.config.discord.prefix.length).trim()
+					: msg.content.trim()
+				const suggestion = await suggestCommand(client.config, text, client.config.discord.prefix)
+				if (suggestion) {
+					msg.reply(suggestion)
+					return
+				}
+			}
+			if (client.config.discord.unrecognisedCommandMessage) {
+				msg.reply(client.config.discord.unrecognisedCommandMessage)
+			}
 		}
 	} catch (err) {
 		client.logs.discord.error('Error during message event', err)

--- a/alerter/src/lib/discord/poracleDiscordMessage.js
+++ b/alerter/src/lib/discord/poracleDiscordMessage.js
@@ -33,6 +33,7 @@ class PoracleDiscordMessage {
 
 		this.discord = msg
 		this.userId = msg.author.id
+		this.prefix = client.config.discord.prefix || '!'
 		this.command = msg.content.split(' ')[0].substring(1)
 	}
 

--- a/alerter/src/lib/poracleMessage/commands/ask.js
+++ b/alerter/src/lib/poracleMessage/commands/ask.js
@@ -1,10 +1,17 @@
 const axios = require('axios')
 
+function replacePrefix(command, prefix) {
+	if (!prefix || prefix === '!') return command
+	return command.replace(/^!/gm, prefix)
+}
+
 exports.run = async (client, msg, args) => {
 	try {
+		const prefix = msg.prefix || client.config.discord.prefix || '!'
+
 		const question = args.join(' ').trim()
 		if (!question) {
-			await msg.reply('Usage: `!ask <what you want to track in plain English>`\nExample: `!ask track shiny pikachu with good PVP`')
+			await msg.reply(`Usage: \`${prefix}ask <what you want to track in plain English>\`\nExample: \`${prefix}ask track perfect dragonite nearby\``)
 			return
 		}
 
@@ -23,7 +30,7 @@ exports.run = async (client, msg, args) => {
 			})
 		} catch (err) {
 			if (err.response && err.response.status === 503) {
-				await msg.reply('`!ask` is not configured. Ask an admin to enable `[ai] enabled = true` in config.toml.')
+				await msg.reply(`\`${prefix}ask\` is not configured. Ask an admin to enable \`[ai] enabled = true\` in config.toml.`)
 				return
 			}
 			client.log.error('ask translate request failed:', err.message)
@@ -33,18 +40,17 @@ exports.run = async (client, msg, args) => {
 
 		const { data } = response
 
-		// Ambiguous: show numbered options
 		if (data.status === 'ambiguous') {
 			let preview = `${data.message || 'Did you mean:'}\n`
 			for (let i = 0; i < data.options.length; i++) {
-				preview += `${i + 1}. ${data.options[i].label}: \`${data.options[i].command}\`\n`
+				const cmd = replacePrefix(data.options[i].command, prefix)
+				preview += `${i + 1}. ${data.options[i].label}: \`${cmd}\`\n`
 			}
 			preview += '\nCopy and paste the command you want.'
 			await msg.reply(preview)
 			return
 		}
 
-		// Error
 		if (data.status !== 'ok' || !data.command) {
 			await msg.reply(`Sorry, I couldn't translate that: ${data.error || 'unknown error'}`)
 			return
@@ -57,11 +63,10 @@ exports.run = async (client, msg, args) => {
 			return
 		}
 
-		// Show suggested commands
 		const commands = command.split('\n').filter((c) => c.trim())
 		let preview = '**Suggested command(s):**\n'
 		for (const cmd of commands) {
-			preview += `\`${cmd}\`\n`
+			preview += `\`${replacePrefix(cmd, prefix)}\`\n`
 		}
 		preview += '\nCopy and paste to run.'
 

--- a/alerter/src/lib/poracleMessage/commands/ask.js
+++ b/alerter/src/lib/poracleMessage/commands/ask.js
@@ -1,0 +1,102 @@
+const axios = require('axios')
+
+exports.run = async (client, msg, args, options) => {
+	try {
+		if (!msg.isDM && !msg.isFromAdmin) {
+			return
+		}
+
+		const question = args.join(' ').trim()
+		if (!question) {
+			await msg.reply('Usage: `!ask <what you want to track in plain English>`\nExample: `!ask track shiny pikachu with good PVP`')
+			return
+		}
+
+		const processorUrl = `${client.config.processor.url}/api/ai/translate`
+
+		let response
+		try {
+			response = await axios.post(processorUrl, {
+				message: question,
+			}, {
+				headers: {
+					'Content-Type': 'application/json',
+					...(client.config.processor.headers || {}),
+				},
+				timeout: 30000,
+			})
+		} catch (err) {
+			if (err.response && err.response.status === 503) {
+				await msg.reply('AI assistant is not configured. Ask an admin to enable it in config.toml.')
+				return
+			}
+			client.log.error('AI translate request failed:', err.message)
+			await msg.reply('Failed to reach AI assistant. Is the processor running?')
+			return
+		}
+
+		const { data } = response
+		if (data.status !== 'ok' || !data.command) {
+			await msg.reply(`Sorry, I couldn't translate that: ${data.error || 'unknown error'}`)
+			return
+		}
+
+		const { command } = data
+
+		// Check if the AI returned an error message
+		if (command.startsWith('ERROR:')) {
+			await msg.reply(command)
+			return
+		}
+
+		// Show the suggested command and ask for confirmation
+		const commands = command.split('\n').filter((c) => c.trim())
+		let preview = '**AI suggests:**\n'
+		for (const cmd of commands) {
+			preview += `\`${cmd}\`\n`
+		}
+		preview += '\nReact ✅ to run, or ❌ to cancel.'
+
+		const confirmMsg = await msg.reply(preview)
+
+		// Add reactions for confirmation
+		if (confirmMsg && confirmMsg.react) {
+			await confirmMsg.react('✅')
+			await confirmMsg.react('❌')
+
+			// Wait for reaction (60 seconds)
+			const filter = (reaction, user) => ['✅', '❌'].includes(reaction.emoji.name) && user.id === msg.author.id
+			try {
+				const collected = await confirmMsg.awaitReactions({
+					filter, max: 1, time: 60000, errors: ['time'],
+				})
+				const reaction = collected.first()
+
+				if (reaction && reaction.emoji.name === '✅') {
+					// Execute each command
+					for (const cmd of commands) {
+						const cmdArgs = cmd.trim().split(/\s+/)
+						const cmdName = cmdArgs.shift().replace('!', '')
+
+						// Route through the normal command system
+						const handler = client.commands.get(cmdName)
+						if (handler) {
+							await handler.run(client, msg, cmdArgs, options)
+						} else {
+							await msg.reply(`Unknown command: \`${cmdName}\``)
+						}
+					}
+				} else {
+					await msg.reply('Cancelled.')
+				}
+			} catch {
+				await msg.reply('No response — cancelled.')
+			}
+		} else {
+			// Telegram or non-interactive — just show the commands
+			await msg.reply(`To run these commands, copy and paste:\n${commands.map((c) => `\`${c}\``).join('\n')}`)
+		}
+	} catch (err) {
+		client.log.error('ask command error:', err)
+	}
+}

--- a/alerter/src/lib/poracleMessage/commands/ask.js
+++ b/alerter/src/lib/poracleMessage/commands/ask.js
@@ -1,11 +1,7 @@
 const axios = require('axios')
 
-exports.run = async (client, msg, args, options) => {
+exports.run = async (client, msg, args) => {
 	try {
-		if (!msg.isDM && !msg.isFromAdmin) {
-			return
-		}
-
 		const question = args.join(' ').trim()
 		if (!question) {
 			await msg.reply('Usage: `!ask <what you want to track in plain English>`\nExample: `!ask track shiny pikachu with good PVP`')
@@ -49,53 +45,15 @@ exports.run = async (client, msg, args, options) => {
 			return
 		}
 
-		// Show the suggested command and ask for confirmation
+		// Show the suggested commands for the user to copy and run
 		const commands = command.split('\n').filter((c) => c.trim())
 		let preview = '**AI suggests:**\n'
 		for (const cmd of commands) {
 			preview += `\`${cmd}\`\n`
 		}
-		preview += '\nReact ✅ to run, or ❌ to cancel.'
+		preview += '\nCopy and paste to run.'
 
-		const confirmMsg = await msg.reply(preview)
-
-		// Add reactions for confirmation
-		if (confirmMsg && confirmMsg.react) {
-			await confirmMsg.react('✅')
-			await confirmMsg.react('❌')
-
-			// Wait for reaction (60 seconds)
-			const filter = (reaction, user) => ['✅', '❌'].includes(reaction.emoji.name) && user.id === msg.author.id
-			try {
-				const collected = await confirmMsg.awaitReactions({
-					filter, max: 1, time: 60000, errors: ['time'],
-				})
-				const reaction = collected.first()
-
-				if (reaction && reaction.emoji.name === '✅') {
-					// Execute each command
-					for (const cmd of commands) {
-						const cmdArgs = cmd.trim().split(/\s+/)
-						const cmdName = cmdArgs.shift().replace('!', '')
-
-						// Route through the normal command system
-						const handler = client.commands.get(cmdName)
-						if (handler) {
-							await handler.run(client, msg, cmdArgs, options)
-						} else {
-							await msg.reply(`Unknown command: \`${cmdName}\``)
-						}
-					}
-				} else {
-					await msg.reply('Cancelled.')
-				}
-			} catch {
-				await msg.reply('No response — cancelled.')
-			}
-		} else {
-			// Telegram or non-interactive — just show the commands
-			await msg.reply(`To run these commands, copy and paste:\n${commands.map((c) => `\`${c}\``).join('\n')}`)
-		}
+		await msg.reply(preview)
 	} catch (err) {
 		client.log.error('ask command error:', err)
 	}

--- a/alerter/src/lib/poracleMessage/commands/ask.js
+++ b/alerter/src/lib/poracleMessage/commands/ask.js
@@ -23,15 +23,28 @@ exports.run = async (client, msg, args) => {
 			})
 		} catch (err) {
 			if (err.response && err.response.status === 503) {
-				await msg.reply('AI assistant is not configured. Ask an admin to enable it in config.toml.')
+				await msg.reply('`!ask` is not configured. Ask an admin to enable `[ai] enabled = true` in config.toml.')
 				return
 			}
-			client.log.error('AI translate request failed:', err.message)
-			await msg.reply('Failed to reach AI assistant. Is the processor running?')
+			client.log.error('ask translate request failed:', err.message)
+			await msg.reply('Failed to reach the processor. Is it running?')
 			return
 		}
 
 		const { data } = response
+
+		// Ambiguous: show numbered options
+		if (data.status === 'ambiguous') {
+			let preview = `${data.message || 'Did you mean:'}\n`
+			for (let i = 0; i < data.options.length; i++) {
+				preview += `${i + 1}. ${data.options[i].label}: \`${data.options[i].command}\`\n`
+			}
+			preview += '\nCopy and paste the command you want.'
+			await msg.reply(preview)
+			return
+		}
+
+		// Error
 		if (data.status !== 'ok' || !data.command) {
 			await msg.reply(`Sorry, I couldn't translate that: ${data.error || 'unknown error'}`)
 			return
@@ -39,15 +52,14 @@ exports.run = async (client, msg, args) => {
 
 		const { command } = data
 
-		// Check if the AI returned an error message
 		if (command.startsWith('ERROR:')) {
 			await msg.reply(command)
 			return
 		}
 
-		// Show the suggested commands for the user to copy and run
+		// Show suggested commands
 		const commands = command.split('\n').filter((c) => c.trim())
-		let preview = '**AI suggests:**\n'
+		let preview = '**Suggested command(s):**\n'
 		for (const cmd of commands) {
 			preview += `\`${cmd}\`\n`
 		}

--- a/alerter/src/lib/poracleMessage/suggestCommand.js
+++ b/alerter/src/lib/poracleMessage/suggestCommand.js
@@ -1,0 +1,66 @@
+const axios = require('axios')
+
+/**
+ * Replace the ! prefix in commands with the platform-specific prefix.
+ */
+function replacePrefix(command, prefix) {
+	if (!prefix || prefix === '!') return command
+	return command.replace(/^!/gm, prefix)
+}
+
+/**
+ * Sends text to the NLP parser and returns a formatted suggestion message,
+ * or null if no useful suggestion was produced.
+ *
+ * @param {object} config - alerter config (needs config.processor.url, config.processor.headers)
+ * @param {string} text - the user's raw text
+ * @param {string} prefix - command prefix for this platform ('!' for Discord default, '/' for Telegram)
+ * @returns {Promise<string|null>} suggestion message or null
+ */
+async function suggestCommand(config, text, prefix) {
+	if (!text || !config.processor || !config.processor.url) return null
+
+	let response
+	try {
+		response = await axios.post(`${config.processor.url}/api/ai/translate`, {
+			message: text,
+		}, {
+			headers: {
+				'Content-Type': 'application/json',
+				...(config.processor.headers || {}),
+			},
+			timeout: 5000,
+		})
+	} catch {
+		return null
+	}
+
+	const { data } = response
+	if (!data) return null
+
+	if (data.status === 'ambiguous' && data.options && data.options.length > 0) {
+		let msg = 'Did you mean:\n'
+		for (let i = 0; i < data.options.length; i++) {
+			const cmd = replacePrefix(data.options[i].command, prefix)
+			msg += `${i + 1}. ${data.options[i].label}: \`${cmd}\`\n`
+		}
+		msg += '\nCopy and paste the command you want.'
+		return msg
+	}
+
+	if (data.status === 'ok' && data.command && !data.command.startsWith('ERROR:')) {
+		const commands = data.command.split('\n').filter((c) => c.trim())
+		if (commands.length === 0) return null
+
+		let msg = 'Did you mean:\n'
+		for (const cmd of commands) {
+			msg += `\`${replacePrefix(cmd, prefix)}\`\n`
+		}
+		msg += '\nCopy and paste to run.'
+		return msg
+	}
+
+	return null
+}
+
+module.exports = suggestCommand

--- a/alerter/src/lib/telegram/Telegram.js
+++ b/alerter/src/lib/telegram/Telegram.js
@@ -118,7 +118,23 @@ class Telegram extends EventEmitter {
 
 	async processCommand(ctx) {
 		const { command } = ctx.state
-		if (!command) return
+
+		// Plain text DM (no /command prefix) — try NLP suggestion
+		if (!command) {
+			if (ctx.update.message && ctx.update.message.chat.type === 'private'
+					&& this.config.ai && this.config.ai.suggestOnDm) {
+				const text = (ctx.update.message.text || '').trim()
+				if (text) {
+					const suggestCommand = require('../poracleMessage/suggestCommand')
+					const suggestion = await suggestCommand(this.config, text, '/')
+					if (suggestion) {
+						ctx.reply(suggestion)
+					}
+				}
+			}
+			return
+		}
+
 		if (command.bot && command.bot.toLowerCase() !== ctx.botInfo.username.toLowerCase()) return
 		if (Object.keys(this.commands).includes(command.command)) {
 			ctx.poracleAddMessageQueue = (queue) => this.emit('sendMessages', queue)
@@ -127,9 +143,21 @@ class Telegram extends EventEmitter {
 
 			return this.commands[command.command](ctx)
 		}
-		if (ctx.update.message.chat.type === 'private'
-				&& this.config.telegram.unrecognisedCommandMessage) {
-			ctx.reply(this.config.telegram.unrecognisedCommandMessage)
+
+		// Unrecognised /command in DM — try NLP suggestion
+		if (ctx.update.message.chat.type === 'private') {
+			if (this.config.ai && this.config.ai.suggestOnDm) {
+				const suggestCommand = require('../poracleMessage/suggestCommand')
+				const text = command.args || command.command
+				const suggestion = await suggestCommand(this.config, text)
+				if (suggestion) {
+					ctx.reply(suggestion)
+					return
+				}
+			}
+			if (this.config.telegram.unrecognisedCommandMessage) {
+				ctx.reply(this.config.telegram.unrecognisedCommandMessage)
+			}
 		}
 	}
 

--- a/alerter/src/lib/telegram/commands/ask.js
+++ b/alerter/src/lib/telegram/commands/ask.js
@@ -1,0 +1,20 @@
+const PoracleTelegramMessage = require('../poracleTelegramMessage')
+const PoracleTelegramState = require('../poracleTelegramState')
+
+const commandLogic = require('../../poracleMessage/commands/ask')
+
+module.exports = async (ctx) => {
+	const { controller, command } = ctx.state
+
+	// channel message authors aren't identifiable, ignore all commands sent in channels
+	if (Object.keys(ctx.update).includes('channel_post')) return
+
+	try {
+		const ptm = new PoracleTelegramMessage(ctx)
+		const pts = new PoracleTelegramState(ctx)
+
+		await commandLogic.run(pts, ptm, command.splitArgsArray[0])
+	} catch (err) {
+		controller.logs.telegram.error('Ask command unhappy:', err)
+	}
+}

--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -484,3 +484,15 @@ webhooks = false                         # matched webhook log (can be quite lar
 discord = true                           # outbound messages to discord users and channels
 telegram = true                          # outbound messages to telegram users, groups and channels
 pvp = false                              # pvp info/calculations (at verbose level)
+
+# ---- AI Command Assistant ----
+# Optional: translates natural language into Poracle commands via !ask
+# Works with any OpenAI-compatible API: Ollama (local), OpenRouter, OpenAI, Groq, etc.
+[ai]
+enabled = false
+# provider_url = "http://localhost:11434/v1"            # Ollama (local, free)
+# provider_url = "https://openrouter.ai/api/v1"        # OpenRouter (many models)
+# provider_url = "https://api.groq.com/openai/v1"      # Groq (fast, free tier)
+# provider_url = "https://api.openai.com/v1"            # OpenAI
+api_key = ""                                             # empty for local Ollama
+model = ""                                               # e.g. "qwen2.5:1.5b", "gpt-4o-mini"

--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -485,14 +485,16 @@ discord = true                           # outbound messages to discord users an
 telegram = true                          # outbound messages to telegram users, groups and channels
 pvp = false                              # pvp info/calculations (at verbose level)
 
-# ---- AI Command Assistant ----
-# Optional: translates natural language into Poracle commands via !ask
-# Works with any OpenAI-compatible API: Ollama (local), OpenRouter, OpenAI, Groq, etc.
+# ---- !ask Command ----
+# Translates natural language into Poracle commands via !ask
+# Uses a built-in NLP parser (no external dependencies needed).
+# Optionally falls back to an AI model for unrecognized input.
 [ai]
-enabled = false
-# provider_url = "http://localhost:11434/v1"            # Ollama (local, free)
-# provider_url = "https://openrouter.ai/api/v1"        # OpenRouter (many models)
-# provider_url = "https://api.groq.com/openai/v1"      # Groq (fast, free tier)
-# provider_url = "https://api.openai.com/v1"            # OpenAI
-api_key = ""                                             # empty for local Ollama
+enabled = false                                          # enables !ask command (NLP parser)
+fallback_to_ai = false                                   # if NLP can't parse, try AI model
+# provider_url = "http://localhost:11434/v1"             # only needed if fallback_to_ai = true
+# provider_url = "https://openrouter.ai/api/v1"         # OpenRouter (many models)
+# provider_url = "https://api.groq.com/openai/v1"       # Groq (fast, free tier)
+# provider_url = "https://api.openai.com/v1"             # OpenAI
+api_key = ""                                             # only needed if fallback_to_ai = true
 model = ""                                               # e.g. "google/gemma-3-12b-it", "qwen2.5:7b"

--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -491,6 +491,7 @@ pvp = false                              # pvp info/calculations (at verbose lev
 # Optionally falls back to an AI model for unrecognized input.
 [ai]
 enabled = false                                          # enables !ask command (NLP parser)
+suggest_on_dm = false                                    # suggest commands for any unrecognised DM
 fallback_to_ai = false                                   # if NLP can't parse, try AI model
 # provider_url = "http://localhost:11434/v1"             # only needed if fallback_to_ai = true
 # provider_url = "https://openrouter.ai/api/v1"         # OpenRouter (many models)

--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -495,4 +495,4 @@ enabled = false
 # provider_url = "https://api.groq.com/openai/v1"      # Groq (fast, free tier)
 # provider_url = "https://api.openai.com/v1"            # OpenAI
 api_key = ""                                             # empty for local Ollama
-model = ""                                               # e.g. "qwen2.5:1.5b", "gpt-4o-mini"
+model = ""                                               # e.g. "google/gemma-3-12b-it", "qwen2.5:7b"

--- a/processor/cmd/processor/main.go
+++ b/processor/cmd/processor/main.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/pokemon/poracleng/processor/internal/ai"
 	"github.com/pokemon/poracleng/processor/internal/api"
+	"github.com/pokemon/poracleng/processor/internal/nlp"
 	"github.com/pokemon/poracleng/processor/internal/config"
 	"github.com/pokemon/poracleng/processor/internal/db"
 	"github.com/pokemon/poracleng/processor/internal/enrichment"
@@ -158,15 +159,23 @@ func main() {
 	mux.HandleFunc("/api/test", auth(api.HandleTest(proc)))
 	mux.HandleFunc("/api/geocode/forward", auth(api.HandleGeocode(proc.enricher.Geocoder)))
 
-	// AI command assistant (optional)
-	var aiClient *ai.Client
+	// NLP command parser + optional AI fallback
+	var nlpParser *nlp.Parser
 	if cfg.AI.Enabled {
-		aiClient = ai.New(cfg.AI.ProviderURL, cfg.AI.APIKey, cfg.AI.Model)
-		if aiClient != nil {
-			log.Infof("AI assistant enabled: model=%s provider=%s", cfg.AI.Model, cfg.AI.ProviderURL)
+		tr := proc.enricher.Translations.For("en")
+		if tr != nil {
+			nlpParser = nlp.NewParser(tr, cfg.BaseDir, nil)
+			log.Infof("NLP command parser enabled (%d pokemon names)", nlpParser.PokemonCount())
 		}
 	}
-	mux.HandleFunc("/api/ai/translate", auth(api.HandleAI(aiClient)))
+	var aiClient *ai.Client
+	if cfg.AI.Enabled && cfg.AI.FallbackToAI {
+		aiClient = ai.New(cfg.AI.ProviderURL, cfg.AI.APIKey, cfg.AI.Model)
+		if aiClient != nil {
+			log.Infof("AI fallback enabled: model=%s provider=%s", cfg.AI.Model, cfg.AI.ProviderURL)
+		}
+	}
+	mux.HandleFunc("/api/ai/translate", auth(api.HandleAI(nlpParser, aiClient, cfg.AI.FallbackToAI)))
 
 	// Geofence data and tile generation endpoints
 	tileDeps := api.TileDeps{

--- a/processor/cmd/processor/main.go
+++ b/processor/cmd/processor/main.go
@@ -22,6 +22,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/natefinch/lumberjack.v2"
 
+	"github.com/pokemon/poracleng/processor/internal/ai"
 	"github.com/pokemon/poracleng/processor/internal/api"
 	"github.com/pokemon/poracleng/processor/internal/config"
 	"github.com/pokemon/poracleng/processor/internal/db"
@@ -156,6 +157,16 @@ func main() {
 	mux.HandleFunc("/health", api.HandleHealth())
 	mux.HandleFunc("/api/test", auth(api.HandleTest(proc)))
 	mux.HandleFunc("/api/geocode/forward", auth(api.HandleGeocode(proc.enricher.Geocoder)))
+
+	// AI command assistant (optional)
+	var aiClient *ai.Client
+	if cfg.AI.Enabled {
+		aiClient = ai.New(cfg.AI.ProviderURL, cfg.AI.APIKey, cfg.AI.Model)
+		if aiClient != nil {
+			log.Infof("AI assistant enabled: model=%s provider=%s", cfg.AI.Model, cfg.AI.ProviderURL)
+		}
+	}
+	mux.HandleFunc("/api/ai/translate", auth(api.HandleAI(aiClient)))
 
 	// Geofence data and tile generation endpoints
 	tileDeps := api.TileDeps{

--- a/processor/internal/ai/client.go
+++ b/processor/internal/ai/client.go
@@ -1,0 +1,133 @@
+// Package ai provides an OpenAI-compatible chat completion client for
+// translating natural language into Poracle tracking commands.
+//
+// Supports any backend that implements the OpenAI chat completions API:
+// Ollama (local), OpenRouter, OpenAI, Groq, Together AI, LM Studio, etc.
+package ai
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// Client talks to an OpenAI-compatible chat completions endpoint.
+type Client struct {
+	baseURL string
+	apiKey  string
+	model   string
+	client  *http.Client
+}
+
+// New creates a new AI client. Returns nil if not configured.
+func New(providerURL, apiKey, model string) *Client {
+	if providerURL == "" || model == "" {
+		return nil
+	}
+	return &Client{
+		baseURL: strings.TrimRight(providerURL, "/"),
+		apiKey:  apiKey,
+		model:   model,
+		client:  &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+// chatRequest is the OpenAI chat completions request format.
+type chatRequest struct {
+	Model       string        `json:"model"`
+	Messages    []chatMessage `json:"messages"`
+	Temperature float64       `json:"temperature"`
+	MaxTokens   int           `json:"max_tokens,omitempty"`
+}
+
+type chatMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+// chatResponse is the OpenAI chat completions response format.
+type chatResponse struct {
+	Choices []struct {
+		Message struct {
+			Content string `json:"content"`
+		} `json:"message"`
+	} `json:"choices"`
+	Error *struct {
+		Message string `json:"message"`
+	} `json:"error,omitempty"`
+}
+
+// TranslateCommand sends a natural language request to the AI model and
+// returns the suggested Poracle command(s).
+func (c *Client) TranslateCommand(userRequest string) (string, error) {
+	if c == nil {
+		return "", fmt.Errorf("AI not configured")
+	}
+
+	req := chatRequest{
+		Model: c.model,
+		Messages: []chatMessage{
+			{Role: "system", Content: systemPrompt},
+			{Role: "user", Content: userRequest},
+		},
+		Temperature: 0.1, // low temperature for deterministic command output
+		MaxTokens:   256,
+	}
+
+	body, err := json.Marshal(req)
+	if err != nil {
+		return "", fmt.Errorf("marshal request: %w", err)
+	}
+
+	url := c.baseURL + "/chat/completions"
+	httpReq, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return "", fmt.Errorf("create request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	if c.apiKey != "" {
+		httpReq.Header.Set("Authorization", "Bearer "+c.apiKey)
+	}
+
+	start := time.Now()
+	resp, err := c.client.Do(httpReq)
+	if err != nil {
+		return "", fmt.Errorf("request failed: %w", err)
+	}
+	defer func() {
+		io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+	}()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("read response: %w", err)
+	}
+
+	log.Debugf("AI request took %dms, model=%s", time.Since(start).Milliseconds(), c.model)
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var chatResp chatResponse
+	if err := json.Unmarshal(respBody, &chatResp); err != nil {
+		return "", fmt.Errorf("unmarshal response: %w", err)
+	}
+
+	if chatResp.Error != nil {
+		return "", fmt.Errorf("API error: %s", chatResp.Error.Message)
+	}
+
+	if len(chatResp.Choices) == 0 {
+		return "", fmt.Errorf("no response from model")
+	}
+
+	return strings.TrimSpace(chatResp.Choices[0].Message.Content), nil
+}

--- a/processor/internal/ai/client.go
+++ b/processor/internal/ai/client.go
@@ -70,11 +70,15 @@ func (c *Client) TranslateCommand(userRequest string) (string, error) {
 		return "", fmt.Errorf("AI not configured")
 	}
 
+	// Wrap the user message with a reinforcement prefix to help smaller models
+	// stay on task and not generate conversational responses.
+	wrappedMessage := "Convert this to Poracle command(s). Reply with ONLY the command(s), nothing else:\n" + userRequest
+
 	req := chatRequest{
 		Model: c.model,
 		Messages: []chatMessage{
 			{Role: "system", Content: systemPrompt},
-			{Role: "user", Content: userRequest},
+			{Role: "user", Content: wrappedMessage},
 		},
 		Temperature: 0.1, // low temperature for deterministic command output
 		MaxTokens:   256,
@@ -129,5 +133,39 @@ func (c *Client) TranslateCommand(userRequest string) (string, error) {
 		return "", fmt.Errorf("no response from model")
 	}
 
-	return strings.TrimSpace(chatResp.Choices[0].Message.Content), nil
+	raw := strings.TrimSpace(chatResp.Choices[0].Message.Content)
+	return extractCommands(raw), nil
+}
+
+// extractCommands pulls valid Poracle commands from the model's response.
+// If the response contains lines starting with '!', only those are returned.
+// This handles models that add explanatory text despite being told not to.
+func extractCommands(raw string) string {
+	// Strip markdown code fences if present
+	raw = strings.TrimPrefix(raw, "```")
+	raw = strings.TrimSuffix(raw, "```")
+	raw = strings.TrimSpace(raw)
+
+	lines := strings.Split(raw, "\n")
+	var commands []string
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		// Strip numbered list prefixes like "1. ", "2) ", etc.
+		for len(line) > 0 && line[0] >= '0' && line[0] <= '9' {
+			line = line[1:]
+		}
+		line = strings.TrimLeft(line, ".) ")
+		if strings.HasPrefix(line, "!") {
+			commands = append(commands, line)
+		} else if strings.HasPrefix(line, "ERROR:") {
+			return line
+		}
+	}
+
+	if len(commands) > 0 {
+		return strings.Join(commands, "\n")
+	}
+
+	// No command lines found — return raw response (may be an error message)
+	return raw
 }

--- a/processor/internal/ai/extract_test.go
+++ b/processor/internal/ai/extract_test.go
@@ -1,0 +1,56 @@
+package ai
+
+import "testing"
+
+func TestExtractCommands(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			"clean command",
+			"!track pikachu iv100",
+			"!track pikachu iv100",
+		},
+		{
+			"multiple commands",
+			"!track pikachu iv100\n!track eevee iv100",
+			"!track pikachu iv100\n!track eevee iv100",
+		},
+		{
+			"command with explanation",
+			"Here is the command:\n!track pikachu iv100\nThis tracks pikachu.",
+			"!track pikachu iv100",
+		},
+		{
+			"markdown code fence",
+			"```\n!track pikachu iv100\n```",
+			"!track pikachu iv100",
+		},
+		{
+			"error response",
+			"ERROR: cannot determine pokemon name",
+			"ERROR: cannot determine pokemon name",
+		},
+		{
+			"no commands at all",
+			"I don't understand your request.",
+			"I don't understand your request.",
+		},
+		{
+			"commands mixed with numbering",
+			"1. !track pikachu iv100\n2. !track eevee iv100",
+			"!track pikachu iv100\n!track eevee iv100",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractCommands(tt.input)
+			if got != tt.expected {
+				t.Errorf("extractCommands(%q) = %q, want %q", tt.input, got, tt.expected)
+			}
+		})
+	}
+}

--- a/processor/internal/ai/prompt.go
+++ b/processor/internal/ai/prompt.go
@@ -1,0 +1,290 @@
+package ai
+
+// systemPrompt is sent to the AI model as the system message.
+// It contains the full Poracle command reference so the model can
+// generate correct commands from natural language input.
+//
+// Designed to work with small models (1.5B+ parameters) by being
+// explicit, example-heavy, and instruction-focused.
+var systemPrompt = `You translate Pokemon GO tracking requests into Poracle bot commands.
+Return ONLY the command(s), one per line. No explanations, no markdown, no backticks.
+
+=== COMMANDS ===
+
+!track <pokemon|everything|type> [filters]  - Wild pokemon spawns
+!raid <pokemon|level|everything> [filters]  - Raid bosses
+!egg <level|everything> [filters]           - Raid eggs
+!quest <reward> [filters]                   - Research tasks
+!invasion <type|everything> [filters]       - Team Rocket
+!lure <type|everything> [filters]           - Pokestop lures
+!nest <pokemon|everything> [filters]        - Nesting pokemon
+!gym <team|everything> [filters]            - Gym control changes
+!maxbattle <pokemon|level|everything> [filters] - Max battles
+!fort <pokestop|gym|everything> [changes]   - Pokestop/gym edits
+
+=== POKEMON FILTERS (!track) ===
+
+IV:        iv90  iv100  iv0-50  maxiv0
+CP:        cp1500  cp500-2500  maxcp1500
+Level:     level30  level20-35  maxlevel10
+Stats:     atk15  def0  sta10  atk0-5  maxatk0  maxdef5  maxsta5
+Weight:    weight5000  maxweight10000
+Size:      size:xxs  size:xs  size:m  size:l  size:xl  size:xs-l
+Rarity:    rarity:1  rarity:rare  maxrarity:4
+Gender:    male  female  genderless
+Form:      form:alolan  form:galarian  form:hisuian  form:shadow  form:purified
+Generation: gen1  gen2  gen3  gen4  gen5  gen6  gen7  gen8  gen9
+
+PVP (pick ONE league):
+  Great League:  great100  great1-50  greathigh100  greatcp1400
+  Ultra League:  ultra100  ultra1-100  ultrahigh50  ultracp2400
+  Little League: little100  little1-100  littlehigh50  littlecp490
+  Level Cap:     cap50  cap40  cap41  cap51
+
+Common:    d500 (meters)  template:1  clean  t300 (min seconds remaining)
+
+=== RAID/EGG FILTERS ===
+
+Level:     level1  level3  level5  level6  level7  (90 = all levels)
+Team:      mystic  valor  instinct  harmony  (or: blue red yellow gray)
+Exclusive: ex
+Move:      move:thunderbolt
+RSVP:      rsvp  |  no rsvp  |  rsvp only
+Common:    d500  template:1  clean
+
+=== INVASION FILTERS ===
+
+Types:     electric  water  fire  grass  ground  rock  bug  ghost  dark
+           dragon  fairy  fighting  flying  ice  normal  poison  psychic
+           steel  metal  darkness  mixed  everything
+Events:    kecleon  showcase  gold-stop
+Gender:    male  female
+Common:    d500  template:1  clean
+
+=== QUEST FILTERS ===
+
+Pokemon:   pikachu  chansey  spinda  (reward encounter)
+Items:     potion  revive  pokeball  razzberry  (item reward)
+Stardust:  stardust  stardust1000  stardust10000  (amount)
+Energy:    energy  energycharizard  (mega energy)
+Candy:     candy  candypikachu  (rare candy for specific)
+Shiny:     shiny  (only shiny-possible rewards)
+Common:    d500  template:1  clean
+
+=== LURE TYPES ===
+
+normal  glacial  mossy  magnetic  rainy  sparkly  everything
+
+=== GYM FILTERS ===
+
+Team:      mystic  valor  instinct  harmony  everything
+Changes:   slot_changes  battle_changes
+Common:    d500  template:1  clean
+
+=== NEST FILTERS ===
+
+Pokemon:   pikachu  bulbasaur  (or type: fire  water)
+MinSpawn:  minspawn5  (minimum avg spawns per hour)
+Common:    d500  template:1  clean
+
+=== MAXBATTLE FILTERS ===
+
+Pokemon:   snorlax  dragonite  (specific boss)
+Level:     level1  level3  level5  level7  (90 = all)
+Dynamax:   gmax  (Gigantamax only)
+Move:      move:thunderbolt
+Common:    d500  template:1  clean
+
+=== FORT CHANGES ===
+
+Type:      pokestop  gym  everything
+Changes:   name  location  photo  removal  new
+Common:    d500  template:1
+
+=== GAME DATA REFERENCE ===
+
+Raid Levels:
+  level1 = Level 1        level2 = Level 2
+  level3 = Level 3        level4 = Level 4
+  level5 = Legendary      level6 = Mega
+  level7 = Mega Legendary  level8 = Ultra Beast
+  level9 = Elite          level10 = Primal
+  level11-15 = Shadow raids (11-14 = tiers, 15 = shadow legendary)
+  level90 = ALL levels (wildcard)
+
+Max Battle Levels:
+  level1-4 = Star ratings   level5 = Legendary
+  level7 = Gigantamax       level8 = Legendary Gigantamax
+  level90 = ALL levels
+
+Teams:
+  mystic (blue) = 1    valor (red) = 2
+  instinct (yellow) = 3    harmony (gray/uncontested) = 0
+
+Rarity (for rarity: filter):
+  1 = Common   2 = Uncommon   3 = Rare
+  4 = Very Rare   5 = Ultra Rare   6 = New/Unseen
+
+Size (for size: filter):
+  1 = XXS   2 = XS   3 = M   4 = XL   5 = XXL
+
+Common Quest Reward Items (use lowercased name in !quest):
+  Balls: poke ball, great ball, ultra ball
+  Potions: potion, super potion, hyper potion, max potion
+  Revives: revive, max revive
+  Berries: razz berry, nanab berry, pinap berry, golden razz berry, silver pinap berry
+  TMs: fast tm, charged tm
+  Evolution: sun stone, kings rock, metal coat, dragon scale, upgrade, sinnoh stone, unova stone
+  Other: rare candy, rare candy xl, lucky egg, incense, star piece
+
+Pokemon Forms (use with form: filter):
+  Regional: alolan, galarian, hisuian, paldean
+  Shadow/Purified: shadow, purified
+  Mega: mega (use !raid level6 for mega raids, not form:mega)
+  Special: origin, altered, attack, defense, speed, plant, sandy, trash
+  Costume: party hat, witch hat, santa hat (use costume names)
+
+=== SPECIAL TERMS ===
+
+hundo    = iv100                      (100% perfect IV)
+nundo    = iv0 maxiv0                 (0/0/0 IV)
+shundo   = iv100                      (shiny hundo - track at iv100)
+shlundo  = iv0 maxiv0                 (shiny nundo)
+pvp      = low attack, high defense   (e.g. maxatk0 or great/ultra filter)
+perfect  = iv100
+zero     = iv0 maxiv0
+trash    = maxiv50 or similar low IV
+
+=== EXAMPLES ===
+
+"track shiny pikachu"
+!track pikachu iv0
+
+"perfect dragonite"
+!track dragonite iv100
+
+"nundo pokemon within 1km"
+!track everything iv0 maxiv0 d1000
+
+"100% pokemon"
+!track everything iv100
+
+"high CP dragonite over level 30"
+!track dragonite level30
+
+"good PVP pikachu for great league"
+!track pikachu great100
+
+"rank 1 great league anything"
+!track everything great1
+
+"PVP pokemon under rank 50 for ultra league"
+!track everything ultra50
+
+"0 attack pokemon for great league PVP"
+!track everything maxatk0 great100
+
+"level 5 raids"
+!raid level5
+
+"mewtwo raids within 2km"
+!raid mewtwo d2000
+
+"mega raids"
+!raid level6
+
+"all raid eggs"
+!egg everything
+
+"team rocket water female"
+!invasion water female
+
+"all invasions"
+!invasion everything
+
+"kecleon pokestop"
+!invasion kecleon
+
+"stardust quests"
+!quest stardust
+
+"pikachu quest reward"
+!quest pikachu
+
+"mossy lure nearby"
+!lure mossy d1000
+
+"gym taken by valor"
+!gym valor
+
+"track pikachu and eevee hundos"
+!track pikachu iv100
+!track eevee iv100
+
+"XXL pokemon"
+!track everything size:xl
+
+"all fire type nests"
+!nest fire
+
+"remove all my pokemon tracking"
+!track remove everything
+
+"alolan vulpix"
+!track vulpix form:alolan
+
+"shadow pokemon with good IVs"
+!track everything form:shadow iv80
+
+"golden razz berry quests"
+!quest "golden razz berry"
+
+"rare candy quest reward"
+!quest "rare candy"
+
+"shadow legendary raids"
+!raid level15
+
+"mega raids nearby"
+!raid level6 d1000
+
+"primal raids"
+!raid level10
+
+"ultra beast raids"
+!raid level8
+
+"ultra rare pokemon"
+!track everything rarity:5
+
+"tiny pokemon"
+!track everything size:xxs
+
+"galarian zigzagoon"
+!track zigzagoon form:galarian
+
+"gigantamax battles"
+!maxbattle level7
+
+"new pokestops added"
+!fort pokestop new
+
+"stop tracking dragonite"
+!track remove dragonite
+
+=== RULES ===
+
+1. Return ONLY Poracle commands. No explanations. No markdown. No backticks.
+2. One command per line if multiple are needed.
+3. Pokemon names in lowercase, no spaces (mr-mime not Mr. Mime).
+4. Arguments with spaces MUST be quoted: !quest "razz berry" not !quest razz berry.
+5. "shiny X" means !track X iv0 (iv0 catches all IVs so you do not miss the shiny).
+6. "hundo" / "perfect" / "100%" means iv100.
+7. "nundo" / "zero" / "0%" means iv0 maxiv0.
+8. If request mentions "within Xkm" use d followed by meters (1km = d1000).
+9. If request mentions "nearby" without distance use d1000.
+10. PVP leagues are mutually exclusive - pick the one mentioned.
+11. If you cannot translate, respond: ERROR: brief reason.
+12. "remove" or "stop tracking" means add "remove" after the command name.
+13. Multiple pokemon means one !track line per pokemon with shared filters.
+14. Raid levels: legendary=level5, mega=level6, shadow=level11-15, primal=level10, ultra beast=level8.`

--- a/processor/internal/ai/prompt.go
+++ b/processor/internal/ai/prompt.go
@@ -272,6 +272,18 @@ trash    = maxiv50 or similar low IV
 "stop tracking dragonite"
 !track remove dragonite
 
+"pokemon between 95 and 99 IV"
+!track everything iv95-99
+
+"low IV pokemon for PVP"
+!track everything iv0-50 great100
+
+"level 20 to 30 pokemon"
+!track everything level20-30
+
+"CP between 1400 and 1500 for great league"
+!track everything cp1400-1500
+
 === RULES ===
 
 1. Return ONLY Poracle commands. No explanations. No markdown. No backticks.

--- a/processor/internal/ai/translate_integration_test.go
+++ b/processor/internal/ai/translate_integration_test.go
@@ -1,0 +1,71 @@
+package ai
+
+import (
+	"os"
+	"testing"
+)
+
+func TestTranslateIntegration(t *testing.T) {
+	key := os.Getenv("OPENROUTER_KEY")
+	if key == "" {
+		t.Skip("OPENROUTER_KEY not set")
+	}
+
+	client := New("https://openrouter.ai/api/v1", key, "qwen/qwen-2.5-7b-instruct")
+
+	tests := []struct {
+		input    string
+		contains string // expected substring in result
+	}{
+		{"track shiny pikachu", "!track pikachu iv0"},
+		{"perfect dragonite", "!track dragonite iv100"},
+		{"level 5 raids nearby", "!raid level5"},
+		{"track hundos for pikachu eevee and dragonite", "!track pikachu iv100"},
+		{"team rocket water invasions", "!invasion water"},
+		{"stardust quest rewards", "!quest stardust"},
+		{"stop tracking bulbasaur", "!track remove bulbasaur"},
+		{"alolan vulpix within 1km", "!track vulpix"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result, err := client.TranslateCommand(tt.input)
+			if err != nil {
+				t.Fatalf("error: %s", err)
+			}
+			t.Logf("%-45s → %s", tt.input, result)
+			if tt.contains != "" && !containsIgnoreCase(result, tt.contains) {
+				t.Errorf("expected result to contain %q, got %q", tt.contains, result)
+			}
+		})
+	}
+}
+
+func containsIgnoreCase(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && findSubstr(s, substr))
+}
+
+func findSubstr(s, sub string) bool {
+	for i := 0; i <= len(s)-len(sub); i++ {
+		if equalFold(s[i:i+len(sub)], sub) {
+			return true
+		}
+	}
+	return false
+}
+
+func equalFold(a, b string) bool {
+	for i := 0; i < len(a); i++ {
+		ca, cb := a[i], b[i]
+		if ca >= 'A' && ca <= 'Z' {
+			ca += 32
+		}
+		if cb >= 'A' && cb <= 'Z' {
+			cb += 32
+		}
+		if ca != cb {
+			return false
+		}
+	}
+	return true
+}

--- a/processor/internal/api/ai.go
+++ b/processor/internal/api/ai.go
@@ -7,6 +7,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/pokemon/poracleng/processor/internal/ai"
+	"github.com/pokemon/poracleng/processor/internal/nlp"
 )
 
 type aiRequest struct {
@@ -14,20 +15,30 @@ type aiRequest struct {
 }
 
 type aiResponse struct {
-	Status  string `json:"status"`
-	Command string `json:"command,omitempty"`
-	Error   string `json:"error,omitempty"`
+	Status  string     `json:"status"`
+	Command string     `json:"command,omitempty"`
+	Error   string     `json:"error,omitempty"`
+	Message string     `json:"message,omitempty"`
+	Options []aiOption `json:"options,omitempty"`
+}
+
+type aiOption struct {
+	Label   string `json:"label"`
+	Command string `json:"command"`
 }
 
 // HandleAI returns a handler for POST /api/ai/translate.
-func HandleAI(client *ai.Client) http.HandlerFunc {
+// It tries the NLP parser first. If NLP returns "ok" or "ambiguous", that result
+// is returned immediately. If NLP fails and fallbackEnabled is true with a
+// configured AI client, the AI model is used as a fallback.
+func HandleAI(parser *nlp.Parser, aiClient *ai.Client, fallbackEnabled bool) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			w.WriteHeader(http.StatusMethodNotAllowed)
 			return
 		}
 
-		if client == nil {
+		if parser == nil && aiClient == nil {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusServiceUnavailable)
 			json.NewEncoder(w).Encode(aiResponse{
@@ -52,9 +63,47 @@ func HandleAI(client *ai.Client) http.HandlerFunc {
 			return
 		}
 
-		log.Infof("[AI] Translating: %q", req.Message)
+		// Try NLP parser first
+		if parser != nil {
+			log.Infof("[NLP] Translating: %q", req.Message)
+			result := parser.Parse(req.Message)
 
-		command, err := client.TranslateCommand(req.Message)
+			if result.Status == "ok" || result.Status == "ambiguous" {
+				log.Infof("[NLP] Result (%s): %q", result.Status, result.Command)
+				resp := aiResponse{
+					Status:  result.Status,
+					Command: result.Command,
+					Message: result.Message,
+				}
+				for _, opt := range result.Options {
+					resp.Options = append(resp.Options, aiOption{
+						Label:   opt.Label,
+						Command: opt.Command,
+					})
+				}
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(resp)
+				return
+			}
+
+			// NLP failed — fall through to AI if enabled
+			log.Infof("[NLP] Parse failed: %s", result.Error)
+		}
+
+		// AI fallback
+		if !fallbackEnabled || aiClient == nil {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			json.NewEncoder(w).Encode(aiResponse{
+				Status: "error",
+				Error:  "could not parse command",
+			})
+			return
+		}
+
+		log.Infof("[AI] Fallback translating: %q", req.Message)
+
+		command, err := aiClient.TranslateCommand(req.Message)
 		if err != nil {
 			log.Errorf("[AI] Translation failed: %s", err)
 			w.Header().Set("Content-Type", "application/json")
@@ -63,7 +112,7 @@ func HandleAI(client *ai.Client) http.HandlerFunc {
 			return
 		}
 
-		log.Infof("[AI] Result: %q", command)
+		log.Infof("[AI] Fallback result: %q", command)
 
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(aiResponse{Status: "ok", Command: command})

--- a/processor/internal/api/ai.go
+++ b/processor/internal/api/ai.go
@@ -1,0 +1,71 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/pokemon/poracleng/processor/internal/ai"
+)
+
+type aiRequest struct {
+	Message string `json:"message"`
+}
+
+type aiResponse struct {
+	Status  string `json:"status"`
+	Command string `json:"command,omitempty"`
+	Error   string `json:"error,omitempty"`
+}
+
+// HandleAI returns a handler for POST /api/ai/translate.
+func HandleAI(client *ai.Client) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+
+		if client == nil {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusServiceUnavailable)
+			json.NewEncoder(w).Encode(aiResponse{
+				Status: "error",
+				Error:  "AI assistant is not configured. Set [ai] enabled=true in config.toml.",
+			})
+			return
+		}
+
+		var req aiRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			json.NewEncoder(w).Encode(aiResponse{Status: "error", Error: "invalid request"})
+			return
+		}
+
+		if req.Message == "" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			json.NewEncoder(w).Encode(aiResponse{Status: "error", Error: "message is required"})
+			return
+		}
+
+		log.Infof("[AI] Translating: %q", req.Message)
+
+		command, err := client.TranslateCommand(req.Message)
+		if err != nil {
+			log.Errorf("[AI] Translation failed: %s", err)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusInternalServerError)
+			json.NewEncoder(w).Encode(aiResponse{Status: "error", Error: err.Error()})
+			return
+		}
+
+		log.Infof("[AI] Result: %q", command)
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(aiResponse{Status: "ok", Command: command})
+	}
+}

--- a/processor/internal/config/config.go
+++ b/processor/internal/config/config.go
@@ -28,8 +28,18 @@ type Config struct {
 	Geocoding      GeocodingConfig      `toml:"geocoding"`
 	Fallbacks      FallbacksConfig      `toml:"fallbacks"`
 
+	AI AIConfig `toml:"ai"`
+
 	// BaseDir is the directory containing the config file, used to resolve relative paths.
 	BaseDir string `toml:"-"`
+}
+
+// AIConfig holds settings for the optional AI command assistant.
+type AIConfig struct {
+	Enabled     bool   `toml:"enabled"`
+	ProviderURL string `toml:"provider_url"` // OpenAI-compatible endpoint (Ollama, OpenRouter, OpenAI, Groq, etc.)
+	APIKey      string `toml:"api_key"`      // empty for local Ollama
+	Model       string `toml:"model"`        // e.g. "qwen2.5:1.5b", "gpt-4o-mini", "qwen/qwen-2.5-7b-instruct"
 }
 
 // GeneralConfig holds settings from the [general] section used by the processor

--- a/processor/internal/config/config.go
+++ b/processor/internal/config/config.go
@@ -37,6 +37,7 @@ type Config struct {
 // AIConfig holds settings for the optional AI command assistant.
 type AIConfig struct {
 	Enabled      bool   `toml:"enabled"`
+	SuggestOnDM  bool   `toml:"suggest_on_dm"`  // suggest commands for unrecognised DMs
 	FallbackToAI bool   `toml:"fallback_to_ai"` // if NLP parser fails, try AI model
 	ProviderURL  string `toml:"provider_url"`    // OpenAI-compatible endpoint (Ollama, OpenRouter, OpenAI, Groq, etc.)
 	APIKey       string `toml:"api_key"`         // empty for local Ollama

--- a/processor/internal/config/config.go
+++ b/processor/internal/config/config.go
@@ -36,10 +36,11 @@ type Config struct {
 
 // AIConfig holds settings for the optional AI command assistant.
 type AIConfig struct {
-	Enabled     bool   `toml:"enabled"`
-	ProviderURL string `toml:"provider_url"` // OpenAI-compatible endpoint (Ollama, OpenRouter, OpenAI, Groq, etc.)
-	APIKey      string `toml:"api_key"`      // empty for local Ollama
-	Model       string `toml:"model"`        // e.g. "qwen2.5:1.5b", "gpt-4o-mini", "qwen/qwen-2.5-7b-instruct"
+	Enabled      bool   `toml:"enabled"`
+	FallbackToAI bool   `toml:"fallback_to_ai"` // if NLP parser fails, try AI model
+	ProviderURL  string `toml:"provider_url"`    // OpenAI-compatible endpoint (Ollama, OpenRouter, OpenAI, Groq, etc.)
+	APIKey       string `toml:"api_key"`         // empty for local Ollama
+	Model        string `toml:"model"`           // e.g. "google/gemma-3-12b-it", "qwen2.5:7b"
 }
 
 // GeneralConfig holds settings from the [general] section used by the processor

--- a/processor/internal/i18n/i18n.go
+++ b/processor/internal/i18n/i18n.go
@@ -63,6 +63,28 @@ func (t *Translator) Lang() string {
 	return t.lang
 }
 
+// Messages returns a copy of all translation keys and values.
+func (t *Translator) Messages() map[string]string {
+	if t == nil || t.messages == nil {
+		return nil
+	}
+	result := make(map[string]string, len(t.messages))
+	for k, v := range t.messages {
+		result[k] = v
+	}
+	return result
+}
+
+// NewTranslator creates a Translator with the given locale and messages.
+// Intended for testing and vocabulary building where a full Bundle is not needed.
+func NewTranslator(lang string, msgs map[string]string) *Translator {
+	m := make(map[string]string, len(msgs))
+	for k, v := range msgs {
+		m[k] = v
+	}
+	return &Translator{lang: lang, messages: m}
+}
+
 // FormatNamed replaces %{name} placeholders in a string with values from a map.
 // Used for gamelocale translations that use named placeholders like %{amount_0}, %{pokemon}.
 func FormatNamed(s string, values map[string]string) string {

--- a/processor/internal/nlp/assemble.go
+++ b/processor/internal/nlp/assemble.go
@@ -1,0 +1,308 @@
+package nlp
+
+import (
+	"fmt"
+	"strings"
+)
+
+// assemble converts a MatchResult into one or more Poracle command strings.
+// Multiple pokemon produce multiple commands (one per pokemon, shared filters).
+func assemble(intent string, isRemove bool, result *MatchResult) []string {
+	switch intent {
+	case "track":
+		return assembleTrack(isRemove, result)
+	case "raid":
+		return assembleRaid(isRemove, result)
+	case "egg":
+		return assembleEgg(isRemove, result)
+	case "invasion":
+		return assembleInvasion(isRemove, result)
+	case "quest":
+		return assembleQuest(isRemove, result)
+	case "lure":
+		return assembleLure(isRemove, result)
+	case "gym":
+		return assembleGym(isRemove, result)
+	case "nest":
+		return assembleNest(isRemove, result)
+	case "fort":
+		return assembleFort(isRemove, result)
+	case "maxbattle":
+		return assembleMaxbattle(isRemove, result)
+	default:
+		return assembleTrack(isRemove, result)
+	}
+}
+
+func assembleTrack(isRemove bool, result *MatchResult) []string {
+	cmd := "!track"
+	if isRemove {
+		cmd = "!untrack"
+	}
+
+	subjects := result.Pokemon
+	if len(subjects) == 0 {
+		subjects = []string{"everything"}
+	}
+
+	filters := joinFilters(result.Forms, result.Filters)
+
+	var commands []string
+	for _, poke := range subjects {
+		parts := []string{cmd, quoteName(poke)}
+		if len(filters) > 0 {
+			parts = append(parts, filters...)
+		}
+		commands = append(commands, strings.Join(parts, " "))
+	}
+	return commands
+}
+
+func assembleRaid(isRemove bool, result *MatchResult) []string {
+	parts := []string{"!raid"}
+	if isRemove {
+		parts = append(parts, "remove")
+	}
+
+	// Pokemon names or "everything"
+	if len(result.Pokemon) > 0 {
+		for _, p := range result.Pokemon {
+			parts = append(parts, quoteName(p))
+		}
+	} else if result.Everything {
+		parts = append(parts, "everything")
+	}
+
+	// Moves become "move:{name}"
+	for _, m := range result.Moves {
+		parts = append(parts, "move:"+strings.ReplaceAll(m, " ", "_"))
+	}
+
+	parts = append(parts, sortFilters(result.Filters)...)
+
+	return []string{strings.Join(parts, " ")}
+}
+
+func assembleEgg(isRemove bool, result *MatchResult) []string {
+	parts := []string{"!egg"}
+	if isRemove {
+		parts = append(parts, "remove")
+	}
+	if result.Everything {
+		parts = append(parts, "everything")
+	}
+	parts = append(parts, result.Filters...)
+	return []string{strings.Join(parts, " ")}
+}
+
+func assembleInvasion(isRemove bool, result *MatchResult) []string {
+	parts := []string{"!invasion"}
+	if isRemove {
+		parts = append(parts, "remove")
+	}
+
+	// Types are the main argument for invasions
+	parts = append(parts, result.Types...)
+
+	// Pokemon names (e.g., kecleon — invasion events passed through)
+	for _, p := range result.Pokemon {
+		parts = append(parts, quoteName(p))
+	}
+
+	parts = append(parts, result.Filters...)
+
+	return []string{strings.Join(parts, " ")}
+}
+
+func assembleQuest(isRemove bool, result *MatchResult) []string {
+	parts := []string{"!quest"}
+	if isRemove {
+		parts = append(parts, "remove")
+	}
+
+	// Items (quoted if multi-word)
+	for _, item := range result.Items {
+		parts = append(parts, quoteItem(item))
+	}
+
+	// Pokemon as quest rewards
+	for _, p := range result.Pokemon {
+		parts = append(parts, quoteName(p))
+	}
+
+	if result.Everything {
+		parts = append(parts, "everything")
+	}
+
+	parts = append(parts, result.Filters...)
+
+	return []string{strings.Join(parts, " ")}
+}
+
+func assembleLure(isRemove bool, result *MatchResult) []string {
+	parts := []string{"!lure"}
+	if isRemove {
+		parts = append(parts, "remove")
+	}
+
+	// Lure type names (from unmatched or types)
+	for _, t := range result.Types {
+		parts = append(parts, t)
+	}
+
+	// Unmatched tokens might be lure type names
+	for _, u := range result.Unmatched {
+		parts = append(parts, u)
+	}
+
+	parts = append(parts, result.Filters...)
+
+	return []string{strings.Join(parts, " ")}
+}
+
+func assembleGym(isRemove bool, result *MatchResult) []string {
+	parts := []string{"!gym"}
+	if isRemove {
+		parts = append(parts, "remove")
+	}
+	if result.Everything {
+		parts = append(parts, "everything")
+	}
+	parts = append(parts, result.Filters...)
+	return []string{strings.Join(parts, " ")}
+}
+
+func assembleNest(isRemove bool, result *MatchResult) []string {
+	parts := []string{"!nest"}
+	if isRemove {
+		parts = append(parts, "remove")
+	}
+
+	// Pokemon names
+	for _, p := range result.Pokemon {
+		parts = append(parts, quoteName(p))
+	}
+
+	// Types are the argument if no pokemon
+	if len(result.Pokemon) == 0 {
+		parts = append(parts, result.Types...)
+	}
+
+	// Only show "everything" if no types or pokemon specified
+	if result.Everything && len(result.Types) == 0 && len(result.Pokemon) == 0 {
+		parts = append(parts, "everything")
+	}
+
+	parts = append(parts, result.Filters...)
+
+	return []string{strings.Join(parts, " ")}
+}
+
+func assembleFort(isRemove bool, result *MatchResult) []string {
+	parts := []string{"!fort"}
+	if isRemove {
+		parts = append(parts, "remove")
+	}
+	if result.Everything {
+		parts = append(parts, "everything")
+	}
+	parts = append(parts, result.Filters...)
+	return []string{strings.Join(parts, " ")}
+}
+
+func assembleMaxbattle(isRemove bool, result *MatchResult) []string {
+	parts := []string{"!maxbattle"}
+	if isRemove {
+		parts = append(parts, "remove")
+	}
+
+	for _, p := range result.Pokemon {
+		parts = append(parts, quoteName(p))
+	}
+
+	// Moves become "move:{name}"
+	for _, m := range result.Moves {
+		parts = append(parts, "move:"+strings.ReplaceAll(m, " ", "_"))
+	}
+
+	if result.Everything {
+		parts = append(parts, "everything")
+	}
+
+	parts = append(parts, result.Filters...)
+
+	return []string{strings.Join(parts, " ")}
+}
+
+// quoteName quotes a name if it contains spaces or punctuation.
+func quoteName(name string) string {
+	if strings.ContainsAny(name, " .'") {
+		return fmt.Sprintf("%q", name)
+	}
+	return name
+}
+
+// quoteItem quotes an item name if it contains spaces.
+func quoteItem(name string) string {
+	if strings.Contains(name, " ") {
+		return fmt.Sprintf("%q", name)
+	}
+	return name
+}
+
+// joinFilters combines form filters and other filters into one slice,
+// with a stable ordering: forms first, then stat filters, then distance, then others.
+func joinFilters(forms []string, filters []string) []string {
+	var out []string
+	out = append(out, forms...)
+	out = append(out, sortFilters(filters)...)
+	return out
+}
+
+// filterPriority returns a sort key for filter ordering.
+// Lower number = earlier in output.
+func filterPriority(f string) int {
+	if strings.HasPrefix(f, "form:") {
+		return 0
+	}
+	if strings.HasPrefix(f, "iv") || strings.HasPrefix(f, "maxiv") {
+		return 1
+	}
+	if strings.HasPrefix(f, "cp") || strings.HasPrefix(f, "maxcp") {
+		return 2
+	}
+	if strings.HasPrefix(f, "level") || strings.HasPrefix(f, "maxlevel") {
+		return 3
+	}
+	if strings.HasPrefix(f, "atk") || strings.HasPrefix(f, "maxatk") ||
+		strings.HasPrefix(f, "def") || strings.HasPrefix(f, "maxdef") ||
+		strings.HasPrefix(f, "sta") || strings.HasPrefix(f, "maxsta") {
+		return 4
+	}
+	if strings.HasPrefix(f, "great") || strings.HasPrefix(f, "ultra") || strings.HasPrefix(f, "little") {
+		return 5
+	}
+	if strings.HasPrefix(f, "size:") {
+		return 6
+	}
+	if strings.HasPrefix(f, "d") && len(f) > 1 && f[1] >= '0' && f[1] <= '9' {
+		return 8
+	}
+	return 7 // everything else
+}
+
+// sortFilters returns a copy of filters sorted by priority.
+func sortFilters(filters []string) []string {
+	if len(filters) <= 1 {
+		return filters
+	}
+	out := make([]string, len(filters))
+	copy(out, filters)
+	// Stable insertion sort (small slices)
+	for i := 1; i < len(out); i++ {
+		for j := i; j > 0 && filterPriority(out[j]) < filterPriority(out[j-1]); j-- {
+			out[j], out[j-1] = out[j-1], out[j]
+		}
+	}
+	return out
+}

--- a/processor/internal/nlp/filters.go
+++ b/processor/internal/nlp/filters.go
@@ -1,0 +1,465 @@
+package nlp
+
+import (
+	"fmt"
+	"math"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// contextSynonyms maps natural language phrases to Poracle filter tokens.
+// The outer key is the command intent ("track", "raid", "quest", etc.),
+// and "*" matches any intent. Empty string value means "consume but produce no filter".
+type contextSynonyms map[string]map[string]string
+
+var synonyms = contextSynonyms{
+	"track": {
+		"shiny":       "", // consumed but not filterable for track
+		"shinies":     "",
+		"hundo":       "iv100",
+		"hundos":      "iv100",
+		"hundred":     "iv100",
+		"perfect":     "iv100",
+		"100%":        "iv100",
+		"nundo":       "iv0 maxiv0",
+		"nundos":      "iv0 maxiv0",
+		"zero":        "iv0 maxiv0",
+		"0%":          "iv0 maxiv0",
+		"good ivs":    "iv80",
+		"good iv":     "iv80",
+		"shadow":      "form:shadow",
+		"tiny":        "size:xxs",
+		"xxs":         "size:xxs",
+		"small":       "size:xs",
+		"xs":          "size:xs",
+		"big":         "size:xl",
+		"large":       "size:xl",
+		"xl":          "size:xl",
+		"huge":        "size:xxl",
+		"xxl":         "size:xxl",
+		"male":        "male",
+		"female":      "female",
+		"gmax":        "gmax",
+	},
+	"raid": {
+		"shadow":         "level15",
+		"legendary":      "level5",
+		"mega":           "level6",
+		"mega legendary": "level7",
+		"primal":         "level10",
+		"ultra beast":    "level8",
+		"ex":             "ex",
+		"exclusive":      "ex",
+	},
+	"quest": {
+		"shiny":      "shiny",
+		"shinies":    "shiny",
+		"stardust":   "stardust",
+		"energy":     "energy",
+		"mega energy": "energy",
+		"candy":      "candy",
+	},
+	"maxbattle": {
+		"gmax": "gmax",
+	},
+	"fort": {
+		"new": "new",
+	},
+	"*": {
+		"nearby":     "d1000",
+		"near me":    "d1000",
+		"close":      "d1000",
+		"everything": "everything",
+		"all":        "everything",
+	},
+}
+
+// teamNames maps team aliases to canonical Poracle team names.
+var teamNames = map[string]string{
+	"mystic":   "mystic",
+	"blue":     "mystic",
+	"valor":    "valor",
+	"red":      "valor",
+	"instinct": "instinct",
+	"yellow":   "instinct",
+	"harmony":  "harmony",
+	"gray":     "harmony",
+}
+
+// poracleFilterRe matches tokens already in Poracle filter syntax.
+var poracleFilterRe = regexp.MustCompile(
+	`^(?:` +
+		`iv\d+(?:-\d+)?` +
+		`|cp\d+(?:-\d+)?` +
+		`|level\d+(?:-\d+)?` +
+		`|d\d+` +
+		`|gen\d+` +
+		`|atk\d+|def\d+|sta\d+` +
+		`|maxiv\d+|maxcp\d+|maxlevel\d+|maxatk\d+|maxdef\d+|maxsta\d+` +
+		`|great\d+|ultra\d+|little\d+` +
+		`|weight\d+|maxweight\d+` +
+		`|rarity:\w+|maxrarity:\w+` +
+		`|template:\d+` +
+		`|clean` +
+		`|size:\w+` +
+		`|form:\w+` +
+		`|move:\S+` +
+		`|male|female` +
+		`|gmax` +
+		`|new` +
+		`|ex` +
+		`|shiny` +
+		`|stardust|energy|candy` +
+		`)$`,
+)
+
+// distanceRe matches "1km", "2.5km", "500m", "1.5 km".
+var distanceRe = regexp.MustCompile(`^(\d+(?:\.\d+)?)\s*(km|m)$`)
+
+// pvpLeagues maps league names/abbreviations to Poracle league prefix.
+var pvpLeagues = map[string]string{
+	"great league":  "great",
+	"gl":            "great",
+	"ultra league":  "ultra",
+	"ul":            "ultra",
+	"little league": "little",
+	"ll":            "little",
+}
+
+// statWords are words that combine with a following number into a filter.
+// "level 5" → "level5", "iv 95" → "iv95", etc.
+var statWords = map[string]bool{
+	"level": true, "iv": true, "cp": true,
+	"atk": true, "def": true, "sta": true,
+}
+
+// betweenPattern matches "between X Y stat" in token sequences
+// (note: "and" is a noise word and gets stripped by normalize).
+var betweenPattern = regexp.MustCompile(`between\s+(\d+)\s+(\d+)\s+(iv|cp|level|atk|def|sta)`)
+
+// FilterResult holds the outcome of applying filter matching to a token sequence.
+type FilterResult struct {
+	Filters    []string
+	Everything bool
+	Consumed   map[int]bool // indices of consumed tokens
+}
+
+// matchFilters processes tokens and extracts filter expressions.
+// It handles context-aware synonyms, distance parsing, PVP, "between X and Y",
+// team names, stat+number combining, and Poracle pass-through syntax.
+func matchFilters(tokens []string, intent string) *FilterResult {
+	result := &FilterResult{
+		Consumed: make(map[int]bool),
+	}
+
+	joined := strings.Join(tokens, " ")
+
+	// --- "between X Y stat" pattern (before other matching) ---
+	if m := betweenPattern.FindStringSubmatch(joined); m != nil {
+		lo, _ := strconv.Atoi(m[1])
+		hi, _ := strconv.Atoi(m[2])
+		stat := m[3]
+		if lo > hi {
+			lo, hi = hi, lo
+		}
+		result.Filters = append(result.Filters, fmt.Sprintf("%s%d-%d", stat, lo, hi))
+		for i, t := range tokens {
+			if t == "between" || t == m[1] || t == m[2] || t == m[3] {
+				result.Consumed[i] = true
+			}
+		}
+		return result
+	}
+
+	// --- Multi-word synonym matching (longest first) ---
+	for _, ctx := range []string{intent, "*"} {
+		synMap, ok := synonyms[ctx]
+		if !ok {
+			continue
+		}
+		// Collect and sort multi-word phrases longest first
+		var multiPhrases []string
+		for phrase := range synMap {
+			if strings.Contains(phrase, " ") {
+				multiPhrases = append(multiPhrases, phrase)
+			}
+		}
+		sortByLengthDesc(multiPhrases)
+
+		for _, phrase := range multiPhrases {
+			// Skip if all tokens of this phrase are already consumed
+			if allTokensConsumed(tokens, phrase, result) {
+				continue
+			}
+			if idx := strings.Index(joined, phrase); idx >= 0 {
+				markMultiWordConsumed(tokens, phrase, result)
+				replacement := synMap[phrase]
+				if replacement == "everything" {
+					result.Everything = true
+				} else if replacement != "" {
+					result.Filters = append(result.Filters, strings.Fields(replacement)...)
+				}
+			}
+		}
+	}
+
+	// --- PVP matching (multi-token) ---
+	matchPVP(tokens, intent, result)
+
+	// --- Stat word + number combining: "level 5" → "level5" ---
+	for i := 0; i < len(tokens)-1; i++ {
+		if result.Consumed[i] || result.Consumed[i+1] {
+			continue
+		}
+		if statWords[tokens[i]] {
+			if _, err := strconv.Atoi(tokens[i+1]); err == nil {
+				combined := tokens[i] + tokens[i+1]
+				if poracleFilterRe.MatchString(combined) {
+					result.Filters = append(result.Filters, combined)
+					result.Consumed[i] = true
+					result.Consumed[i+1] = true
+				}
+			}
+		}
+	}
+
+	// --- Distance parsing (multi-token: "1.5 km") ---
+	for i := 0; i < len(tokens)-1; i++ {
+		if result.Consumed[i] || result.Consumed[i+1] {
+			continue
+		}
+		combined := tokens[i] + tokens[i+1]
+		if d := parseDistance(combined); d != "" {
+			result.Filters = append(result.Filters, d)
+			result.Consumed[i] = true
+			result.Consumed[i+1] = true
+		}
+	}
+
+	// --- Single-token matching ---
+	for i, t := range tokens {
+		if result.Consumed[i] {
+			continue
+		}
+
+		// Distance with unit attached: "1km", "500m"
+		if d := parseDistance(t); d != "" {
+			result.Filters = append(result.Filters, d)
+			result.Consumed[i] = true
+			continue
+		}
+
+		// Context-specific single-word synonyms FIRST (before passthrough).
+		// This ensures e.g. "shiny" in track context is consumed as empty
+		// rather than passed through as a filter.
+		if hasSynonym(t, intent) {
+			syn := lookupSynonym(t, intent)
+			if syn == "everything" {
+				result.Everything = true
+			} else if syn != "" {
+				result.Filters = append(result.Filters, strings.Fields(syn)...)
+			}
+			result.Consumed[i] = true
+			continue
+		}
+
+		// Wildcard single-word synonyms
+		if hasSynonym(t, "*") {
+			syn := lookupSynonym(t, "*")
+			if syn == "everything" {
+				result.Everything = true
+			} else if syn != "" {
+				result.Filters = append(result.Filters, strings.Fields(syn)...)
+			}
+			result.Consumed[i] = true
+			continue
+		}
+
+		// Poracle pass-through syntax
+		if poracleFilterRe.MatchString(t) {
+			if t == "everything" {
+				result.Everything = true
+			} else {
+				result.Filters = append(result.Filters, t)
+			}
+			result.Consumed[i] = true
+			continue
+		}
+
+		// Team names (all contexts)
+		if team, ok := teamNames[t]; ok {
+			result.Filters = append(result.Filters, team)
+			result.Consumed[i] = true
+			continue
+		}
+	}
+
+	return result
+}
+
+// hasSynonym checks if a token exists as a key in the synonym map for the given context.
+func hasSynonym(token, ctx string) bool {
+	synMap, ok := synonyms[ctx]
+	if !ok {
+		return false
+	}
+	_, exists := synMap[token]
+	return exists
+}
+
+// lookupSynonym returns the replacement for a synonym, or "".
+func lookupSynonym(token, ctx string) string {
+	synMap, ok := synonyms[ctx]
+	if !ok {
+		return ""
+	}
+	return synMap[token]
+}
+
+// parseDistance converts distance expressions to Poracle "d{meters}" format.
+func parseDistance(s string) string {
+	m := distanceRe.FindStringSubmatch(s)
+	if m == nil {
+		return ""
+	}
+	val, err := strconv.ParseFloat(m[1], 64)
+	if err != nil {
+		return ""
+	}
+	unit := m[2]
+	if unit == "km" {
+		val *= 1000
+	}
+	meters := int(math.Round(val))
+	return fmt.Sprintf("d%d", meters)
+}
+
+// matchPVP handles PVP-related token sequences.
+func matchPVP(tokens []string, intent string, result *FilterResult) {
+	if intent != "track" {
+		return
+	}
+
+	joined := strings.Join(tokens, " ")
+
+	// Detect league (multi-word first)
+	league := ""
+	for phrase, lg := range pvpLeagues {
+		if strings.Contains(phrase, " ") {
+			if idx := strings.Index(joined, phrase); idx >= 0 {
+				league = lg
+				markMultiWordConsumed(tokens, phrase, result)
+				break
+			}
+		}
+	}
+	// Single-word league abbreviations
+	if league == "" {
+		for i, t := range tokens {
+			if result.Consumed[i] {
+				continue
+			}
+			if lg, ok := pvpLeagues[t]; ok {
+				league = lg
+				result.Consumed[i] = true
+				break
+			}
+		}
+	}
+
+	// Detect rank/top N
+	rank := 0
+	for i, t := range tokens {
+		if result.Consumed[i] {
+			continue
+		}
+		if (t == "rank" || t == "top") && i+1 < len(tokens) {
+			if n, err := strconv.Atoi(tokens[i+1]); err == nil && n > 0 {
+				rank = n
+				result.Consumed[i] = true
+				result.Consumed[i+1] = true
+				break
+			}
+		}
+	}
+
+	// Detect bare "pvp" or "good pvp"
+	hasPVPWord := false
+	for i, t := range tokens {
+		if result.Consumed[i] {
+			continue
+		}
+		if t == "pvp" {
+			hasPVPWord = true
+			result.Consumed[i] = true
+			// Also consume "good" before pvp
+			if i > 0 && tokens[i-1] == "good" && !result.Consumed[i-1] {
+				result.Consumed[i-1] = true
+			}
+			break
+		}
+	}
+
+	// Build PVP filter
+	if league != "" || rank > 0 || hasPVPWord {
+		if league == "" {
+			league = "great"
+		}
+		if rank == 0 {
+			rank = 5
+		}
+		result.Filters = append(result.Filters, fmt.Sprintf("%s%d", league, rank))
+	}
+}
+
+// sortByLengthDesc sorts strings by length descending.
+func sortByLengthDesc(ss []string) {
+	for i := 1; i < len(ss); i++ {
+		for j := i; j > 0 && len(ss[j]) > len(ss[j-1]); j-- {
+			ss[j], ss[j-1] = ss[j-1], ss[j]
+		}
+	}
+}
+
+// allTokensConsumed checks if all tokens that would match a phrase are already consumed.
+func allTokensConsumed(tokens []string, phrase string, result *FilterResult) bool {
+	words := strings.Fields(phrase)
+	for _, w := range words {
+		foundUnconsumed := false
+		for i, t := range tokens {
+			if t == w && !result.Consumed[i] {
+				foundUnconsumed = true
+				break
+			}
+		}
+		if !foundUnconsumed {
+			return true
+		}
+	}
+	return false
+}
+
+// markMultiWordConsumed marks token indices that form a multi-word phrase.
+func markMultiWordConsumed(tokens []string, phrase string, result *FilterResult) {
+	words := strings.Fields(phrase)
+	joined := strings.Join(tokens, " ")
+	idx := strings.Index(joined, phrase)
+	if idx < 0 {
+		return
+	}
+
+	pos := 0
+	for i, t := range tokens {
+		end := pos + len(t)
+		if pos >= idx && end <= idx+len(phrase) {
+			for _, w := range words {
+				if t == w {
+					result.Consumed[i] = true
+					break
+				}
+			}
+		}
+		pos = end + 1
+	}
+}

--- a/processor/internal/nlp/filters_test.go
+++ b/processor/internal/nlp/filters_test.go
@@ -1,0 +1,173 @@
+package nlp
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseDistance(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"1km", "d1000"},
+		{"2.5km", "d2500"},
+		{"500m", "d500"},
+		{"1.5km", "d1500"},
+		{"0.5km", "d500"},
+		{"3m", "d3"},
+		{"notadistance", ""},
+		{"km", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := parseDistance(tt.input)
+			if got != tt.want {
+				t.Errorf("parseDistance(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMatchFiltersSynonyms(t *testing.T) {
+	tests := []struct {
+		name    string
+		tokens  []string
+		intent  string
+		wantAny string // at least one filter should contain this
+	}{
+		{"hundo track", []string{"hundo"}, "track", "iv100"},
+		{"perfect track", []string{"perfect"}, "track", "iv100"},
+		{"100% track", []string{"100%"}, "track", "iv100"},
+		{"nundo track", []string{"nundo"}, "track", "iv0"},
+		{"good ivs track", []string{"good", "ivs"}, "track", "iv80"},
+		{"shadow track", []string{"shadow"}, "track", "form:shadow"},
+		{"shadow raid", []string{"shadow"}, "raid", "level15"},
+		{"legendary raid", []string{"legendary"}, "raid", "level5"},
+		{"mega raid", []string{"mega"}, "raid", "level6"},
+		{"nearby any", []string{"nearby"}, "track", "d1000"},
+		{"xxl track", []string{"xxl"}, "track", "size:xxl"},
+		{"shiny quest", []string{"shiny"}, "quest", "shiny"},
+		{"stardust quest", []string{"stardust"}, "quest", "stardust"},
+		{"energy quest", []string{"energy"}, "quest", "energy"},
+		{"candy quest", []string{"candy"}, "quest", "candy"},
+		{"new fort", []string{"new"}, "fort", "new"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := matchFilters(tt.tokens, tt.intent)
+			found := false
+			for _, f := range r.Filters {
+				if f == tt.wantAny {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("matchFilters(%v, %q) filters=%v, want to contain %q", tt.tokens, tt.intent, r.Filters, tt.wantAny)
+			}
+		})
+	}
+}
+
+func TestMatchFiltersEverything(t *testing.T) {
+	r := matchFilters([]string{"everything"}, "track")
+	if !r.Everything {
+		t.Error("expected Everything=true for 'everything'")
+	}
+	r = matchFilters([]string{"all"}, "track")
+	if !r.Everything {
+		t.Error("expected Everything=true for 'all'")
+	}
+}
+
+func TestMatchFiltersTeams(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"mystic", "mystic"},
+		{"blue", "mystic"},
+		{"valor", "valor"},
+		{"red", "valor"},
+		{"instinct", "instinct"},
+		{"yellow", "instinct"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			r := matchFilters([]string{tt.input}, "gym")
+			if len(r.Filters) == 0 || r.Filters[0] != tt.want {
+				t.Errorf("matchFilters([%q], gym) = %v, want [%q]", tt.input, r.Filters, tt.want)
+			}
+		})
+	}
+}
+
+func TestMatchFiltersPVP(t *testing.T) {
+	tests := []struct {
+		name   string
+		tokens []string
+		want   string
+	}{
+		{"pvp alone", []string{"pvp"}, "great5"},
+		{"good pvp", []string{"good", "pvp"}, "great5"},
+		{"great league", []string{"great", "league"}, "great5"},
+		{"ultra league rank 1", []string{"ultra", "league", "rank", "1"}, "ultra1"},
+		{"rank 1 great league", []string{"rank", "1", "great", "league"}, "great1"},
+		{"rank 10", []string{"rank", "10"}, "great10"},
+		{"top 5", []string{"top", "5"}, "great5"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := matchFilters(tt.tokens, "track")
+			found := false
+			for _, f := range r.Filters {
+				if f == tt.want {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("matchFilters(%v, track) = %v, want to contain %q", tt.tokens, r.Filters, tt.want)
+			}
+		})
+	}
+}
+
+func TestMatchFiltersBetween(t *testing.T) {
+	r := matchFilters([]string{"between", "95", "99", "iv"}, "track")
+	found := false
+	for _, f := range r.Filters {
+		if f == "iv95-99" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("matchFilters(between 95 99 iv) = %v, want iv95-99", r.Filters)
+	}
+}
+
+func TestMatchFiltersPassthrough(t *testing.T) {
+	passthroughs := []string{"iv100", "cp2500", "level35", "d500", "gen1", "great1", "ultra5", "clean", "template:2"}
+	for _, pt := range passthroughs {
+		t.Run(pt, func(t *testing.T) {
+			r := matchFilters([]string{pt}, "track")
+			if len(r.Filters) == 0 || !strings.Contains(strings.Join(r.Filters, " "), pt) {
+				t.Errorf("expected passthrough for %q, got %v", pt, r.Filters)
+			}
+		})
+	}
+}
+
+func TestMatchFiltersShinyIgnoredInTrack(t *testing.T) {
+	r := matchFilters([]string{"shiny"}, "track")
+	// "shiny" in track context should be consumed but produce no filter
+	if !r.Consumed[0] {
+		t.Error("shiny should be consumed in track context")
+	}
+	for _, f := range r.Filters {
+		if f == "shiny" {
+			t.Error("shiny should be ignored in track context but was added to filters")
+		}
+	}
+}

--- a/processor/internal/nlp/intent.go
+++ b/processor/internal/nlp/intent.go
@@ -1,0 +1,163 @@
+package nlp
+
+import "strings"
+
+// IntentResult holds the output of intent detection.
+type IntentResult struct {
+	CommandType string
+	IsRemove    bool
+	Remaining   string
+}
+
+// removeKeywords trigger removal mode.
+var removeKeywords = []string{
+	"stop tracking", // multi-word first
+	"get rid of",
+	"remove",
+	"delete",
+	"untrack",
+	"cancel",
+	"disable",
+}
+
+// intentKeywords maps single tokens to command types (first match wins in scan order).
+// Order matters: we iterate intentKeywordOrder for priority.
+var intentKeywords = map[string]string{
+	"raid":       "raid",
+	"raids":      "raid",
+	"egg":        "egg",
+	"eggs":       "egg",
+	"quest":      "quest",
+	"quests":     "quest",
+	"research":   "quest",
+	"task":       "quest",
+	"tasks":      "quest",
+	"invasion":   "invasion",
+	"invasions":  "invasion",
+	"rocket":     "invasion",
+	"grunt":      "invasion",
+	"grunts":     "invasion",
+	"lure":       "lure",
+	"lures":      "lure",
+	"nest":       "nest",
+	"nests":      "nest",
+	"nesting":    "nest",
+	"gym":        "gym",
+	"gyms":       "gym",
+	"pokestop":   "fort",
+	"pokestops":  "fort",
+	"fort":       "fort",
+	"maxbattle":  "maxbattle",
+	"dynamax":    "maxbattle",
+	"gigantamax": "maxbattle",
+	"battles":    "", // consumed as noise when near maxbattle keywords
+}
+
+// DetectIntent determines the command type, removal flag, and remaining tokens
+// from normalized input. invasionEvents is a set of known invasion event names
+// (e.g. "kecleon", "showcase", "gold-stop") that force intent to "invasion".
+func DetectIntent(normalized string, invasionEvents map[string]bool) IntentResult {
+	tokens := strings.Fields(normalized)
+	result := IntentResult{CommandType: "track"}
+
+	// --- Pre-scan: check for invasion event names ---
+	hasInvasionEvent := false
+	for _, t := range tokens {
+		if invasionEvents[t] {
+			hasInvasionEvent = true
+			break
+		}
+	}
+	if hasInvasionEvent {
+		result.CommandType = "invasion"
+		// Remove intent keywords but keep the event name.
+		tokens = removeIntentKeywords(tokens, invasionEvents)
+		result.Remaining = strings.Join(tokens, " ")
+		return result
+	}
+
+	// --- Remove detection (multi-word phrases first, then single words) ---
+	joined := strings.Join(tokens, " ")
+	for _, kw := range removeKeywords {
+		if idx := strings.Index(joined, kw); idx >= 0 {
+			result.IsRemove = true
+			joined = joined[:idx] + joined[idx+len(kw):]
+			joined = collapseSpaces(joined)
+			break
+		}
+	}
+	tokens = strings.Fields(joined)
+
+	// --- Multi-word intent: "max battle" ---
+	tokens = detectMultiWordIntent(tokens, &result)
+
+	// --- Implicit filter injection for gigantamax ---
+	injectGigantamax := false
+
+	// --- Single-token intent detection (first match wins) ---
+	if result.CommandType == "track" {
+		filtered := make([]string, 0, len(tokens))
+		found := false
+		for _, t := range tokens {
+			if !found {
+				if cmd, ok := intentKeywords[t]; ok && cmd != "" {
+					result.CommandType = cmd
+					found = true
+					if t == "gigantamax" {
+						injectGigantamax = true
+					}
+					continue // consume the keyword
+				}
+			}
+			filtered = append(filtered, t)
+		}
+		tokens = filtered
+	}
+
+	// When intent is maxbattle, consume "battles" noise token.
+	if result.CommandType == "maxbattle" {
+		filtered := make([]string, 0, len(tokens))
+		for _, t := range tokens {
+			if t == "battles" || t == "battle" {
+				continue
+			}
+			filtered = append(filtered, t)
+		}
+		tokens = filtered
+	}
+
+	if injectGigantamax {
+		tokens = append(tokens, "level7")
+	}
+
+	result.Remaining = strings.Join(tokens, " ")
+	return result
+}
+
+// removeIntentKeywords removes any token that is an intent keyword but not an invasion event.
+func removeIntentKeywords(tokens []string, invasionEvents map[string]bool) []string {
+	filtered := make([]string, 0, len(tokens))
+	for _, t := range tokens {
+		if invasionEvents[t] {
+			filtered = append(filtered, t)
+			continue
+		}
+		if _, isIntent := intentKeywords[t]; isIntent {
+			continue
+		}
+		filtered = append(filtered, t)
+	}
+	return filtered
+}
+
+// detectMultiWordIntent handles "max battle" → "maxbattle".
+func detectMultiWordIntent(tokens []string, result *IntentResult) []string {
+	for i := 0; i < len(tokens)-1; i++ {
+		if tokens[i] == "max" && tokens[i+1] == "battle" {
+			result.CommandType = "maxbattle"
+			// Remove both tokens.
+			return append(tokens[:i], tokens[i+2:]...)
+		}
+	}
+	return tokens
+}

--- a/processor/internal/nlp/intent.go
+++ b/processor/internal/nlp/intent.go
@@ -88,7 +88,7 @@ func DetectIntent(normalized string, invasionEvents map[string]bool) IntentResul
 	}
 	tokens = strings.Fields(joined)
 
-	// --- Multi-word intent: "max battle" ---
+	// --- Multi-word intent: "max battle", "raid egg(s)" ---
 	tokens = detectMultiWordIntent(tokens, &result)
 
 	// --- Implicit filter injection for gigantamax ---
@@ -150,12 +150,17 @@ func removeIntentKeywords(tokens []string, invasionEvents map[string]bool) []str
 	return filtered
 }
 
-// detectMultiWordIntent handles "max battle" → "maxbattle".
+// detectMultiWordIntent handles compound intent phrases:
+// "max battle" → "maxbattle", "raid egg(s)" → "egg".
 func detectMultiWordIntent(tokens []string, result *IntentResult) []string {
 	for i := 0; i < len(tokens)-1; i++ {
 		if tokens[i] == "max" && tokens[i+1] == "battle" {
 			result.CommandType = "maxbattle"
-			// Remove both tokens.
+			return append(tokens[:i], tokens[i+2:]...)
+		}
+		// "raid egg" / "raid eggs" → egg intent (consume both tokens)
+		if tokens[i] == "raid" && (tokens[i+1] == "egg" || tokens[i+1] == "eggs") {
+			result.CommandType = "egg"
 			return append(tokens[:i], tokens[i+2:]...)
 		}
 	}

--- a/processor/internal/nlp/intent_test.go
+++ b/processor/internal/nlp/intent_test.go
@@ -1,0 +1,57 @@
+package nlp
+
+import "testing"
+
+func TestDetectIntent(t *testing.T) {
+	invasionEvents := map[string]bool{
+		"kecleon":   true,
+		"showcase":  true,
+		"gold-stop": true,
+	}
+
+	tests := []struct {
+		input   string
+		wantCmd string
+		wantRm  bool
+		wantRst string
+	}{
+		{"level 5 raids nearby", "raid", false, "level 5 nearby"},
+		{"pikachu iv100", "track", false, "pikachu iv100"},
+		{"stop tracking dragonite", "track", true, "dragonite"},
+		{"remove raids", "raid", true, ""},
+		{"kecleon pokestop", "invasion", false, "kecleon"},
+		{"showcase", "invasion", false, "showcase"},
+		{"gigantamax battles", "maxbattle", false, "level7"},
+		{"dynamax snorlax", "maxbattle", false, "snorlax"},
+		{"max battle snorlax", "maxbattle", false, "snorlax"},
+		{"quest stardust", "quest", false, "stardust"},
+		{"grunt water", "invasion", false, "water"},
+		// Additional cases
+		{"egg level 3", "egg", false, "level 3"},
+		{"lure glacial", "lure", false, "glacial"},
+		{"nesting pikachu", "nest", false, "pikachu"},
+		{"gym team valor", "gym", false, "team valor"},
+		{"pokestop changes", "fort", false, "changes"},
+		{"delete quest stardust", "quest", true, "stardust"},
+		{"untrack pikachu", "track", true, "pikachu"},
+		{"research stardust", "quest", false, "stardust"},
+		{"rocket leader", "invasion", false, "leader"},
+		{"gold-stop nearby", "invasion", false, "gold-stop nearby"},
+		{"kecleon invasion nearby", "invasion", false, "kecleon nearby"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := DetectIntent(tt.input, invasionEvents)
+			if got.CommandType != tt.wantCmd {
+				t.Errorf("DetectIntent(%q).CommandType = %q, want %q", tt.input, got.CommandType, tt.wantCmd)
+			}
+			if got.IsRemove != tt.wantRm {
+				t.Errorf("DetectIntent(%q).IsRemove = %v, want %v", tt.input, got.IsRemove, tt.wantRm)
+			}
+			if got.Remaining != tt.wantRst {
+				t.Errorf("DetectIntent(%q).Remaining = %q, want %q", tt.input, got.Remaining, tt.wantRst)
+			}
+		})
+	}
+}

--- a/processor/internal/nlp/match.go
+++ b/processor/internal/nlp/match.go
@@ -30,11 +30,12 @@ func matchTokens(input string, intent string, vocabs *Vocabularies, invasionEven
 	remaining := input
 
 	// --- Phase 1: Multi-word matching (longest first) ---
-	// Try multi-word pokemon names
-	for _, name := range vocabs.Pokemon.MultiWordNames() {
-		if idx := findPhrase(remaining, name); idx >= 0 {
-			result.Pokemon = append(result.Pokemon, name)
-			remaining = removePhrase(remaining, idx, len(name))
+	// Try multi-word pokemon names (includes fuzzy variants like "mr mime" → "mr. mime")
+	for _, variant := range vocabs.Pokemon.MultiWordNames() {
+		if idx := findPhrase(remaining, variant); idx >= 0 {
+			canonical := vocabs.Pokemon.multiMap[variant]
+			result.Pokemon = append(result.Pokemon, canonical)
+			remaining = removePhrase(remaining, idx, len(variant))
 		}
 	}
 

--- a/processor/internal/nlp/match.go
+++ b/processor/internal/nlp/match.go
@@ -1,0 +1,167 @@
+package nlp
+
+import (
+	"strings"
+)
+
+// MatchResult holds the outcome of greedy multi-word token matching.
+type MatchResult struct {
+	Pokemon    []string // canonical pokemon names
+	Forms      []string // "form:alolan", etc.
+	Types      []string // type names (for invasion/nest)
+	Items      []string // item names (for quest)
+	Moves      []string // move names (for raid/maxbattle)
+	Filters    []string // iv100, d1000, level5, great5, male, size:xxl, etc.
+	Everything bool
+	Unmatched  []string
+}
+
+// matchTokens performs greedy multi-word token matching against vocabularies
+// and filter patterns. Multi-word matches are tried first (longest first),
+// then remaining single tokens are classified.
+// invasionEvents is optional; if non-nil, tokens matching invasion event names
+// are treated as Pokemon (passed through as-is in invasion commands).
+func matchTokens(input string, intent string, vocabs *Vocabularies, invasionEvents map[string]bool) *MatchResult {
+	result := &MatchResult{}
+	if input == "" {
+		return result
+	}
+
+	remaining := input
+
+	// --- Phase 1: Multi-word matching (longest first) ---
+	// Try multi-word pokemon names
+	for _, name := range vocabs.Pokemon.MultiWordNames() {
+		if idx := findPhrase(remaining, name); idx >= 0 {
+			result.Pokemon = append(result.Pokemon, name)
+			remaining = removePhrase(remaining, idx, len(name))
+		}
+	}
+
+	// Try multi-word item names (quest context)
+	if intent == "quest" {
+		for _, name := range vocabs.Items.MultiWordNames() {
+			if idx := findPhrase(remaining, name); idx >= 0 {
+				result.Items = append(result.Items, name)
+				remaining = removePhrase(remaining, idx, len(name))
+			}
+		}
+	}
+
+	// Try multi-word move names (raid/maxbattle context)
+	if intent == "raid" || intent == "maxbattle" {
+		for _, name := range vocabs.Moves.MultiWordNames() {
+			if idx := findPhrase(remaining, name); idx >= 0 {
+				result.Moves = append(result.Moves, name)
+				remaining = removePhrase(remaining, idx, len(name))
+			}
+		}
+	}
+
+	// --- Phase 2: Apply filter matching on remaining tokens ---
+	tokens := strings.Fields(remaining)
+	if len(tokens) == 0 {
+		return result
+	}
+
+	filterResult := matchFilters(tokens, intent)
+	result.Filters = filterResult.Filters
+	result.Everything = filterResult.Everything
+
+	// --- Phase 3: Classify unconsumed tokens ---
+	for i, t := range tokens {
+		if filterResult.Consumed[i] {
+			continue
+		}
+
+		// Invasion event names (e.g., kecleon, showcase)
+		if invasionEvents != nil && invasionEvents[t] {
+			result.Pokemon = append(result.Pokemon, t)
+			continue
+		}
+
+		// Pokemon lookup
+		if name := vocabs.Pokemon.Lookup(t); name != "" {
+			result.Pokemon = append(result.Pokemon, name)
+			continue
+		}
+
+		// Form lookup
+		if f := vocabs.Forms.Lookup(t); f != "" {
+			// In raid context, "shadow" is handled as a filter synonym
+			if intent == "raid" && t == "shadow" {
+				// Already handled by filter synonyms
+			} else {
+				result.Forms = append(result.Forms, f)
+				continue
+			}
+		}
+
+		// Type lookup (invasion/nest context)
+		if intent == "invasion" || intent == "nest" {
+			if typeName := vocabs.Types.Lookup(t); typeName != "" {
+				result.Types = append(result.Types, typeName)
+				continue
+			}
+		}
+
+		// Single-word item lookup (quest context)
+		if intent == "quest" {
+			if itemName := vocabs.Items.Lookup(t); itemName != "" {
+				result.Items = append(result.Items, itemName)
+				continue
+			}
+		}
+
+		// Single-word move lookup (raid/maxbattle context)
+		if intent == "raid" || intent == "maxbattle" {
+			if moveName := vocabs.Moves.Lookup(t); moveName != "" {
+				result.Moves = append(result.Moves, moveName)
+				continue
+			}
+		}
+
+		// Skip common generic nouns that are semantic noise
+		if isGenericNoun(t) {
+			continue
+		}
+
+		// Unmatched
+		result.Unmatched = append(result.Unmatched, t)
+	}
+
+	return result
+}
+
+// isGenericNoun returns true for words that carry no command information.
+func isGenericNoun(t string) bool {
+	switch t {
+	case "pokemon", "type", "added", "taken", "pokestops",
+		"anything", "within":
+		return true
+	}
+	return false
+}
+
+// findPhrase finds a phrase as whole words within text, returning the byte index or -1.
+func findPhrase(text, phrase string) int {
+	idx := strings.Index(text, phrase)
+	if idx < 0 {
+		return -1
+	}
+	// Verify word boundaries
+	if idx > 0 && text[idx-1] != ' ' {
+		return -1
+	}
+	end := idx + len(phrase)
+	if end < len(text) && text[end] != ' ' {
+		return -1
+	}
+	return idx
+}
+
+// removePhrase removes a substring at the given position and cleans up whitespace.
+func removePhrase(text string, idx, length int) string {
+	result := text[:idx] + text[idx+length:]
+	return collapseSpaces(result)
+}

--- a/processor/internal/nlp/normalize.go
+++ b/processor/internal/nlp/normalize.go
@@ -1,0 +1,78 @@
+package nlp
+
+import (
+	"strings"
+)
+
+// fillerPrefixes are stripped from the beginning of input (longest first).
+var fillerPrefixes = []string{
+	"notify me about",
+	"let me know about",
+	"alert me when",
+	"alert me about",
+	"tell me about",
+	"can you please",
+	"looking for",
+	"can you",
+	"find me",
+	"get me",
+	"show me",
+	"i'd like",
+	"i want",
+	"please",
+	"track",
+}
+
+// noiseWords are removed from anywhere in the token list.
+var noiseWords = map[string]bool{
+	"and": true, "or": true, "&": true, "for": true, "with": true,
+	"the": true, "a": true, "an": true, "some": true, "any": true,
+	"of": true, "about": true, "when": true, "that": true, "are": true,
+	"is": true, "there": true, "to": true, "me": true, "my": true,
+	"on": true, "in": true, "it": true, "its": true, "by": true,
+}
+
+// Normalize lowercases the input, strips filler prefixes and noise words,
+// replaces commas with spaces, and collapses whitespace.
+func Normalize(input string) string {
+	s := strings.ToLower(input)
+	s = strings.ReplaceAll(s, ",", " ")
+	s = collapseSpaces(s)
+
+	// Strip filler prefixes (longest first).
+	for _, prefix := range fillerPrefixes {
+		if strings.HasPrefix(s, prefix) {
+			s = strings.TrimPrefix(s, prefix)
+			s = strings.TrimSpace(s)
+			break
+		}
+	}
+
+	// Remove noise words.
+	tokens := strings.Fields(s)
+	filtered := tokens[:0]
+	for _, t := range tokens {
+		if !noiseWords[t] {
+			filtered = append(filtered, t)
+		}
+	}
+
+	return strings.Join(filtered, " ")
+}
+
+func collapseSpaces(s string) string {
+	var b strings.Builder
+	prev := false
+	for _, r := range s {
+		if r == ' ' || r == '\t' {
+			if !prev {
+				b.WriteByte(' ')
+			}
+			prev = true
+		} else {
+			b.WriteRune(r)
+			prev = false
+		}
+	}
+	return strings.TrimSpace(b.String())
+}

--- a/processor/internal/nlp/normalize_test.go
+++ b/processor/internal/nlp/normalize_test.go
@@ -1,0 +1,33 @@
+package nlp
+
+import "testing"
+
+func TestNormalize(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"Track Shiny Pikachu", "shiny pikachu"},
+		{"NOTIFY ME ABOUT perfect dragonite", "perfect dragonite"},
+		{"I want level 5 raids nearby", "level 5 raids nearby"},
+		{"track hundos for pikachu eevee and dragonite", "hundos pikachu eevee dragonite"},
+		{"looking for pikachu with good IVs", "pikachu good ivs"},
+		{"tell me about the legendary raids", "legendary raids"},
+		// Extra edge cases
+		{"", ""},
+		{"pikachu", "pikachu"},
+		{"can you please find pikachu", "find pikachu"},
+		{"track pikachu, eevee, dragonite", "pikachu eevee dragonite"},
+		{"PLEASE   show   me   bulbasaur", "show bulbasaur"},
+		{"a an the", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := Normalize(tt.input)
+			if got != tt.want {
+				t.Errorf("Normalize(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/processor/internal/nlp/parser.go
+++ b/processor/internal/nlp/parser.go
@@ -1,0 +1,89 @@
+package nlp
+
+import (
+	"strings"
+
+	"github.com/pokemon/poracleng/processor/internal/i18n"
+)
+
+// ParseOption represents an alternative command the user might have meant.
+type ParseOption struct {
+	Label   string `json:"label"`
+	Command string `json:"command"`
+}
+
+// ParseResult holds the output of the NLP parser.
+type ParseResult struct {
+	Status  string        `json:"status"`
+	Command string        `json:"command,omitempty"`
+	Error   string        `json:"error,omitempty"`
+	Message string        `json:"message,omitempty"`
+	Options []ParseOption `json:"options,omitempty"`
+}
+
+// Parser is the main NLP parser that converts natural language into Poracle commands.
+type Parser struct {
+	vocabs          *Vocabularies
+	invasionEvents  map[string]bool
+}
+
+// NewParser creates a new Parser from a translator and base directory.
+// invasionEvents is a set of known invasion event names (e.g. "kecleon", "showcase").
+func NewParser(tr *i18n.Translator, baseDir string, invasionEvents map[string]bool) *Parser {
+	vocabs := BuildVocabularies(tr, baseDir)
+	if invasionEvents == nil {
+		invasionEvents = map[string]bool{}
+	}
+	return &Parser{
+		vocabs:         vocabs,
+		invasionEvents: invasionEvents,
+	}
+}
+
+// Parse converts natural language input into Poracle command(s).
+func (p *Parser) Parse(input string) ParseResult {
+	if strings.TrimSpace(input) == "" {
+		return ParseResult{
+			Status: "error",
+			Error:  "empty input",
+		}
+	}
+
+	// Step 1: Normalize
+	normalized := Normalize(input)
+	if normalized == "" {
+		return ParseResult{
+			Status: "error",
+			Error:  "input contains only filler words",
+		}
+	}
+
+	// Step 2: Detect intent
+	intent := DetectIntent(normalized, p.invasionEvents)
+
+	// Step 3: Match tokens
+	matched := matchTokens(intent.Remaining, intent.CommandType, p.vocabs, p.invasionEvents)
+
+	// Step 4: Assemble commands
+	commands := assemble(intent.CommandType, intent.IsRemove, matched)
+
+	if len(commands) == 0 {
+		return ParseResult{
+			Status: "error",
+			Error:  "could not parse command",
+		}
+	}
+
+	return ParseResult{
+		Status:  "ok",
+		Command: strings.Join(commands, "\n"),
+	}
+}
+
+// PokemonCount returns the number of pokemon in the vocabulary.
+func (p *Parser) PokemonCount() int {
+	if p.vocabs == nil || p.vocabs.Pokemon == nil {
+		return 0
+	}
+	return len(p.vocabs.Pokemon.single)
+}

--- a/processor/internal/nlp/parser.go
+++ b/processor/internal/nlp/parser.go
@@ -40,6 +40,26 @@ func NewParser(tr *i18n.Translator, baseDir string, invasionEvents map[string]bo
 	}
 }
 
+// shortcutPhrases maps common natural language phrases to direct commands.
+// Checked before the main NLP pipeline.
+var shortcutPhrases = map[string]string{
+	"stop":                          "!stop",
+	"stop alerts":                   "!stop",
+	"pause":                         "!stop",
+	"pause alerts":                  "!stop",
+	"show me what i'm tracking":     "!tracked",
+	"show me what im tracking":      "!tracked",
+	"show tracking":                 "!tracked",
+	"what am i tracking":            "!tracked",
+	"whats tracked":                 "!tracked",
+	"list tracking":                 "!tracked",
+	"my tracking":                   "!tracked",
+	"tracked":                       "!tracked",
+	"help":                          "!help",
+	"start":                         "!poracle",
+	"register":                      "!poracle",
+}
+
 // Parse converts natural language input into Poracle command(s).
 func (p *Parser) Parse(input string) ParseResult {
 	if strings.TrimSpace(input) == "" {
@@ -47,6 +67,12 @@ func (p *Parser) Parse(input string) ParseResult {
 			Status: "error",
 			Error:  "empty input",
 		}
+	}
+
+	// Check shortcut phrases first
+	lowered := strings.ToLower(strings.TrimSpace(input))
+	if cmd, ok := shortcutPhrases[lowered]; ok {
+		return ParseResult{Status: "ok", Command: cmd}
 	}
 
 	// Step 1: Normalize

--- a/processor/internal/nlp/parser_test.go
+++ b/processor/internal/nlp/parser_test.go
@@ -137,6 +137,13 @@ func TestParserEndToEnd(t *testing.T) {
 
 		// Multiple pokemon
 		{"track hundos for pikachu eevee and dragonite", "!track pikachu iv100\n!track eevee iv100\n!track dragonite iv100"},
+
+		// Multi-word pokemon names (fuzzy matching)
+		{"track mr mime", `!track "mr. mime"`},
+		{"track mr. mime", `!track "mr. mime"`},
+		{"track tapu koko", `!track "tapu koko"`},
+		{"track ho-oh", "!track ho-oh"},
+		{"perfect farfetchd", `!track "farfetch'd" iv100`},
 	}
 
 	for _, tt := range tests {

--- a/processor/internal/nlp/parser_test.go
+++ b/processor/internal/nlp/parser_test.go
@@ -159,6 +159,37 @@ func TestParserEndToEnd(t *testing.T) {
 	}
 }
 
+func TestParserShortcuts(t *testing.T) {
+	p := newTestParser()
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"stop", "!stop"},
+		{"Stop", "!stop"},
+		{"STOP", "!stop"},
+		{"stop alerts", "!stop"},
+		{"pause", "!stop"},
+		{"show me what i'm tracking", "!tracked"},
+		{"what am i tracking", "!tracked"},
+		{"tracked", "!tracked"},
+		{"help", "!help"},
+		{"start", "!poracle"},
+		{"register", "!poracle"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := p.Parse(tt.input)
+			if result.Status != "ok" {
+				t.Fatalf("Parse(%q) status=%q error=%q", tt.input, result.Status, result.Error)
+			}
+			if result.Command != tt.want {
+				t.Errorf("Parse(%q) = %q, want %q", tt.input, result.Command, tt.want)
+			}
+		})
+	}
+}
+
 func TestParserEmptyInput(t *testing.T) {
 	p := newTestParser()
 	result := p.Parse("")

--- a/processor/internal/nlp/parser_test.go
+++ b/processor/internal/nlp/parser_test.go
@@ -1,0 +1,169 @@
+package nlp
+
+import (
+	"testing"
+
+	"github.com/pokemon/poracleng/processor/internal/i18n"
+)
+
+func testParserTranslator() *i18n.Translator {
+	return i18n.NewTranslator("en", map[string]string{
+		// Pokemon
+		"poke_25":  "Pikachu",
+		"poke_149": "Dragonite",
+		"poke_37":  "Vulpix",
+		"poke_133": "Eevee",
+		"poke_1":   "Bulbasaur",
+		"poke_150": "Mewtwo",
+		"poke_143": "Snorlax",
+		"poke_184": "Azumarill",
+		"poke_122": "Mr. Mime",
+		"poke_83":  "Farfetch'd",
+		"poke_250": "Ho-Oh",
+		"poke_785": "Tapu Koko",
+
+		// Types
+		"poke_type_1":  "Normal",
+		"poke_type_2":  "Fighting",
+		"poke_type_3":  "Flying",
+		"poke_type_4":  "Poison",
+		"poke_type_5":  "Ground",
+		"poke_type_6":  "Rock",
+		"poke_type_7":  "Bug",
+		"poke_type_8":  "Ghost",
+		"poke_type_9":  "Steel",
+		"poke_type_10": "Fire",
+		"poke_type_11": "Water",
+		"poke_type_12": "Grass",
+		"poke_type_13": "Electric",
+		"poke_type_14": "Psychic",
+		"poke_type_15": "Ice",
+		"poke_type_16": "Dragon",
+		"poke_type_17": "Dark",
+		"poke_type_18": "Fairy",
+
+		// Forms
+		"form_46": "Alolan",
+		"form_47": "Galarian",
+		"form_99": "Shadow",
+
+		// Items
+		"item_1":    "Poke Ball",
+		"item_701":  "Razz Berry",
+		"item_706":  "Golden Razz Berry",
+		"item_1301": "Rare Candy",
+		"item_100":  "Potion",
+
+		// Moves
+		"move_14":  "Hyper Beam",
+		"move_13":  "Wrap",
+		"move_100": "Shadow Ball",
+		"move_200": "Rock Slide",
+		"move_201": "Psystrike",
+	})
+}
+
+func newTestParser() *Parser {
+	tr := testParserTranslator()
+	invasionEvents := map[string]bool{
+		"kecleon":  true,
+		"showcase": true,
+	}
+	return NewParser(tr, "/nonexistent", invasionEvents)
+}
+
+func TestParserEndToEnd(t *testing.T) {
+	p := newTestParser()
+
+	tests := []struct {
+		input string
+		want  string
+	}{
+		// Basic tracking
+		{"track shiny pikachu", "!track pikachu"},
+		{"perfect dragonite", "!track dragonite iv100"},
+		{"nundo pokemon within 1km", "!track everything iv0 maxiv0 d1000"},
+		{"100% pokemon", "!track everything iv100"},
+		{"pikachu", "!track pikachu"},
+		{"nearby 100%", "!track everything iv100 d1000"},
+		{"XXL pokemon", "!track everything size:xxl"},
+		{"alolan vulpix", "!track vulpix form:alolan"},
+		{"shadow pokemon with good IVs", "!track everything form:shadow iv80"},
+
+		// PVP
+		{"good PVP pikachu for great league", "!track pikachu great5"},
+		{"rank 1 great league anything", "!track everything great1"},
+		{"ultra league rank 1 azumarill", "!track azumarill ultra1"},
+
+		// Raids
+		{"level 5 raids", "!raid level5"},
+		{"mewtwo raids within 2km", "!raid mewtwo d2000"},
+		{"mega raids", "!raid level6"},
+		{"mewtwo raids with psystrike", "!raid mewtwo move:psystrike"},
+
+		// Eggs
+		{"all raid eggs", "!egg everything"},
+
+		// Invasions
+		{"team rocket water female", "!invasion water female"},
+		{"kecleon pokestop", "!invasion kecleon"},
+
+		// Quests
+		{"stardust quests", "!quest stardust"},
+		{"golden razz berry quests", `!quest "golden razz berry"`},
+		{"rare candy quests", `!quest "rare candy"`},
+
+		// Lures
+		{"mossy lure nearby", "!lure mossy d1000"},
+
+		// Gyms
+		{"gym taken by valor", "!gym valor"},
+
+		// Nests
+		{"all fire type nests", "!nest fire"},
+
+		// Removal
+		{"stop tracking dragonite", "!untrack dragonite"},
+		{"remove all raid tracking", "!raid remove everything"},
+
+		// Maxbattle
+		{"gigantamax battles", "!maxbattle level7"},
+
+		// Fort
+		{"new pokestops added", "!fort new"},
+
+		// Between pattern
+		{"pokemon between 95 and 99 IV", "!track everything iv95-99"},
+
+		// Multiple pokemon
+		{"track hundos for pikachu eevee and dragonite", "!track pikachu iv100\n!track eevee iv100\n!track dragonite iv100"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := p.Parse(tt.input)
+			if result.Status != "ok" {
+				t.Fatalf("Parse(%q) status=%q error=%q, want ok", tt.input, result.Status, result.Error)
+			}
+			if result.Command != tt.want {
+				t.Errorf("Parse(%q)\n  got:  %q\n  want: %q", tt.input, result.Command, tt.want)
+			}
+		})
+	}
+}
+
+func TestParserEmptyInput(t *testing.T) {
+	p := newTestParser()
+	result := p.Parse("")
+	if result.Status != "error" {
+		t.Errorf("expected error for empty input, got %q", result.Status)
+	}
+}
+
+func TestParserPokemonCount(t *testing.T) {
+	p := newTestParser()
+	count := p.PokemonCount()
+	if count < 12 {
+		t.Errorf("PokemonCount() = %d, want >= 12", count)
+	}
+}

--- a/processor/internal/nlp/vocabulary.go
+++ b/processor/internal/nlp/vocabulary.go
@@ -1,0 +1,351 @@
+package nlp
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/pokemon/poracleng/processor/internal/i18n"
+)
+
+// PokemonVocab provides fuzzy lookup from user input to canonical pokemon names.
+type PokemonVocab struct {
+	single     map[string]string   // normalized input → canonical lowercase name
+	groups     map[string][]string // group alias → list of canonical names
+	multiWords []string            // multi-word names sorted longest-first
+}
+
+// Lookup returns the canonical lowercase pokemon name for input, or "" if not found.
+func (v *PokemonVocab) Lookup(input string) string {
+	return v.single[strings.ToLower(input)]
+}
+
+// LookupGroup returns multiple canonical names for a group alias, or nil.
+func (v *PokemonVocab) LookupGroup(input string) []string {
+	return v.groups[strings.ToLower(input)]
+}
+
+// MultiWordNames returns multi-word pokemon names sorted longest-first.
+func (v *PokemonVocab) MultiWordNames() []string {
+	return v.multiWords
+}
+
+// TypeVocab maps type name strings to themselves (for membership checks).
+type TypeVocab struct {
+	names map[string]bool
+}
+
+// Lookup returns the type name if known, or "".
+func (v *TypeVocab) Lookup(input string) string {
+	if v.names[strings.ToLower(input)] {
+		return strings.ToLower(input)
+	}
+	return ""
+}
+
+// Names returns all known type names.
+func (v *TypeVocab) Names() []string {
+	out := make([]string, 0, len(v.names))
+	for n := range v.names {
+		out = append(out, n)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// FormVocab maps form names to "form:{name}" identifiers.
+type FormVocab struct {
+	forms map[string]string // lowered name → "form:{name}"
+}
+
+// Lookup returns "form:{name}" for a known form, or "".
+func (v *FormVocab) Lookup(input string) string {
+	return v.forms[strings.ToLower(input)]
+}
+
+// ItemVocab provides lookup for item names.
+type ItemVocab struct {
+	items      map[string]bool // known item names (lowercased)
+	multiWords []string        // multi-word item names sorted longest-first
+}
+
+// Lookup returns the item name if known, or "".
+func (v *ItemVocab) Lookup(input string) string {
+	low := strings.ToLower(input)
+	if v.items[low] {
+		return low
+	}
+	return ""
+}
+
+// MultiWordNames returns multi-word item names sorted longest-first.
+func (v *ItemVocab) MultiWordNames() []string {
+	return v.multiWords
+}
+
+// MoveVocab provides lookup for move names.
+type MoveVocab struct {
+	moves      map[string]bool
+	multiWords []string // multi-word move names sorted longest-first
+}
+
+// Lookup returns the move name if known, or "".
+func (v *MoveVocab) Lookup(input string) string {
+	low := strings.ToLower(input)
+	if v.moves[low] {
+		return low
+	}
+	return ""
+}
+
+// MultiWordNames returns multi-word move names sorted longest-first.
+func (v *MoveVocab) MultiWordNames() []string {
+	return v.multiWords
+}
+
+// Vocabularies holds all vocabulary lookups built from game data and translations.
+type Vocabularies struct {
+	Pokemon *PokemonVocab
+	Types   *TypeVocab
+	Forms   *FormVocab
+	Items   *ItemVocab
+	Moves   *MoveVocab
+}
+
+// BuildVocabularies constructs all vocabularies from the translator and alias files.
+func BuildVocabularies(tr *i18n.Translator, baseDir string) *Vocabularies {
+	msgs := tr.Messages()
+	if msgs == nil {
+		msgs = map[string]string{}
+	}
+
+	return &Vocabularies{
+		Pokemon: buildPokemonVocab(msgs, baseDir),
+		Types:   buildTypeVocab(msgs),
+		Forms:   buildFormVocab(msgs),
+		Items:   buildItemVocab(msgs),
+		Moves:   buildMoveVocab(msgs),
+	}
+}
+
+// stripPunctuation removes . ' ' characters and replaces - with space, then lowercases.
+func stripPunctuation(s string) string {
+	s = strings.ToLower(s)
+	s = strings.ReplaceAll(s, "-", " ")
+	s = strings.ReplaceAll(s, ".", "")
+	s = strings.ReplaceAll(s, "'", "")
+	s = strings.ReplaceAll(s, "\u2019", "") // right single quotation mark
+	return s
+}
+
+func buildPokemonVocab(msgs map[string]string, baseDir string) *PokemonVocab {
+	single := make(map[string]string)
+	groups := make(map[string][]string)
+	multiWordSet := make(map[string]bool)
+
+	// Map from pokemon ID → canonical lowercase name
+	idToName := make(map[int]string)
+
+	for key, val := range msgs {
+		if !strings.HasPrefix(key, "poke_") {
+			continue
+		}
+		idStr := strings.TrimPrefix(key, "poke_")
+		id, err := strconv.Atoi(idStr)
+		if err != nil {
+			continue
+		}
+
+		canonical := strings.ToLower(val)
+		idToName[id] = canonical
+
+		// Register canonical
+		single[canonical] = canonical
+
+		// Stripped variant (remove . ' ', replace - with space)
+		stripped := stripPunctuation(val)
+		if stripped != canonical {
+			single[stripped] = canonical
+		}
+
+		// Spaces-removed variant
+		noSpaces := strings.ReplaceAll(stripped, " ", "")
+		if noSpaces != canonical && noSpaces != stripped {
+			single[noSpaces] = canonical
+		}
+
+		// Track multi-word names
+		if strings.Contains(canonical, " ") || strings.Contains(canonical, "-") {
+			multiWordSet[canonical] = true
+		}
+	}
+
+	// Load aliases
+	aliases := loadPokemonAliases(baseDir)
+	for alias, val := range aliases {
+		aliasLow := strings.ToLower(alias)
+		switch v := val.(type) {
+		case float64:
+			// Single pokemon ID
+			id := int(v)
+			if name, ok := idToName[id]; ok {
+				single[aliasLow] = name
+			}
+		case []interface{}:
+			// Group of pokemon IDs
+			var names []string
+			for _, item := range v {
+				if fid, ok := item.(float64); ok {
+					if name, found := idToName[int(fid)]; found {
+						names = append(names, name)
+					}
+				}
+			}
+			if len(names) > 0 {
+				groups[aliasLow] = names
+			}
+		}
+	}
+
+	// Build sorted multi-word list (longest first)
+	multiWords := make([]string, 0, len(multiWordSet))
+	for name := range multiWordSet {
+		multiWords = append(multiWords, name)
+	}
+	sort.Slice(multiWords, func(i, j int) bool {
+		if len(multiWords[i]) != len(multiWords[j]) {
+			return len(multiWords[i]) > len(multiWords[j])
+		}
+		return multiWords[i] < multiWords[j]
+	})
+
+	return &PokemonVocab{
+		single:     single,
+		groups:     groups,
+		multiWords: multiWords,
+	}
+}
+
+func buildTypeVocab(msgs map[string]string) *TypeVocab {
+	names := make(map[string]bool)
+	for key, val := range msgs {
+		if !strings.HasPrefix(key, "poke_type_") {
+			continue
+		}
+		names[strings.ToLower(val)] = true
+	}
+	return &TypeVocab{names: names}
+}
+
+// trackableForms lists form names that can be tracked.
+var trackableForms = map[string]bool{
+	"alolan":   true,
+	"galarian": true,
+	"hisuian":  true,
+	"paldean":  true,
+	"shadow":   true,
+	"purified": true,
+	"origin":   true,
+	"altered":  true,
+	"attack":   true,
+	"defense":  true,
+	"speed":    true,
+	"plant":    true,
+	"sandy":    true,
+	"trash":    true,
+}
+
+func buildFormVocab(msgs map[string]string) *FormVocab {
+	forms := make(map[string]string)
+	for key, val := range msgs {
+		if !strings.HasPrefix(key, "form_") {
+			continue
+		}
+		low := strings.ToLower(val)
+		if trackableForms[low] {
+			forms[low] = "form:" + low
+		}
+	}
+	return &FormVocab{forms: forms}
+}
+
+func buildItemVocab(msgs map[string]string) *ItemVocab {
+	items := make(map[string]bool)
+	var multiWords []string
+	for key, val := range msgs {
+		if !strings.HasPrefix(key, "item_") {
+			continue
+		}
+		low := strings.ToLower(val)
+		if low == "" {
+			continue
+		}
+		items[low] = true
+		if strings.Contains(low, " ") {
+			multiWords = append(multiWords, low)
+		}
+	}
+	sort.Slice(multiWords, func(i, j int) bool {
+		if len(multiWords[i]) != len(multiWords[j]) {
+			return len(multiWords[i]) > len(multiWords[j])
+		}
+		return multiWords[i] < multiWords[j]
+	})
+	return &ItemVocab{items: items, multiWords: multiWords}
+}
+
+func buildMoveVocab(msgs map[string]string) *MoveVocab {
+	moves := make(map[string]bool)
+	var multiWords []string
+	for key, val := range msgs {
+		if !strings.HasPrefix(key, "move_") {
+			continue
+		}
+		low := strings.ToLower(val)
+		if low == "" {
+			continue
+		}
+		moves[low] = true
+		if strings.Contains(low, " ") {
+			multiWords = append(multiWords, low)
+		}
+	}
+	sort.Slice(multiWords, func(i, j int) bool {
+		if len(multiWords[i]) != len(multiWords[j]) {
+			return len(multiWords[i]) > len(multiWords[j])
+		}
+		return multiWords[i] < multiWords[j]
+	})
+	return &MoveVocab{moves: moves, multiWords: multiWords}
+}
+
+// loadPokemonAliases loads pokemonAlias.json from fallbacks/ then config/ (later overrides).
+func loadPokemonAliases(baseDir string) map[string]any {
+	result := make(map[string]any)
+
+	paths := []string{
+		filepath.Join(baseDir, "fallbacks", "pokemonAlias.json"),
+		filepath.Join(baseDir, "config", "pokemonAlias.json"),
+	}
+
+	for _, path := range paths {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue // file may not exist
+		}
+		var m map[string]any
+		if err := json.Unmarshal(data, &m); err != nil {
+			fmt.Fprintf(os.Stderr, "nlp: failed to parse %s: %v\n", path, err)
+			continue
+		}
+		for k, v := range m {
+			result[k] = v
+		}
+	}
+
+	return result
+}

--- a/processor/internal/nlp/vocabulary.go
+++ b/processor/internal/nlp/vocabulary.go
@@ -16,7 +16,8 @@ import (
 type PokemonVocab struct {
 	single     map[string]string   // normalized input → canonical lowercase name
 	groups     map[string][]string // group alias → list of canonical names
-	multiWords []string            // multi-word names sorted longest-first
+	multiWords []string            // multi-word lookup keys sorted longest-first
+	multiMap   map[string]string   // multi-word lookup key → canonical name
 }
 
 // Lookup returns the canonical lowercase pokemon name for input, or "" if not found.
@@ -145,7 +146,7 @@ func stripPunctuation(s string) string {
 func buildPokemonVocab(msgs map[string]string, baseDir string) *PokemonVocab {
 	single := make(map[string]string)
 	groups := make(map[string][]string)
-	multiWordSet := make(map[string]bool)
+	multiMap := make(map[string]string) // multi-word variant → canonical name
 
 	// Map from pokemon ID → canonical lowercase name
 	idToName := make(map[int]string)
@@ -178,9 +179,12 @@ func buildPokemonVocab(msgs map[string]string, baseDir string) *PokemonVocab {
 			single[noSpaces] = canonical
 		}
 
-		// Track multi-word names
+		// Track multi-word names — include both canonical and stripped variants
 		if strings.Contains(canonical, " ") || strings.Contains(canonical, "-") {
-			multiWordSet[canonical] = true
+			multiMap[canonical] = canonical
+			if stripped != canonical && strings.Contains(stripped, " ") {
+				multiMap[stripped] = canonical
+			}
 		}
 	}
 
@@ -212,9 +216,9 @@ func buildPokemonVocab(msgs map[string]string, baseDir string) *PokemonVocab {
 	}
 
 	// Build sorted multi-word list (longest first)
-	multiWords := make([]string, 0, len(multiWordSet))
-	for name := range multiWordSet {
-		multiWords = append(multiWords, name)
+	multiWords := make([]string, 0, len(multiMap))
+	for variant := range multiMap {
+		multiWords = append(multiWords, variant)
 	}
 	sort.Slice(multiWords, func(i, j int) bool {
 		if len(multiWords[i]) != len(multiWords[j]) {
@@ -227,6 +231,7 @@ func buildPokemonVocab(msgs map[string]string, baseDir string) *PokemonVocab {
 		single:     single,
 		groups:     groups,
 		multiWords: multiWords,
+		multiMap:   multiMap,
 	}
 }
 

--- a/processor/internal/nlp/vocabulary_test.go
+++ b/processor/internal/nlp/vocabulary_test.go
@@ -1,0 +1,291 @@
+package nlp
+
+import (
+	"testing"
+
+	"github.com/pokemon/poracleng/processor/internal/i18n"
+)
+
+func testTranslator() *i18n.Translator {
+	return i18n.NewTranslator("en", map[string]string{
+		// Pokemon
+		"poke_25":  "Pikachu",
+		"poke_122": "Mr. Mime",
+		"poke_83":  "Farfetch'd",
+		"poke_250": "Ho-Oh",
+		"poke_785": "Tapu Koko",
+		"poke_439": "Mime Jr.",
+		"poke_474": "Porygon-Z",
+		"poke_233": "Porygon2",
+		"poke_480": "Uxie",
+		"poke_481": "Mesprit",
+		"poke_482": "Azelf",
+		"poke_1":   "Bulbasaur",
+
+		// Types
+		"poke_type_1":  "Normal",
+		"poke_type_2":  "Fighting",
+		"poke_type_10": "Fire",
+		"poke_type_13": "Electric",
+		"poke_type_11": "Water",
+
+		// Forms
+		"form_46": "Alolan",
+		"form_47": "Galarian",
+		"form_99": "Shadow",
+		"form_50": "Normal", // not in trackable list
+
+		// Items
+		"item_1":   "Poke Ball",
+		"item_701": "Razz Berry",
+		"item_706": "Golden Razz Berry",
+		"item_100": "Potion",
+
+		// Moves
+		"move_14":  "Hyper Beam",
+		"move_13":  "Wrap",
+		"move_100": "Shadow Ball",
+		"move_200": "Rock Slide",
+	})
+}
+
+func TestVocabularyPokemonLookup(t *testing.T) {
+	tr := testTranslator()
+	// Use empty baseDir so alias files won't be found; we test canonical + fuzzy only
+	v := BuildVocabularies(tr, "/nonexistent")
+
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"pikachu", "pikachu"},
+		{"Pikachu", "pikachu"},
+		{"PIKACHU", "pikachu"},
+		{"mr. mime", "mr. mime"},
+		{"mr mime", "mr. mime"},
+		{"mrmime", "mr. mime"},
+		{"farfetch'd", "farfetch'd"},
+		{"farfetchd", "farfetch'd"},
+		{"ho-oh", "ho-oh"},
+		{"hooh", "ho-oh"},      // stripped: ho oh → spaces removed: hooh
+		{"ho oh", "ho-oh"},     // stripped variant
+		{"tapu koko", "tapu koko"},
+		{"tapukoko", "tapu koko"},
+		{"mime jr.", "mime jr."},
+		{"mime jr", "mime jr."},
+		{"mimejr", "mime jr."},
+		{"porygon-z", "porygon-z"},
+		{"porygonz", "porygon-z"},
+		{"porygon2", "porygon2"},
+		{"bulbasaur", "bulbasaur"},
+		{"notapokemon", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := v.Pokemon.Lookup(tt.input)
+			if got != tt.want {
+				t.Errorf("Pokemon.Lookup(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestVocabularyPokemonAliases(t *testing.T) {
+	tr := testTranslator()
+	// Use real baseDir to load fallbacks/pokemonAlias.json
+	v := BuildVocabularies(tr, "/Users/james/GolandProjects/PoracleNG")
+
+	// Single-ID aliases from pokemonAlias.json
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"mrmime", "mr. mime"},
+		{"mr mime", "mr. mime"},
+		{"hooh", "ho-oh"},
+		{"ho oh", "ho-oh"},
+		{"mimejr", "mime jr."},
+		{"farfetchd", "farfetch'd"},
+		{"porygonz", "porygon-z"},
+		{"porygon2", "porygon2"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := v.Pokemon.Lookup(tt.input)
+			if got != tt.want {
+				t.Errorf("Pokemon.Lookup(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+
+	// Group alias
+	group := v.Pokemon.LookupGroup("laketrio")
+	if group == nil {
+		t.Fatal("LookupGroup(laketrio) returned nil")
+	}
+	if len(group) != 3 {
+		t.Fatalf("LookupGroup(laketrio) returned %d names, want 3", len(group))
+	}
+	// Should contain uxie, mesprit, azelf
+	nameSet := map[string]bool{}
+	for _, n := range group {
+		nameSet[n] = true
+	}
+	for _, want := range []string{"uxie", "mesprit", "azelf"} {
+		if !nameSet[want] {
+			t.Errorf("LookupGroup(laketrio) missing %q, got %v", want, group)
+		}
+	}
+}
+
+func TestVocabularyTypeLookup(t *testing.T) {
+	tr := testTranslator()
+	v := BuildVocabularies(tr, "/nonexistent")
+
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"fire", "fire"},
+		{"Fire", "fire"},
+		{"electric", "electric"},
+		{"water", "water"},
+		{"normal", "normal"},
+		{"fighting", "fighting"},
+		{"psychic", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := v.Types.Lookup(tt.input)
+			if got != tt.want {
+				t.Errorf("Types.Lookup(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestVocabularyFormLookup(t *testing.T) {
+	tr := testTranslator()
+	v := BuildVocabularies(tr, "/nonexistent")
+
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"alolan", "form:alolan"},
+		{"Alolan", "form:alolan"},
+		{"galarian", "form:galarian"},
+		{"shadow", "form:shadow"},
+		{"normal", ""},  // "Normal" form is not in trackableForms
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := v.Forms.Lookup(tt.input)
+			if got != tt.want {
+				t.Errorf("Forms.Lookup(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestVocabularyItemLookup(t *testing.T) {
+	tr := testTranslator()
+	v := BuildVocabularies(tr, "/nonexistent")
+
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"potion", "potion"},
+		{"razz berry", "razz berry"},
+		{"golden razz berry", "golden razz berry"},
+		{"Poke Ball", "poke ball"},
+		{"unknown item", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := v.Items.Lookup(tt.input)
+			if got != tt.want {
+				t.Errorf("Items.Lookup(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+
+	// Multi-word items sorted longest first
+	mw := v.Items.MultiWordNames()
+	if len(mw) < 2 {
+		t.Fatalf("expected at least 2 multi-word items, got %d", len(mw))
+	}
+	// "golden razz berry" (17 chars) should come before "razz berry" (10 chars)
+	if mw[0] != "golden razz berry" {
+		t.Errorf("first multi-word item = %q, want %q", mw[0], "golden razz berry")
+	}
+}
+
+func TestVocabularyMoveLookup(t *testing.T) {
+	tr := testTranslator()
+	v := BuildVocabularies(tr, "/nonexistent")
+
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"wrap", "wrap"},
+		{"Hyper Beam", "hyper beam"},
+		{"shadow ball", "shadow ball"},
+		{"rock slide", "rock slide"},
+		{"unknown move", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := v.Moves.Lookup(tt.input)
+			if got != tt.want {
+				t.Errorf("Moves.Lookup(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestVocabularyMultiWordPokemon(t *testing.T) {
+	tr := testTranslator()
+	v := BuildVocabularies(tr, "/nonexistent")
+
+	mw := v.Pokemon.MultiWordNames()
+	if len(mw) == 0 {
+		t.Fatal("MultiWordNames() returned empty")
+	}
+
+	// Verify sorted longest-first
+	for i := 1; i < len(mw); i++ {
+		if len(mw[i]) > len(mw[i-1]) {
+			t.Errorf("not sorted longest-first: %q (%d) after %q (%d)",
+				mw[i], len(mw[i]), mw[i-1], len(mw[i-1]))
+		}
+	}
+
+	// mr. mime and tapu koko should be in the list (multi-word with space or hyphen)
+	nameSet := map[string]bool{}
+	for _, n := range mw {
+		nameSet[n] = true
+	}
+	for _, want := range []string{"mr. mime", "tapu koko", "mime jr.", "ho-oh", "porygon-z"} {
+		if !nameSet[want] {
+			t.Errorf("MultiWordNames() missing %q", want)
+		}
+	}
+}
+
+func TestVocabularyNilTranslator(t *testing.T) {
+	// Should not panic with nil translator
+	var tr *i18n.Translator
+	v := BuildVocabularies(tr, "/nonexistent")
+	if got := v.Pokemon.Lookup("pikachu"); got != "" {
+		t.Errorf("expected empty from nil translator, got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `!ask` command that translates natural language into Poracle tracking commands
- **Built-in NLP parser** — no external AI service, API keys, or cost needed. Just `[ai] enabled = true`
- Vocabularies built at startup from game data translations (1118 pokemon names, types, forms, items, moves)
- Optional AI model fallback via `fallback_to_ai = true` for edge cases the parser can't handle
- **DM suggestion mode** (`suggest_on_dm = true`) — any unrecognised DM is automatically parsed and a command suggestion is shown
- Platform-aware command prefixes: `/` for Telegram, configurable for Discord
- Shortcut phrases: "stop"→`!stop`, "tracked"→`!tracked`, "help"→`!help`, "start"→`!poracle`

## What it understands

| Natural language | Generated command |
|---|---|
| perfect dragonite | `!track dragonite iv100` |
| nundo pokemon within 1km | `!track everything iv0 maxiv0 d1000` |
| great league rank 1 azumarill | `!track azumarill great1` |
| mr mime | `!track "mr. mime"` |
| level 5 raids nearby | `!raid level5 d1000` |
| mewtwo raids with psystrike | `!raid mewtwo move:psystrike` |
| golden razz berry quests | `!quest "golden razz berry"` |
| team rocket water female | `!invasion water female` |
| kecleon pokestop | `!invasion kecleon` |
| stop tracking dragonite | `!untrack dragonite` |
| hundos for pikachu eevee and dragonite | 3 separate `!track` commands |
| stop | `!stop` |
| what am i tracking | `!tracked` |

- Fuzzy pokemon name matching: "mr mime", "mrmime", "farfetchd", "hooh" all resolve correctly
- Context-aware synonyms: "shadow" → `form:shadow` in track, `level15` in raid
- PVP defaults to great5 (top 5 ranks)
- Distance: "nearby"→d1000, "2.5km"→d2500
- Existing Poracle syntax passes through (iv95-99, d2000, great5, etc.)

## Config

```toml
[ai]
enabled = true          # enables !ask command
suggest_on_dm = true    # also suggest for any unrecognised DM
# fallback_to_ai = true # optional: AI model fallback for unrecognised input
# provider_url = "https://openrouter.ai/api/v1"
# api_key = "..."
# model = "google/gemma-3-12b-it"
```

## Architecture

```
processor/internal/nlp/   — NLP parser (normalize → intent → vocabulary match → filter → assemble)
processor/internal/ai/    — AI client for optional fallback
processor/internal/api/   — /api/ai/translate endpoint (NLP first, AI fallback)
alerter/commands/ask.js   — !ask Discord/Telegram command
alerter/suggestCommand.js — shared DM suggestion helper (platform-aware prefix)
```

## Test plan

- [x] 47 end-to-end parser tests covering all command types + shortcuts
- [x] Unit tests for normalize, intent, vocabulary, filters, matching
- [x] Multi-word fuzzy pokemon names (mr mime, tapu koko, farfetch'd)
- [x] Processor builds cleanly
- [x] Live tested via Discord `!ask` command
- [x] Live tested DM suggestion mode
- [x] Live test Telegram prefix (`/` instead of `!`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)