### PR TITLE
Update Grafana dashboards for processor-native delivery metrics

### DIFF
--- a/monitoring/grafana/generate-dashboard.mjs
+++ b/monitoring/grafana/generate-dashboard.mjs
@@ -212,14 +212,14 @@ function commonTemplating() {
 				value: ['$__all'],
 			},
 			datasource,
-			definition: 'label_values(poracle_alerter_matched_queue_depth, job)',
+			definition: 'label_values(process_resident_memory_bytes{job!~"$processor_job"}, job)',
 			hide: 0,
 			includeAll: true,
 			label: 'Alerter job',
 			multi: true,
 			name: 'alerter_job',
 			options: [],
-			query: 'label_values(poracle_alerter_matched_queue_depth, job)',
+			query: 'label_values(process_resident_memory_bytes{job!~"$processor_job"}, job)',
 			refresh: 1,
 			sort: 1,
 			type: 'query',
@@ -231,14 +231,14 @@ function commonTemplating() {
 				value: ['$__all'],
 			},
 			datasource,
-			definition: 'label_values(poracle_alerter_matched_queue_depth{job=~"$alerter_job"}, instance)',
+			definition: 'label_values(process_resident_memory_bytes{job=~"$alerter_job"}, instance)',
 			hide: 0,
 			includeAll: true,
 			label: 'Alerter instance',
 			multi: true,
 			name: 'alerter_instance',
 			options: [],
-			query: 'label_values(poracle_alerter_matched_queue_depth{job=~"$alerter_job"}, instance)',
+			query: 'label_values(process_resident_memory_bytes{job=~"$alerter_job"}, instance)',
 			refresh: 2,
 			sort: 1,
 			type: 'query',
@@ -301,6 +301,8 @@ function buildDashboard({ title, uid, version, description, panels }) {
 		weekStart: '',
 	}
 }
+
+// ─── Full Observability Dashboard ────────────────────────────────────────────
 
 const panels = []
 
@@ -365,8 +367,8 @@ panels.push(
 )
 panels.push(
 	statPanel({
-		title: 'Messages Sent/s',
-		expr: `sum(rate(poracle_alerter_messages_sent_total${alerterFilter}[$__rate_interval]))`,
+		title: 'Delivered/s',
+		expr: `sum(rate(poracle_delivery_total${processorFilter}[$__rate_interval]))`,
 		x: 12,
 		y,
 		unit: 'ops',
@@ -376,9 +378,8 @@ panels.push(
 	statPanel({
 		title: 'Delivery Failure %',
 		expr:
-			`100 * sum(rate(poracle_alerter_messages_failed_total${alerterFilter}[$__rate_interval])) / ` +
-			`clamp_min(sum(rate(poracle_alerter_messages_sent_total${alerterFilter}[$__rate_interval])) + ` +
-			`sum(rate(poracle_alerter_messages_failed_total${alerterFilter}[$__rate_interval])), 0.001)`,
+			`100 * sum(rate(poracle_delivery_total{status!="ok",job=~"$processor_job",instance=~"$processor_instance"}[$__rate_interval])) / ` +
+			`clamp_min(sum(rate(poracle_delivery_total${processorFilter}[$__rate_interval])), 0.001)`,
 		x: 15,
 		y,
 		unit: 'percent',
@@ -407,21 +408,30 @@ panels.push(
 )
 panels.push(
 	statPanel({
-		title: 'Backpressure/s',
-		expr: `sum(rate(poracle_alerter_backpressure_events_total${alerterFilter}[$__rate_interval]))`,
+		title: 'Render Queue %',
+		expr:
+			`100 * sum(poracle_render_queue_depth${processorFilter}) / ` +
+			`clamp_min(sum(poracle_render_queue_capacity${processorFilter}), 1)`,
 		x: 21,
 		y,
-		unit: 'ops',
+		unit: 'percent',
+		thresholdSteps: [
+			{ color: 'green', value: null },
+			{ color: 'yellow', value: 70 },
+			{ color: 'red', value: 90 },
+		],
 	}),
 )
 y += 4
+
+// ─── Processor Pipeline ──────────────────────────────────────────────────────
 
 panels.push(rowPanel('Processor Pipeline', y))
 y += 1
 
 panels.push(
 	timeseriesPanel({
-		title: 'Processor Webhook Intake by Type',
+		title: 'Webhook Intake by Type',
 		x: 0,
 		y,
 		unit: 'ops',
@@ -435,7 +445,7 @@ panels.push(
 )
 panels.push(
 	timeseriesPanel({
-		title: 'Processor Webhook Processing p95 by Type',
+		title: 'Webhook Processing p95 by Type',
 		x: 12,
 		y,
 		unit: 's',
@@ -453,7 +463,7 @@ y += 8
 
 panels.push(
 	timeseriesPanel({
-		title: 'Processor Match Production by Type',
+		title: 'Match Production by Type',
 		x: 0,
 		y,
 		unit: 'ops',
@@ -475,7 +485,7 @@ panels.push(
 )
 panels.push(
 	timeseriesPanel({
-		title: 'Processor Worker and Sender Pressure',
+		title: 'Worker Pool Pressure',
 		x: 12,
 		y,
 		unit: 'short',
@@ -488,10 +498,6 @@ panels.push(
 				expr: `sum(poracle_processor_worker_pool_capacity${processorFilter})`,
 				legendFormat: 'worker pool capacity',
 			},
-			{
-				expr: `sum(poracle_processor_sender_queue_depth${processorFilter})`,
-				legendFormat: 'sender queue depth',
-			},
 		],
 	}),
 )
@@ -499,48 +505,32 @@ y += 8
 
 panels.push(
 	timeseriesPanel({
-		title: 'Processor Sender Outcomes and Batch Size',
+		title: 'Matching Duration p95 by Type',
 		x: 0,
 		y,
-		unit: 'short',
+		unit: 's',
 		targets: [
-			{
-				expr: `sum by(status) (rate(poracle_processor_sender_batches_total${processorFilter}[$__rate_interval]))`,
-				legendFormat: 'batches {{status}}',
-			},
-			{
-				expr:
-					`sum(rate(poracle_processor_sender_batch_size_sum${processorFilter}[$__rate_interval])) / ` +
-					`clamp_min(sum(rate(poracle_processor_sender_batch_size_count${processorFilter}[$__rate_interval])), 0.001)`,
-				legendFormat: 'avg batch size',
-			},
 			{
 				expr:
 					`histogram_quantile(0.95, ` +
-					`sum by(le) (rate(poracle_processor_sender_batch_size_bucket${processorFilter}[$__rate_interval])))`,
-				legendFormat: 'batch size p95',
+					`sum by(le, type) (rate(poracle_processor_matching_seconds_bucket${processorFilter}[$__rate_interval])))`,
+				legendFormat: '{{type}}',
 			},
 		],
 	}),
 )
 panels.push(
 	timeseriesPanel({
-		title: 'Processor Sender Flush Duration',
+		title: 'Enrichment Duration p95 by Type',
 		x: 12,
 		y,
 		unit: 's',
 		targets: [
 			{
 				expr:
-					`sum(rate(poracle_processor_sender_flush_seconds_sum${processorFilter}[$__rate_interval])) / ` +
-					`clamp_min(sum(rate(poracle_processor_sender_flush_seconds_count${processorFilter}[$__rate_interval])), 0.001)`,
-				legendFormat: 'flush avg',
-			},
-			{
-				expr:
 					`histogram_quantile(0.95, ` +
-					`sum by(le) (rate(poracle_processor_sender_flush_seconds_bucket${processorFilter}[$__rate_interval])))`,
-				legendFormat: 'flush p95',
+					`sum by(le, type) (rate(poracle_processor_enrichment_seconds_bucket${processorFilter}[$__rate_interval])))`,
+				legendFormat: '{{type}}',
 			},
 		],
 	}),
@@ -549,7 +539,7 @@ y += 8
 
 panels.push(
 	timeseriesPanel({
-		title: 'Processor Reloads and Rate Limiter',
+		title: 'Reloads and Rate Limiter',
 		x: 0,
 		y,
 		unit: 'short',
@@ -581,7 +571,7 @@ panels.push(
 )
 panels.push(
 	timeseriesPanel({
-		title: 'Processor Match Yield per Webhook',
+		title: 'Match Yield per Webhook',
 		x: 12,
 		y,
 		unit: 'short',
@@ -603,12 +593,262 @@ panels.push(
 )
 y += 8
 
+// ─── Render Pipeline ─────────────────────────────────────────────────────────
+
+panels.push(rowPanel('Render Pipeline', y))
+y += 1
+
+panels.push(
+	timeseriesPanel({
+		title: 'Render Queue Depth and Capacity',
+		x: 0,
+		y,
+		unit: 'short',
+		targets: [
+			{
+				expr: `sum(poracle_render_queue_depth${processorFilter})`,
+				legendFormat: 'queue depth',
+			},
+			{
+				expr: `sum(poracle_render_queue_capacity${processorFilter})`,
+				legendFormat: 'queue capacity',
+			},
+			{
+				expr: `sum(rate(poracle_render_tile_skipped_total${processorFilter}[$__rate_interval]))`,
+				legendFormat: 'tiles skipped (backpressure)',
+			},
+		],
+	}),
+)
+panels.push(
+	timeseriesPanel({
+		title: 'Render Job Duration p95',
+		x: 12,
+		y,
+		unit: 's',
+		targets: [
+			{
+				expr:
+					`histogram_quantile(0.95, ` +
+					`sum by(le) (rate(poracle_render_duration_seconds_bucket${processorFilter}[$__rate_interval])))`,
+				legendFormat: 'render job p95',
+			},
+			{
+				expr:
+					`sum(rate(poracle_render_duration_seconds_sum${processorFilter}[$__rate_interval])) / ` +
+					`clamp_min(sum(rate(poracle_render_duration_seconds_count${processorFilter}[$__rate_interval])), 0.001)`,
+				legendFormat: 'render job avg',
+			},
+		],
+	}),
+)
+y += 8
+
+panels.push(
+	timeseriesPanel({
+		title: 'Render Outcomes',
+		x: 0,
+		y,
+		unit: 'ops',
+		targets: [
+			{
+				expr: `sum by(status) (rate(poracle_render_total${processorFilter}[$__rate_interval]))`,
+				legendFormat: '{{status}}',
+			},
+		],
+	}),
+)
+panels.push(
+	timeseriesPanel({
+		title: 'Template Render Duration p95 by Type',
+		x: 12,
+		y,
+		unit: 's',
+		targets: [
+			{
+				expr:
+					`histogram_quantile(0.95, ` +
+					`sum by(le, type) (rate(poracle_template_render_seconds_bucket${processorFilter}[$__rate_interval])))`,
+				legendFormat: '{{type}}',
+			},
+		],
+	}),
+)
+y += 8
+
+panels.push(
+	timeseriesPanel({
+		title: 'Template Render Outcomes by Type',
+		x: 0,
+		y,
+		unit: 'ops',
+		targets: [
+			{
+				expr: `sum by(type, status) (rate(poracle_template_render_total${processorFilter}[$__rate_interval]))`,
+				legendFormat: '{{type}} {{status}}',
+			},
+		],
+	}),
+)
+panels.push(
+	timeseriesPanel({
+		title: 'Shlink URL Shortening',
+		x: 12,
+		y,
+		unit: 'short',
+		targets: [
+			{
+				expr: `sum by(result) (rate(poracle_shlink_total${processorFilter}[$__rate_interval]))`,
+				legendFormat: '{{result}}',
+			},
+			{
+				expr:
+					`histogram_quantile(0.95, ` +
+					`sum by(le) (rate(poracle_shlink_seconds_bucket${processorFilter}[$__rate_interval])))`,
+				legendFormat: 'latency p95',
+			},
+		],
+	}),
+)
+y += 8
+
+// ─── Delivery ────────────────────────────────────────────────────────────────
+
+panels.push(rowPanel('Delivery', y))
+y += 1
+
+panels.push(
+	timeseriesPanel({
+		title: 'Delivery Queue Depths',
+		x: 0,
+		y,
+		unit: 'short',
+		targets: [
+			{
+				expr: `sum(poracle_delivery_queue_depth${processorFilter})`,
+				legendFormat: 'total queue',
+			},
+			{
+				expr: `sum(poracle_delivery_discord_queue_depth${processorFilter})`,
+				legendFormat: 'discord',
+			},
+			{
+				expr: `sum(poracle_delivery_webhook_queue_depth${processorFilter})`,
+				legendFormat: 'discord webhook',
+			},
+			{
+				expr: `sum(poracle_delivery_telegram_queue_depth${processorFilter})`,
+				legendFormat: 'telegram',
+			},
+		],
+	}),
+)
+panels.push(
+	timeseriesPanel({
+		title: 'Delivery Outcomes by Platform',
+		x: 12,
+		y,
+		unit: 'ops',
+		targets: [
+			{
+				expr: `sum by(platform, status) (rate(poracle_delivery_total${processorFilter}[$__rate_interval]))`,
+				legendFormat: '{{platform}} {{status}}',
+			},
+		],
+	}),
+)
+y += 8
+
+panels.push(
+	timeseriesPanel({
+		title: 'Delivery Latency p95 by Platform',
+		x: 0,
+		y,
+		unit: 's',
+		targets: [
+			{
+				expr:
+					`histogram_quantile(0.95, ` +
+					`sum by(le, platform) (rate(poracle_delivery_duration_seconds_bucket${processorFilter}[$__rate_interval])))`,
+				legendFormat: '{{platform}}',
+			},
+		],
+	}),
+)
+panels.push(
+	timeseriesPanel({
+		title: 'Delivery In-Flight and Tracker',
+		x: 12,
+		y,
+		unit: 'short',
+		targets: [
+			{
+				expr: `sum by(platform) (poracle_delivery_in_flight${processorFilter})`,
+				legendFormat: 'in-flight {{platform}}',
+			},
+			{
+				expr: `sum(poracle_delivery_tracker_size${processorFilter})`,
+				legendFormat: 'tracker size',
+			},
+			{
+				expr: `sum(rate(poracle_delivery_clean_total${processorFilter}[$__rate_interval]))`,
+				legendFormat: 'clean deletes/s',
+			},
+			{
+				expr: `sum(rate(poracle_delivery_tracker_evictions_total${processorFilter}[$__rate_interval]))`,
+				legendFormat: 'tracker evictions/s',
+			},
+		],
+	}),
+)
+y += 8
+
+panels.push(
+	timeseriesPanel({
+		title: 'Delivery Rate Limits',
+		x: 0,
+		y,
+		unit: 'ops',
+		targets: [
+			{
+				expr: `sum by(platform) (rate(poracle_delivery_rate_limited_total${processorFilter}[$__rate_interval]))`,
+				legendFormat: 'rate limited {{platform}}',
+			},
+		],
+	}),
+)
+panels.push(
+	timeseriesPanel({
+		title: 'Discord Rate Limit Wait Time',
+		x: 12,
+		y,
+		unit: 's',
+		targets: [
+			{
+				expr:
+					`histogram_quantile(0.95, ` +
+					`sum by(le, platform) (rate(poracle_delivery_rate_limit_wait_seconds_bucket${processorFilter}[$__rate_interval])))`,
+				legendFormat: '{{platform}} p95',
+			},
+			{
+				expr:
+					`sum by(platform) (rate(poracle_delivery_rate_limit_wait_seconds_sum${processorFilter}[$__rate_interval])) / ` +
+					`clamp_min(sum by(platform) (rate(poracle_delivery_rate_limit_wait_seconds_count${processorFilter}[$__rate_interval])), 0.001)`,
+				legendFormat: '{{platform}} avg',
+			},
+		],
+	}),
+)
+y += 8
+
+// ─── Processor Integrations ──────────────────────────────────────────────────
+
 panels.push(rowPanel('Processor Integrations', y))
 y += 1
 
 panels.push(
 	timeseriesPanel({
-		title: 'Processor Geocode Outcomes and In Flight',
+		title: 'Geocode Outcomes and In Flight',
 		x: 0,
 		y,
 		unit: 'short',
@@ -626,7 +866,7 @@ panels.push(
 )
 panels.push(
 	timeseriesPanel({
-		title: 'Processor Geocode Latency',
+		title: 'Geocode Latency',
 		x: 12,
 		y,
 		unit: 's',
@@ -650,7 +890,7 @@ y += 8
 
 panels.push(
 	timeseriesPanel({
-		title: 'Processor Tile Outcomes and In Flight',
+		title: 'Tile Outcomes and In Flight',
 		x: 0,
 		y,
 		unit: 'short',
@@ -663,12 +903,16 @@ panels.push(
 				expr: `sum(poracle_processor_tile_in_flight${processorFilter})`,
 				legendFormat: 'in flight',
 			},
+			{
+				expr: `sum(poracle_processor_tile_queue_depth${processorFilter})`,
+				legendFormat: 'async queue depth',
+			},
 		],
 	}),
 )
 panels.push(
 	timeseriesPanel({
-		title: 'Processor Tile Latency',
+		title: 'Tile Latency',
 		x: 12,
 		y,
 		unit: 's',
@@ -684,6 +928,46 @@ panels.push(
 					`histogram_quantile(0.95, ` +
 					`sum by(le) (rate(poracle_processor_tile_seconds_bucket${processorFilter}[$__rate_interval])))`,
 				legendFormat: 'p95',
+			},
+		],
+	}),
+)
+y += 8
+
+panels.push(
+	timeseriesPanel({
+		title: 'Circuit Breakers',
+		x: 0,
+		y,
+		unit: 'short',
+		targets: [
+			{
+				expr: `sum(poracle_tile_circuit_healthy${processorFilter})`,
+				legendFormat: 'tileserver circuit (1=healthy)',
+			},
+			{
+				expr: `sum(poracle_geocode_circuit_healthy${processorFilter})`,
+				legendFormat: 'geocode circuit (1=healthy)',
+			},
+		],
+	}),
+)
+panels.push(
+	timeseriesPanel({
+		title: 'Uicons Index Refresh',
+		x: 12,
+		y,
+		unit: 'short',
+		targets: [
+			{
+				expr: `sum by(result) (rate(poracle_uicons_refresh_total${processorFilter}[$__rate_interval]))`,
+				legendFormat: '{{result}}',
+			},
+			{
+				expr:
+					`histogram_quantile(0.95, ` +
+					`sum by(le) (rate(poracle_uicons_refresh_seconds_bucket${processorFilter}[$__rate_interval])))`,
+				legendFormat: 'latency p95',
 			},
 		],
 	}),
@@ -730,92 +1014,51 @@ panels.push(
 )
 y += 8
 
-panels.push(rowPanel('Alerter Delivery', y))
+// ─── State & API ─────────────────────────────────────────────────────────────
+
+panels.push(rowPanel('State & API', y))
 y += 1
 
 panels.push(
 	timeseriesPanel({
-		title: 'Alerter Queue Depths',
+		title: 'State Size',
 		x: 0,
 		y,
 		unit: 'short',
 		targets: [
 			{
-				expr: `sum(poracle_alerter_matched_queue_depth${alerterFilter})`,
-				legendFormat: 'matched queue',
+				expr: `sum(poracle_processor_state_humans${processorFilter})`,
+				legendFormat: 'humans',
 			},
 			{
-				expr: `sum(poracle_alerter_hook_queue_depth${alerterFilter})`,
-				legendFormat: 'hook queue',
+				expr: `sum by(type) (poracle_processor_state_tracking_rules${processorFilter})`,
+				legendFormat: 'rules {{type}}',
 			},
 			{
-				expr: `sum(poracle_alerter_discord_queue_depth${alerterFilter})`,
-				legendFormat: 'discord queue',
-			},
-			{
-				expr: `sum(poracle_alerter_discord_webhook_queue_depth${alerterFilter})`,
-				legendFormat: 'discord webhook queue',
-			},
-			{
-				expr: `sum(poracle_alerter_telegram_queue_depth${alerterFilter})`,
-				legendFormat: 'telegram queue',
+				expr: `sum(poracle_processor_state_geofences${processorFilter})`,
+				legendFormat: 'geofences',
 			},
 		],
 	}),
 )
 panels.push(
 	timeseriesPanel({
-		title: 'Alerter Message Creation by Controller and Destination',
+		title: 'State Reload Breakdown',
 		x: 12,
-		y,
-		unit: 'ops',
-		targets: [
-			{
-				expr:
-					`sum by(controller_type, destination_type) (` +
-					`rate(poracle_alerter_messages_created_total${alerterFilter}[$__rate_interval]))`,
-				legendFormat: '{{controller_type}} -> {{destination_type}}',
-			},
-		],
-	}),
-)
-y += 8
-
-panels.push(
-	timeseriesPanel({
-		title: 'Alerter Message Create p95 by Controller',
-		x: 0,
 		y,
 		unit: 's',
 		targets: [
 			{
 				expr:
 					`histogram_quantile(0.95, ` +
-					`sum by(le, controller_type) (` +
-					`rate(poracle_alerter_message_create_seconds_bucket${alerterFilter}[$__rate_interval])))`,
-				legendFormat: '{{controller_type}}',
-			},
-		],
-	}),
-)
-panels.push(
-	timeseriesPanel({
-		title: 'Alerter Delivery Outcomes by Destination',
-		x: 12,
-		y,
-		unit: 'ops',
-		targets: [
-			{
-				expr:
-					`sum by(destination_type) (` +
-					`rate(poracle_alerter_messages_sent_total${alerterFilter}[$__rate_interval]))`,
-				legendFormat: 'sent {{destination_type}}',
+					`sum by(le) (rate(poracle_processor_state_reload_seconds_bucket${processorFilter}[$__rate_interval])))`,
+				legendFormat: 'total reload p95',
 			},
 			{
 				expr:
-					`sum by(destination_type) (` +
-					`rate(poracle_alerter_messages_failed_total${alerterFilter}[$__rate_interval]))`,
-				legendFormat: 'failed {{destination_type}}',
+					`histogram_quantile(0.95, ` +
+					`sum by(le) (rate(poracle_processor_state_db_query_seconds_bucket${processorFilter}[$__rate_interval])))`,
+				legendFormat: 'DB query p95',
 			},
 		],
 	}),
@@ -824,59 +1067,30 @@ y += 8
 
 panels.push(
 	timeseriesPanel({
-		title: 'Alerter Delivery Latency p95',
+		title: 'API Request Rate',
 		x: 0,
+		y,
+		unit: 'ops',
+		targets: [
+			{
+				expr: `sum by(method, endpoint) (rate(poracle_processor_api_requests_total${processorFilter}[$__rate_interval]))`,
+				legendFormat: '{{method}} {{endpoint}}',
+			},
+		],
+	}),
+)
+panels.push(
+	timeseriesPanel({
+		title: 'API Request Latency p95',
+		x: 12,
 		y,
 		unit: 's',
 		targets: [
 			{
 				expr:
 					`histogram_quantile(0.95, ` +
-					`sum by(le, destination_type) (` +
-					`rate(poracle_alerter_discord_delivery_seconds_bucket${alerterFilter}[$__rate_interval])))`,
-				legendFormat: 'discord {{destination_type}}',
-			},
-			{
-				expr:
-					`histogram_quantile(0.95, ` +
-					`sum by(le) (` +
-					`rate(poracle_alerter_discord_webhook_delivery_seconds_bucket${alerterFilter}[$__rate_interval])))`,
-				legendFormat: 'discord webhook',
-			},
-			{
-				expr:
-					`histogram_quantile(0.95, ` +
-					`sum by(le, destination_type) (` +
-					`rate(poracle_alerter_telegram_delivery_seconds_bucket${alerterFilter}[$__rate_interval])))`,
-				legendFormat: 'telegram {{destination_type}}',
-			},
-		],
-	}),
-)
-panels.push(
-	timeseriesPanel({
-		title: 'Alerter Rate Limits, Drops and Backpressure',
-		x: 12,
-		y,
-		unit: 'ops',
-		targets: [
-			{
-				expr:
-					`sum by(source) (` +
-					`rate(poracle_alerter_discord_rate_limits_total${alerterFilter}[$__rate_interval]))`,
-				legendFormat: 'discord {{source}}',
-			},
-			{
-				expr: `sum(rate(poracle_alerter_telegram_rate_limits_total${alerterFilter}[$__rate_interval]))`,
-				legendFormat: 'telegram',
-			},
-			{
-				expr: `sum(rate(poracle_alerter_rate_limited_total${alerterFilter}[$__rate_interval]))`,
-				legendFormat: 'dropped',
-			},
-			{
-				expr: `sum(rate(poracle_alerter_backpressure_events_total${alerterFilter}[$__rate_interval]))`,
-				legendFormat: 'backpressure',
+					`sum by(le, endpoint) (rate(poracle_processor_api_request_seconds_bucket${processorFilter}[$__rate_interval])))`,
+				legendFormat: '{{endpoint}}',
 			},
 		],
 	}),
@@ -885,87 +1099,43 @@ y += 8
 
 panels.push(
 	timeseriesPanel({
-		title: 'Alerter Geocode Outcomes and In Flight',
+		title: 'Webhook Batch Size',
 		x: 0,
 		y,
 		unit: 'short',
 		targets: [
 			{
-				expr: `sum by(result) (rate(poracle_alerter_geocode_total${alerterFilter}[$__rate_interval]))`,
-				legendFormat: '{{result}}',
+				expr:
+					`histogram_quantile(0.95, ` +
+					`sum by(le) (rate(poracle_processor_webhook_batch_size_bucket${processorFilter}[$__rate_interval])))`,
+				legendFormat: 'batch size p95',
 			},
 			{
-				expr: `sum(poracle_alerter_geocode_in_flight${alerterFilter})`,
-				legendFormat: 'in flight',
+				expr:
+					`sum(rate(poracle_processor_webhook_batch_size_sum${processorFilter}[$__rate_interval])) / ` +
+					`clamp_min(sum(rate(poracle_processor_webhook_batch_size_count${processorFilter}[$__rate_interval])), 0.001)`,
+				legendFormat: 'batch size avg',
 			},
 		],
 	}),
 )
 panels.push(
 	timeseriesPanel({
-		title: 'Alerter Geocode Latency',
+		title: 'Last Successful Reload',
 		x: 12,
 		y,
-		unit: 's',
+		unit: 'dateTimeAsIso',
 		targets: [
 			{
-				expr:
-					`sum(rate(poracle_alerter_geocode_seconds_sum${alerterFilter}[$__rate_interval])) / ` +
-					`clamp_min(sum(rate(poracle_alerter_geocode_seconds_count${alerterFilter}[$__rate_interval])), 0.001)`,
-				legendFormat: 'avg',
-			},
-			{
-				expr:
-					`histogram_quantile(0.95, ` +
-					`sum by(le) (rate(poracle_alerter_geocode_seconds_bucket${alerterFilter}[$__rate_interval])))`,
-				legendFormat: 'p95',
+				expr: `poracle_processor_state_last_reload_success_timestamp${processorFilter} * 1000`,
+				legendFormat: '{{instance}}',
 			},
 		],
 	}),
 )
 y += 8
 
-panels.push(
-	timeseriesPanel({
-		title: 'Alerter Tile Outcomes and In Flight',
-		x: 0,
-		y,
-		unit: 'short',
-		targets: [
-			{
-				expr: `sum by(result) (rate(poracle_alerter_tile_total${alerterFilter}[$__rate_interval]))`,
-				legendFormat: '{{result}}',
-			},
-			{
-				expr: `sum(poracle_alerter_tile_in_flight${alerterFilter})`,
-				legendFormat: 'in flight',
-			},
-		],
-	}),
-)
-panels.push(
-	timeseriesPanel({
-		title: 'Alerter Tile Latency',
-		x: 12,
-		y,
-		unit: 's',
-		targets: [
-			{
-				expr:
-					`sum(rate(poracle_alerter_tile_seconds_sum${alerterFilter}[$__rate_interval])) / ` +
-					`clamp_min(sum(rate(poracle_alerter_tile_seconds_count${alerterFilter}[$__rate_interval])), 0.001)`,
-				legendFormat: 'avg',
-			},
-			{
-				expr:
-					`histogram_quantile(0.95, ` +
-					`sum by(le) (rate(poracle_alerter_tile_seconds_bucket${alerterFilter}[$__rate_interval])))`,
-				legendFormat: 'p95',
-			},
-		],
-	}),
-)
-y += 8
+// ─── Runtime and Process Health ──────────────────────────────────────────────
 
 panels.push(rowPanel('Runtime and Process Health', y))
 y += 1
@@ -1140,11 +1310,13 @@ panels.push(
 const dashboard = buildDashboard({
 	title: 'PoracleNG Observability',
 	uid: 'poracleng-observability',
-	version: 2,
+	version: 3,
 	description:
-		'Complete observability dashboard for PoracleNG processor and alerter Prometheus metrics, including runtime telemetry.',
+		'Complete observability dashboard for PoracleNG processor and alerter Prometheus metrics, including render pipeline, delivery, and runtime telemetry.',
 	panels,
 })
+
+// ─── Operations Lite Dashboard ───────────────────────────────────────────────
 
 resetPanelIds()
 
@@ -1200,8 +1372,8 @@ litePanels.push(
 )
 litePanels.push(
 	statPanel({
-		title: 'Messages Sent/s',
-		expr: `sum(rate(poracle_alerter_messages_sent_total${alerterFilter}[$__rate_interval]))`,
+		title: 'Delivered/s',
+		expr: `sum(rate(poracle_delivery_total${processorFilter}[$__rate_interval]))`,
 		x: 12,
 		y: liteY,
 		unit: 'ops',
@@ -1211,9 +1383,8 @@ litePanels.push(
 	statPanel({
 		title: 'Delivery Failure %',
 		expr:
-			`100 * sum(rate(poracle_alerter_messages_failed_total${alerterFilter}[$__rate_interval])) / ` +
-			`clamp_min(sum(rate(poracle_alerter_messages_sent_total${alerterFilter}[$__rate_interval])) + ` +
-			`sum(rate(poracle_alerter_messages_failed_total${alerterFilter}[$__rate_interval])), 0.001)`,
+			`100 * sum(rate(poracle_delivery_total{status!="ok",job=~"$processor_job",instance=~"$processor_instance"}[$__rate_interval])) / ` +
+			`clamp_min(sum(rate(poracle_delivery_total${processorFilter}[$__rate_interval])), 0.001)`,
 		x: 15,
 		y: liteY,
 		unit: 'percent',
@@ -1242,11 +1413,18 @@ litePanels.push(
 )
 litePanels.push(
 	statPanel({
-		title: 'Backpressure/s',
-		expr: `sum(rate(poracle_alerter_backpressure_events_total${alerterFilter}[$__rate_interval]))`,
+		title: 'Render Queue %',
+		expr:
+			`100 * sum(poracle_render_queue_depth${processorFilter}) / ` +
+			`clamp_min(sum(poracle_render_queue_capacity${processorFilter}), 1)`,
 		x: 21,
 		y: liteY,
-		unit: 'ops',
+		unit: 'percent',
+		thresholdSteps: [
+			{ color: 'green', value: null },
+			{ color: 'yellow', value: 70 },
+			{ color: 'red', value: 90 },
+		],
 	}),
 )
 liteY += 4
@@ -1256,7 +1434,7 @@ liteY += 1
 
 litePanels.push(
 	timeseriesPanel({
-		title: 'Processor Intake and Match Rate',
+		title: 'Intake and Match Rate',
 		x: 0,
 		y: liteY,
 		unit: 'ops',
@@ -1274,7 +1452,7 @@ litePanels.push(
 )
 litePanels.push(
 	timeseriesPanel({
-		title: 'Processor Latency and Pressure',
+		title: 'Processing Latency and Pressure',
 		x: 12,
 		y: liteY,
 		unit: 'short',
@@ -1286,8 +1464,8 @@ litePanels.push(
 				legendFormat: 'p95 {{type}}',
 			},
 			{
-				expr: `sum(poracle_processor_sender_queue_depth${processorFilter})`,
-				legendFormat: 'sender queue',
+				expr: `sum(poracle_render_queue_depth${processorFilter})`,
+				legendFormat: 'render queue',
 			},
 			{
 				expr: `sum(poracle_processor_worker_pool_in_use${processorFilter})`,
@@ -1300,29 +1478,25 @@ liteY += 8
 
 litePanels.push(
 	timeseriesPanel({
-		title: 'Alerter Queues',
+		title: 'Delivery Queues',
 		x: 0,
 		y: liteY,
 		unit: 'short',
 		targets: [
 			{
-				expr: `sum(poracle_alerter_matched_queue_depth${alerterFilter})`,
-				legendFormat: 'matched',
+				expr: `sum(poracle_delivery_queue_depth${processorFilter})`,
+				legendFormat: 'total',
 			},
 			{
-				expr: `sum(poracle_alerter_hook_queue_depth${alerterFilter})`,
-				legendFormat: 'hook',
-			},
-			{
-				expr: `sum(poracle_alerter_discord_queue_depth${alerterFilter})`,
+				expr: `sum(poracle_delivery_discord_queue_depth${processorFilter})`,
 				legendFormat: 'discord',
 			},
 			{
-				expr: `sum(poracle_alerter_discord_webhook_queue_depth${alerterFilter})`,
+				expr: `sum(poracle_delivery_webhook_queue_depth${processorFilter})`,
 				legendFormat: 'discord webhook',
 			},
 			{
-				expr: `sum(poracle_alerter_telegram_queue_depth${alerterFilter})`,
+				expr: `sum(poracle_delivery_telegram_queue_depth${processorFilter})`,
 				legendFormat: 'telegram',
 			},
 		],
@@ -1336,23 +1510,19 @@ litePanels.push(
 		unit: 'short',
 		targets: [
 			{
-				expr:
-					`sum by(destination_type) (` +
-					`rate(poracle_alerter_messages_sent_total${alerterFilter}[$__rate_interval]))`,
-				legendFormat: 'sent {{destination_type}}',
+				expr: `sum by(platform) (rate(poracle_delivery_total{status="ok",job=~"$processor_job",instance=~"$processor_instance"}[$__rate_interval]))`,
+				legendFormat: 'sent {{platform}}',
 			},
 			{
-				expr:
-					`sum by(destination_type) (` +
-					`rate(poracle_alerter_messages_failed_total${alerterFilter}[$__rate_interval]))`,
-				legendFormat: 'failed {{destination_type}}',
+				expr: `sum by(platform) (rate(poracle_delivery_total{status!="ok",job=~"$processor_job",instance=~"$processor_instance"}[$__rate_interval]))`,
+				legendFormat: 'failed {{platform}}',
 			},
 			{
 				expr:
 					`histogram_quantile(0.95, ` +
-					`sum by(le) (` +
-					`rate(poracle_alerter_discord_webhook_delivery_seconds_bucket${alerterFilter}[$__rate_interval])))`,
-				legendFormat: 'discord webhook p95',
+					`sum by(le, platform) (` +
+					`rate(poracle_delivery_duration_seconds_bucket${processorFilter}[$__rate_interval])))`,
+				legendFormat: '{{platform}} p95',
 			},
 		],
 	}),
@@ -1368,21 +1538,15 @@ litePanels.push(
 		targets: [
 			{
 				expr: `sum(rate(poracle_processor_rate_limit_dropped_total${processorFilter}[$__rate_interval]))`,
-				legendFormat: 'processor dropped',
+				legendFormat: 'alert rate limit dropped',
 			},
 			{
 				expr: `sum(rate(poracle_processor_rate_limit_breaches_total${processorFilter}[$__rate_interval]))`,
-				legendFormat: 'processor breaches',
+				legendFormat: 'alert rate limit breaches',
 			},
 			{
-				expr:
-					`sum by(source) (` +
-					`rate(poracle_alerter_discord_rate_limits_total${alerterFilter}[$__rate_interval]))`,
-				legendFormat: 'discord {{source}}',
-			},
-			{
-				expr: `sum(rate(poracle_alerter_telegram_rate_limits_total${alerterFilter}[$__rate_interval]))`,
-				legendFormat: 'telegram',
+				expr: `sum by(platform) (rate(poracle_delivery_rate_limited_total${processorFilter}[$__rate_interval]))`,
+				legendFormat: 'delivery rate limited {{platform}}',
 			},
 		],
 	}),
@@ -1396,19 +1560,11 @@ litePanels.push(
 		targets: [
 			{
 				expr: `sum by(result) (rate(poracle_processor_tile_total${processorFilter}[$__rate_interval]))`,
-				legendFormat: 'processor tile {{result}}',
+				legendFormat: 'tile {{result}}',
 			},
 			{
 				expr: `sum by(result) (rate(poracle_processor_geocode_total${processorFilter}[$__rate_interval]))`,
-				legendFormat: 'processor geocode {{result}}',
-			},
-			{
-				expr: `sum by(result) (rate(poracle_alerter_tile_total${alerterFilter}[$__rate_interval]))`,
-				legendFormat: 'alerter tile {{result}}',
-			},
-			{
-				expr: `sum by(result) (rate(poracle_alerter_geocode_total${alerterFilter}[$__rate_interval]))`,
-				legendFormat: 'alerter geocode {{result}}',
+				legendFormat: 'geocode {{result}}',
 			},
 		],
 	}),
@@ -1460,7 +1616,7 @@ litePanels.push(
 const liteDashboard = buildDashboard({
 	title: 'PoracleNG Operations Lite',
 	uid: 'poracleng-ops-lite',
-	version: 1,
+	version: 2,
 	description:
 		'Concise Grafana dashboard for day-to-day PoracleNG operations, focusing on service health, flow pressure, delivery, and runtime.',
 	panels: litePanels,

--- a/monitoring/grafana/poracle-observability-dashboard.json
+++ b/monitoring/grafana/poracle-observability-dashboard.json
@@ -25,7 +25,7 @@
       }
     ]
   },
-  "description": "Complete observability dashboard for PoracleNG processor and alerter Prometheus metrics, including runtime telemetry.",
+  "description": "Complete observability dashboard for PoracleNG processor and alerter Prometheus metrics, including render pipeline, delivery, and runtime telemetry.",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
@@ -351,11 +351,11 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "sum(rate(poracle_alerter_messages_sent_total{job=~\"$alerter_job\",instance=~\"$alerter_instance\"}[$__rate_interval]))",
+          "expr": "sum(rate(poracle_delivery_total{job=~\"$processor_job\",instance=~\"$processor_instance\"}[$__rate_interval]))",
           "legendFormat": ""
         }
       ],
-      "title": "Messages Sent/s",
+      "title": "Delivered/s",
       "type": "stat"
     },
     {
@@ -415,7 +415,7 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "100 * sum(rate(poracle_alerter_messages_failed_total{job=~\"$alerter_job\",instance=~\"$alerter_instance\"}[$__rate_interval])) / clamp_min(sum(rate(poracle_alerter_messages_sent_total{job=~\"$alerter_job\",instance=~\"$alerter_instance\"}[$__rate_interval])) + sum(rate(poracle_alerter_messages_failed_total{job=~\"$alerter_job\",instance=~\"$alerter_instance\"}[$__rate_interval])), 0.001)",
+          "expr": "100 * sum(rate(poracle_delivery_total{status!=\"ok\",job=~\"$processor_job\",instance=~\"$processor_instance\"}[$__rate_interval])) / clamp_min(sum(rate(poracle_delivery_total{job=~\"$processor_job\",instance=~\"$processor_instance\"}[$__rate_interval])), 0.001)",
           "legendFormat": ""
         }
       ],
@@ -504,10 +504,18 @@
               {
                 "color": "green",
                 "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 70
+              },
+              {
+                "color": "red",
+                "value": 90
               }
             ]
           },
-          "unit": "ops"
+          "unit": "percent"
         },
         "overrides": []
       },
@@ -535,11 +543,11 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "sum(rate(poracle_alerter_backpressure_events_total{job=~\"$alerter_job\",instance=~\"$alerter_instance\"}[$__rate_interval]))",
+          "expr": "100 * sum(poracle_render_queue_depth{job=~\"$processor_job\",instance=~\"$processor_instance\"}) / clamp_min(sum(poracle_render_queue_capacity{job=~\"$processor_job\",instance=~\"$processor_instance\"}), 1)",
           "legendFormat": ""
         }
       ],
-      "title": "Backpressure/s",
+      "title": "Render Queue %",
       "type": "stat"
     },
     {
@@ -637,7 +645,7 @@
           "legendFormat": "{{type}}"
         }
       ],
-      "title": "Processor Webhook Intake by Type",
+      "title": "Webhook Intake by Type",
       "type": "timeseries"
     },
     {
@@ -722,7 +730,7 @@
           "legendFormat": "{{type}}"
         }
       ],
-      "title": "Processor Webhook Processing p95 by Type",
+      "title": "Webhook Processing p95 by Type",
       "type": "timeseries"
     },
     {
@@ -817,7 +825,7 @@
           "legendFormat": "duplicates {{type}}"
         }
       ],
-      "title": "Processor Match Production by Type",
+      "title": "Match Production by Type",
       "type": "timeseries"
     },
     {
@@ -905,14 +913,9 @@
           "refId": "B",
           "expr": "sum(poracle_processor_worker_pool_capacity{job=~\"$processor_job\",instance=~\"$processor_instance\"})",
           "legendFormat": "worker pool capacity"
-        },
-        {
-          "refId": "C",
-          "expr": "sum(poracle_processor_sender_queue_depth{job=~\"$processor_job\",instance=~\"$processor_instance\"})",
-          "legendFormat": "sender queue depth"
         }
       ],
-      "title": "Processor Worker and Sender Pressure",
+      "title": "Worker Pool Pressure",
       "type": "timeseries"
     },
     {
@@ -967,7 +970,7 @@
               }
             ]
           },
-          "unit": "short"
+          "unit": "s"
         },
         "overrides": []
       },
@@ -993,21 +996,11 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "sum by(status) (rate(poracle_processor_sender_batches_total{job=~\"$processor_job\",instance=~\"$processor_instance\"}[$__rate_interval]))",
-          "legendFormat": "batches {{status}}"
-        },
-        {
-          "refId": "B",
-          "expr": "sum(rate(poracle_processor_sender_batch_size_sum{job=~\"$processor_job\",instance=~\"$processor_instance\"}[$__rate_interval])) / clamp_min(sum(rate(poracle_processor_sender_batch_size_count{job=~\"$processor_job\",instance=~\"$processor_instance\"}[$__rate_interval])), 0.001)",
-          "legendFormat": "avg batch size"
-        },
-        {
-          "refId": "C",
-          "expr": "histogram_quantile(0.95, sum by(le) (rate(poracle_processor_sender_batch_size_bucket{job=~\"$processor_job\",instance=~\"$processor_instance\"}[$__rate_interval])))",
-          "legendFormat": "batch size p95"
+          "expr": "histogram_quantile(0.95, sum by(le, type) (rate(poracle_processor_matching_seconds_bucket{job=~\"$processor_job\",instance=~\"$processor_instance\"}[$__rate_interval])))",
+          "legendFormat": "{{type}}"
         }
       ],
-      "title": "Processor Sender Outcomes and Batch Size",
+      "title": "Matching Duration p95 by Type",
       "type": "timeseries"
     },
     {
@@ -1088,16 +1081,11 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "sum(rate(poracle_processor_sender_flush_seconds_sum{job=~\"$processor_job\",instance=~\"$processor_instance\"}[$__rate_interval])) / clamp_min(sum(rate(poracle_processor_sender_flush_seconds_count{job=~\"$processor_job\",instance=~\"$processor_instance\"}[$__rate_interval])), 0.001)",
-          "legendFormat": "flush avg"
-        },
-        {
-          "refId": "B",
-          "expr": "histogram_quantile(0.95, sum by(le) (rate(poracle_processor_sender_flush_seconds_bucket{job=~\"$processor_job\",instance=~\"$processor_instance\"}[$__rate_interval])))",
-          "legendFormat": "flush p95"
+          "expr": "histogram_quantile(0.95, sum by(le, type) (rate(poracle_processor_enrichment_seconds_bucket{job=~\"$processor_job\",instance=~\"$processor_instance\"}[$__rate_interval])))",
+          "legendFormat": "{{type}}"
         }
       ],
-      "title": "Processor Sender Flush Duration",
+      "title": "Enrichment Duration p95 by Type",
       "type": "timeseries"
     },
     {
@@ -1202,7 +1190,7 @@
           "legendFormat": "rate limit disabled"
         }
       ],
-      "title": "Processor Reloads and Rate Limiter",
+      "title": "Reloads and Rate Limiter",
       "type": "timeseries"
     },
     {
@@ -1292,7 +1280,7 @@
           "legendFormat": "matched events per webhook"
         }
       ],
-      "title": "Processor Match Yield per Webhook",
+      "title": "Match Yield per Webhook",
       "type": "timeseries"
     },
     {
@@ -1305,7 +1293,7 @@
       },
       "id": 19,
       "panels": [],
-      "title": "Processor Integrations",
+      "title": "Render Pipeline",
       "type": "row"
     },
     {
@@ -1386,16 +1374,21 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "sum by(result) (rate(poracle_processor_geocode_total{job=~\"$processor_job\",instance=~\"$processor_instance\"}[$__rate_interval]))",
-          "legendFormat": "{{result}}"
+          "expr": "sum(poracle_render_queue_depth{job=~\"$processor_job\",instance=~\"$processor_instance\"})",
+          "legendFormat": "queue depth"
         },
         {
           "refId": "B",
-          "expr": "sum(poracle_processor_geocode_in_flight{job=~\"$processor_job\",instance=~\"$processor_instance\"})",
-          "legendFormat": "in flight"
+          "expr": "sum(poracle_render_queue_capacity{job=~\"$processor_job\",instance=~\"$processor_instance\"})",
+          "legendFormat": "queue capacity"
+        },
+        {
+          "refId": "C",
+          "expr": "sum(rate(poracle_render_tile_skipped_total{job=~\"$processor_job\",instance=~\"$processor_instance\"}[$__rate_interval]))",
+          "legendFormat": "tiles skipped (backpressure)"
         }
       ],
-      "title": "Processor Geocode Outcomes and In Flight",
+      "title": "Render Queue Depth and Capacity",
       "type": "timeseries"
     },
     {
@@ -1476,16 +1469,16 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "sum(rate(poracle_processor_geocode_seconds_sum{job=~\"$processor_job\",instance=~\"$processor_instance\"}[$__rate_interval])) / clamp_min(sum(rate(poracle_processor_geocode_seconds_count{job=~\"$processor_job\",instance=~\"$processor_instance\"}[$__rate_interval])), 0.001)",
-          "legendFormat": "avg"
+          "expr": "histogram_quantile(0.95, sum by(le) (rate(poracle_render_duration_seconds_bucket{job=~\"$processor_job\",instance=~\"$processor_instance\"}[$__rate_interval])))",
+          "legendFormat": "render job p95"
         },
         {
           "refId": "B",
-          "expr": "histogram_quantile(0.95, sum by(le) (rate(poracle_processor_geocode_seconds_bucket{job=~\"$processor_job\",instance=~\"$processor_instance\"}[$__rate_interval])))",
-          "legendFormat": "p95"
+          "expr": "sum(rate(poracle_render_duration_seconds_sum{job=~\"$processor_job\",instance=~\"$processor_instance\"}[$__rate_interval])) / clamp_min(sum(rate(poracle_render_duration_seconds_count{job=~\"$processor_job\",instance=~\"$processor_instance\"}[$__rate_interval])), 0.001)",
+          "legendFormat": "render job avg"
         }
       ],
-      "title": "Processor Geocode Latency",
+      "title": "Render Job Duration p95",
       "type": "timeseries"
     },
     {
@@ -1540,7 +1533,7 @@
               }
             ]
           },
-          "unit": "short"
+          "unit": "ops"
         },
         "overrides": []
       },
@@ -1566,16 +1559,11 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "sum by(result) (rate(poracle_processor_tile_total{job=~\"$processor_job\",instance=~\"$processor_instance\"}[$__rate_interval]))",
-          "legendFormat": "{{result}}"
-        },
-        {
-          "refId": "B",
-          "expr": "sum(poracle_processor_tile_in_flight{job=~\"$processor_job\",instance=~\"$processor_instance\"})",
-          "legendFormat": "in flight"
+          "expr": "sum by(status) (rate(poracle_render_total{job=~\"$processor_job\",instance=~\"$processor_instance\"}[$__rate_interval]))",
+          "legendFormat": "{{status}}"
         }
       ],
-      "title": "Processor Tile Outcomes and In Flight",
+      "title": "Render Outcomes",
       "type": "timeseries"
     },
     {
@@ -1656,16 +1644,11 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "sum(rate(poracle_processor_tile_seconds_sum{job=~\"$processor_job\",instance=~\"$processor_instance\"}[$__rate_interval])) / clamp_min(sum(rate(poracle_processor_tile_seconds_count{job=~\"$processor_job\",instance=~\"$processor_instance\"}[$__rate_interval])), 0.001)",
-          "legendFormat": "avg"
-        },
-        {
-          "refId": "B",
-          "expr": "histogram_quantile(0.95, sum by(le) (rate(poracle_processor_tile_seconds_bucket{job=~\"$processor_job\",instance=~\"$processor_instance\"}[$__rate_interval])))",
-          "legendFormat": "p95"
+          "expr": "histogram_quantile(0.95, sum by(le, type) (rate(poracle_template_render_seconds_bucket{job=~\"$processor_job\",instance=~\"$processor_instance\"}[$__rate_interval])))",
+          "legendFormat": "{{type}}"
         }
       ],
-      "title": "Processor Tile Latency",
+      "title": "Template Render Duration p95 by Type",
       "type": "timeseries"
     },
     {
@@ -1731,6 +1714,1297 @@
         "y": 55
       },
       "id": 24,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by(type, status) (rate(poracle_template_render_total{job=~\"$processor_job\",instance=~\"$processor_instance\"}[$__rate_interval]))",
+          "legendFormat": "{{type}} {{status}}"
+        }
+      ],
+      "title": "Template Render Outcomes by Type",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 55
+      },
+      "id": 25,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by(result) (rate(poracle_shlink_total{job=~\"$processor_job\",instance=~\"$processor_instance\"}[$__rate_interval]))",
+          "legendFormat": "{{result}}"
+        },
+        {
+          "refId": "B",
+          "expr": "histogram_quantile(0.95, sum by(le) (rate(poracle_shlink_seconds_bucket{job=~\"$processor_job\",instance=~\"$processor_instance\"}[$__rate_interval])))",
+          "legendFormat": "latency p95"
+        }
+      ],
+      "title": "Shlink URL Shortening",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 63
+      },
+      "id": 26,
+      "panels": [],
+      "title": "Delivery",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 64
+      },
+      "id": 27,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(poracle_delivery_queue_depth{job=~\"$processor_job\",instance=~\"$processor_instance\"})",
+          "legendFormat": "total queue"
+        },
+        {
+          "refId": "B",
+          "expr": "sum(poracle_delivery_discord_queue_depth{job=~\"$processor_job\",instance=~\"$processor_instance\"})",
+          "legendFormat": "discord"
+        },
+        {
+          "refId": "C",
+          "expr": "sum(poracle_delivery_webhook_queue_depth{job=~\"$processor_job\",instance=~\"$processor_instance\"})",
+          "legendFormat": "discord webhook"
+        },
+        {
+          "refId": "D",
+          "expr": "sum(poracle_delivery_telegram_queue_depth{job=~\"$processor_job\",instance=~\"$processor_instance\"})",
+          "legendFormat": "telegram"
+        }
+      ],
+      "title": "Delivery Queue Depths",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 64
+      },
+      "id": 28,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by(platform, status) (rate(poracle_delivery_total{job=~\"$processor_job\",instance=~\"$processor_instance\"}[$__rate_interval]))",
+          "legendFormat": "{{platform}} {{status}}"
+        }
+      ],
+      "title": "Delivery Outcomes by Platform",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 72
+      },
+      "id": 29,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "histogram_quantile(0.95, sum by(le, platform) (rate(poracle_delivery_duration_seconds_bucket{job=~\"$processor_job\",instance=~\"$processor_instance\"}[$__rate_interval])))",
+          "legendFormat": "{{platform}}"
+        }
+      ],
+      "title": "Delivery Latency p95 by Platform",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 72
+      },
+      "id": 30,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by(platform) (poracle_delivery_in_flight{job=~\"$processor_job\",instance=~\"$processor_instance\"})",
+          "legendFormat": "in-flight {{platform}}"
+        },
+        {
+          "refId": "B",
+          "expr": "sum(poracle_delivery_tracker_size{job=~\"$processor_job\",instance=~\"$processor_instance\"})",
+          "legendFormat": "tracker size"
+        },
+        {
+          "refId": "C",
+          "expr": "sum(rate(poracle_delivery_clean_total{job=~\"$processor_job\",instance=~\"$processor_instance\"}[$__rate_interval]))",
+          "legendFormat": "clean deletes/s"
+        },
+        {
+          "refId": "D",
+          "expr": "sum(rate(poracle_delivery_tracker_evictions_total{job=~\"$processor_job\",instance=~\"$processor_instance\"}[$__rate_interval]))",
+          "legendFormat": "tracker evictions/s"
+        }
+      ],
+      "title": "Delivery In-Flight and Tracker",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 80
+      },
+      "id": 31,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by(platform) (rate(poracle_delivery_rate_limited_total{job=~\"$processor_job\",instance=~\"$processor_instance\"}[$__rate_interval]))",
+          "legendFormat": "rate limited {{platform}}"
+        }
+      ],
+      "title": "Delivery Rate Limits",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 80
+      },
+      "id": 32,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "histogram_quantile(0.95, sum by(le, platform) (rate(poracle_delivery_rate_limit_wait_seconds_bucket{job=~\"$processor_job\",instance=~\"$processor_instance\"}[$__rate_interval])))",
+          "legendFormat": "{{platform}} p95"
+        },
+        {
+          "refId": "B",
+          "expr": "sum by(platform) (rate(poracle_delivery_rate_limit_wait_seconds_sum{job=~\"$processor_job\",instance=~\"$processor_instance\"}[$__rate_interval])) / clamp_min(sum by(platform) (rate(poracle_delivery_rate_limit_wait_seconds_count{job=~\"$processor_job\",instance=~\"$processor_instance\"}[$__rate_interval])), 0.001)",
+          "legendFormat": "{{platform}} avg"
+        }
+      ],
+      "title": "Discord Rate Limit Wait Time",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 88
+      },
+      "id": 33,
+      "panels": [],
+      "title": "Processor Integrations",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 89
+      },
+      "id": 34,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by(result) (rate(poracle_processor_geocode_total{job=~\"$processor_job\",instance=~\"$processor_instance\"}[$__rate_interval]))",
+          "legendFormat": "{{result}}"
+        },
+        {
+          "refId": "B",
+          "expr": "sum(poracle_processor_geocode_in_flight{job=~\"$processor_job\",instance=~\"$processor_instance\"})",
+          "legendFormat": "in flight"
+        }
+      ],
+      "title": "Geocode Outcomes and In Flight",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 89
+      },
+      "id": 35,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(rate(poracle_processor_geocode_seconds_sum{job=~\"$processor_job\",instance=~\"$processor_instance\"}[$__rate_interval])) / clamp_min(sum(rate(poracle_processor_geocode_seconds_count{job=~\"$processor_job\",instance=~\"$processor_instance\"}[$__rate_interval])), 0.001)",
+          "legendFormat": "avg"
+        },
+        {
+          "refId": "B",
+          "expr": "histogram_quantile(0.95, sum by(le) (rate(poracle_processor_geocode_seconds_bucket{job=~\"$processor_job\",instance=~\"$processor_instance\"}[$__rate_interval])))",
+          "legendFormat": "p95"
+        }
+      ],
+      "title": "Geocode Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 97
+      },
+      "id": 36,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by(result) (rate(poracle_processor_tile_total{job=~\"$processor_job\",instance=~\"$processor_instance\"}[$__rate_interval]))",
+          "legendFormat": "{{result}}"
+        },
+        {
+          "refId": "B",
+          "expr": "sum(poracle_processor_tile_in_flight{job=~\"$processor_job\",instance=~\"$processor_instance\"})",
+          "legendFormat": "in flight"
+        },
+        {
+          "refId": "C",
+          "expr": "sum(poracle_processor_tile_queue_depth{job=~\"$processor_job\",instance=~\"$processor_instance\"})",
+          "legendFormat": "async queue depth"
+        }
+      ],
+      "title": "Tile Outcomes and In Flight",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 97
+      },
+      "id": 37,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(rate(poracle_processor_tile_seconds_sum{job=~\"$processor_job\",instance=~\"$processor_instance\"}[$__rate_interval])) / clamp_min(sum(rate(poracle_processor_tile_seconds_count{job=~\"$processor_job\",instance=~\"$processor_instance\"}[$__rate_interval])), 0.001)",
+          "legendFormat": "avg"
+        },
+        {
+          "refId": "B",
+          "expr": "histogram_quantile(0.95, sum by(le) (rate(poracle_processor_tile_seconds_bucket{job=~\"$processor_job\",instance=~\"$processor_instance\"}[$__rate_interval])))",
+          "legendFormat": "p95"
+        }
+      ],
+      "title": "Tile Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 105
+      },
+      "id": 38,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(poracle_tile_circuit_healthy{job=~\"$processor_job\",instance=~\"$processor_instance\"})",
+          "legendFormat": "tileserver circuit (1=healthy)"
+        },
+        {
+          "refId": "B",
+          "expr": "sum(poracle_geocode_circuit_healthy{job=~\"$processor_job\",instance=~\"$processor_instance\"})",
+          "legendFormat": "geocode circuit (1=healthy)"
+        }
+      ],
+      "title": "Circuit Breakers",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 105
+      },
+      "id": 39,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by(result) (rate(poracle_uicons_refresh_total{job=~\"$processor_job\",instance=~\"$processor_instance\"}[$__rate_interval]))",
+          "legendFormat": "{{result}}"
+        },
+        {
+          "refId": "B",
+          "expr": "histogram_quantile(0.95, sum by(le) (rate(poracle_uicons_refresh_seconds_bucket{job=~\"$processor_job\",instance=~\"$processor_instance\"}[$__rate_interval])))",
+          "legendFormat": "latency p95"
+        }
+      ],
+      "title": "Uicons Index Refresh",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 113
+      },
+      "id": 40,
       "options": {
         "legend": {
           "calcs": [],
@@ -1813,9 +3087,9 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 55
+        "y": 113
       },
-      "id": 25,
+      "id": 41,
       "options": {
         "legend": {
           "calcs": [],
@@ -1854,11 +3128,11 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 63
+        "y": 121
       },
-      "id": 26,
+      "id": 42,
       "panels": [],
-      "title": "Alerter Delivery",
+      "title": "State & API",
       "type": "row"
     },
     {
@@ -1921,9 +3195,9 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 64
+        "y": 122
       },
-      "id": 27,
+      "id": 43,
       "options": {
         "legend": {
           "calcs": [],
@@ -1939,116 +3213,21 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "sum(poracle_alerter_matched_queue_depth{job=~\"$alerter_job\",instance=~\"$alerter_instance\"})",
-          "legendFormat": "matched queue"
+          "expr": "sum(poracle_processor_state_humans{job=~\"$processor_job\",instance=~\"$processor_instance\"})",
+          "legendFormat": "humans"
         },
         {
           "refId": "B",
-          "expr": "sum(poracle_alerter_hook_queue_depth{job=~\"$alerter_job\",instance=~\"$alerter_instance\"})",
-          "legendFormat": "hook queue"
+          "expr": "sum by(type) (poracle_processor_state_tracking_rules{job=~\"$processor_job\",instance=~\"$processor_instance\"})",
+          "legendFormat": "rules {{type}}"
         },
         {
           "refId": "C",
-          "expr": "sum(poracle_alerter_discord_queue_depth{job=~\"$alerter_job\",instance=~\"$alerter_instance\"})",
-          "legendFormat": "discord queue"
-        },
-        {
-          "refId": "D",
-          "expr": "sum(poracle_alerter_discord_webhook_queue_depth{job=~\"$alerter_job\",instance=~\"$alerter_instance\"})",
-          "legendFormat": "discord webhook queue"
-        },
-        {
-          "refId": "E",
-          "expr": "sum(poracle_alerter_telegram_queue_depth{job=~\"$alerter_job\",instance=~\"$alerter_instance\"})",
-          "legendFormat": "telegram queue"
+          "expr": "sum(poracle_processor_state_geofences{job=~\"$processor_job\",instance=~\"$processor_instance\"})",
+          "legendFormat": "geofences"
         }
       ],
-      "title": "Alerter Queue Depths",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 12,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 2,
-            "pointSize": 4,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": true,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "decimals": 2,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "ops"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 64
-      },
-      "id": 28,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "expr": "sum by(controller_type, destination_type) (rate(poracle_alerter_messages_created_total{job=~\"$alerter_job\",instance=~\"$alerter_instance\"}[$__rate_interval]))",
-          "legendFormat": "{{controller_type}} -> {{destination_type}}"
-        }
-      ],
-      "title": "Alerter Message Creation by Controller and Destination",
+      "title": "State Size",
       "type": "timeseries"
     },
     {
@@ -2110,10 +3289,10 @@
       "gridPos": {
         "h": 8,
         "w": 12,
-        "x": 0,
-        "y": 72
+        "x": 12,
+        "y": 122
       },
-      "id": 29,
+      "id": 44,
       "options": {
         "legend": {
           "calcs": [],
@@ -2129,11 +3308,16 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "histogram_quantile(0.95, sum by(le, controller_type) (rate(poracle_alerter_message_create_seconds_bucket{job=~\"$alerter_job\",instance=~\"$alerter_instance\"}[$__rate_interval])))",
-          "legendFormat": "{{controller_type}}"
+          "expr": "histogram_quantile(0.95, sum by(le) (rate(poracle_processor_state_reload_seconds_bucket{job=~\"$processor_job\",instance=~\"$processor_instance\"}[$__rate_interval])))",
+          "legendFormat": "total reload p95"
+        },
+        {
+          "refId": "B",
+          "expr": "histogram_quantile(0.95, sum by(le) (rate(poracle_processor_state_db_query_seconds_bucket{job=~\"$processor_job\",instance=~\"$processor_instance\"}[$__rate_interval])))",
+          "legendFormat": "DB query p95"
         }
       ],
-      "title": "Alerter Message Create p95 by Controller",
+      "title": "State Reload Breakdown",
       "type": "timeseries"
     },
     {
@@ -2195,10 +3379,10 @@
       "gridPos": {
         "h": 8,
         "w": 12,
-        "x": 12,
-        "y": 72
+        "x": 0,
+        "y": 130
       },
-      "id": 30,
+      "id": 45,
       "options": {
         "legend": {
           "calcs": [],
@@ -2214,16 +3398,11 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "sum by(destination_type) (rate(poracle_alerter_messages_sent_total{job=~\"$alerter_job\",instance=~\"$alerter_instance\"}[$__rate_interval]))",
-          "legendFormat": "sent {{destination_type}}"
-        },
-        {
-          "refId": "B",
-          "expr": "sum by(destination_type) (rate(poracle_alerter_messages_failed_total{job=~\"$alerter_job\",instance=~\"$alerter_instance\"}[$__rate_interval]))",
-          "legendFormat": "failed {{destination_type}}"
+          "expr": "sum by(method, endpoint) (rate(poracle_processor_api_requests_total{job=~\"$processor_job\",instance=~\"$processor_instance\"}[$__rate_interval]))",
+          "legendFormat": "{{method}} {{endpoint}}"
         }
       ],
-      "title": "Alerter Delivery Outcomes by Destination",
+      "title": "API Request Rate",
       "type": "timeseries"
     },
     {
@@ -2285,105 +3464,10 @@
       "gridPos": {
         "h": 8,
         "w": 12,
-        "x": 0,
-        "y": 80
-      },
-      "id": 31,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "expr": "histogram_quantile(0.95, sum by(le, destination_type) (rate(poracle_alerter_discord_delivery_seconds_bucket{job=~\"$alerter_job\",instance=~\"$alerter_instance\"}[$__rate_interval])))",
-          "legendFormat": "discord {{destination_type}}"
-        },
-        {
-          "refId": "B",
-          "expr": "histogram_quantile(0.95, sum by(le) (rate(poracle_alerter_discord_webhook_delivery_seconds_bucket{job=~\"$alerter_job\",instance=~\"$alerter_instance\"}[$__rate_interval])))",
-          "legendFormat": "discord webhook"
-        },
-        {
-          "refId": "C",
-          "expr": "histogram_quantile(0.95, sum by(le, destination_type) (rate(poracle_alerter_telegram_delivery_seconds_bucket{job=~\"$alerter_job\",instance=~\"$alerter_instance\"}[$__rate_interval])))",
-          "legendFormat": "telegram {{destination_type}}"
-        }
-      ],
-      "title": "Alerter Delivery Latency p95",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 12,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 2,
-            "pointSize": 4,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": true,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "decimals": 2,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "ops"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
         "x": 12,
-        "y": 80
+        "y": 130
       },
-      "id": 32,
+      "id": 46,
       "options": {
         "legend": {
           "calcs": [],
@@ -2399,26 +3483,11 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "sum by(source) (rate(poracle_alerter_discord_rate_limits_total{job=~\"$alerter_job\",instance=~\"$alerter_instance\"}[$__rate_interval]))",
-          "legendFormat": "discord {{source}}"
-        },
-        {
-          "refId": "B",
-          "expr": "sum(rate(poracle_alerter_telegram_rate_limits_total{job=~\"$alerter_job\",instance=~\"$alerter_instance\"}[$__rate_interval]))",
-          "legendFormat": "telegram"
-        },
-        {
-          "refId": "C",
-          "expr": "sum(rate(poracle_alerter_rate_limited_total{job=~\"$alerter_job\",instance=~\"$alerter_instance\"}[$__rate_interval]))",
-          "legendFormat": "dropped"
-        },
-        {
-          "refId": "D",
-          "expr": "sum(rate(poracle_alerter_backpressure_events_total{job=~\"$alerter_job\",instance=~\"$alerter_instance\"}[$__rate_interval]))",
-          "legendFormat": "backpressure"
+          "expr": "histogram_quantile(0.95, sum by(le, endpoint) (rate(poracle_processor_api_request_seconds_bucket{job=~\"$processor_job\",instance=~\"$processor_instance\"}[$__rate_interval])))",
+          "legendFormat": "{{endpoint}}"
         }
       ],
-      "title": "Alerter Rate Limits, Drops and Backpressure",
+      "title": "API Request Latency p95",
       "type": "timeseries"
     },
     {
@@ -2481,9 +3550,9 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 88
+        "y": 138
       },
-      "id": 33,
+      "id": 47,
       "options": {
         "legend": {
           "calcs": [],
@@ -2499,16 +3568,16 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "sum by(result) (rate(poracle_alerter_geocode_total{job=~\"$alerter_job\",instance=~\"$alerter_instance\"}[$__rate_interval]))",
-          "legendFormat": "{{result}}"
+          "expr": "histogram_quantile(0.95, sum by(le) (rate(poracle_processor_webhook_batch_size_bucket{job=~\"$processor_job\",instance=~\"$processor_instance\"}[$__rate_interval])))",
+          "legendFormat": "batch size p95"
         },
         {
           "refId": "B",
-          "expr": "sum(poracle_alerter_geocode_in_flight{job=~\"$alerter_job\",instance=~\"$alerter_instance\"})",
-          "legendFormat": "in flight"
+          "expr": "sum(rate(poracle_processor_webhook_batch_size_sum{job=~\"$processor_job\",instance=~\"$processor_instance\"}[$__rate_interval])) / clamp_min(sum(rate(poracle_processor_webhook_batch_size_count{job=~\"$processor_job\",instance=~\"$processor_instance\"}[$__rate_interval])), 0.001)",
+          "legendFormat": "batch size avg"
         }
       ],
-      "title": "Alerter Geocode Outcomes and In Flight",
+      "title": "Webhook Batch Size",
       "type": "timeseries"
     },
     {
@@ -2563,7 +3632,7 @@
               }
             ]
           },
-          "unit": "s"
+          "unit": "dateTimeAsIso"
         },
         "overrides": []
       },
@@ -2571,9 +3640,9 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 88
+        "y": 138
       },
-      "id": 34,
+      "id": 48,
       "options": {
         "legend": {
           "calcs": [],
@@ -2589,196 +3658,11 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "sum(rate(poracle_alerter_geocode_seconds_sum{job=~\"$alerter_job\",instance=~\"$alerter_instance\"}[$__rate_interval])) / clamp_min(sum(rate(poracle_alerter_geocode_seconds_count{job=~\"$alerter_job\",instance=~\"$alerter_instance\"}[$__rate_interval])), 0.001)",
-          "legendFormat": "avg"
-        },
-        {
-          "refId": "B",
-          "expr": "histogram_quantile(0.95, sum by(le) (rate(poracle_alerter_geocode_seconds_bucket{job=~\"$alerter_job\",instance=~\"$alerter_instance\"}[$__rate_interval])))",
-          "legendFormat": "p95"
+          "expr": "poracle_processor_state_last_reload_success_timestamp{job=~\"$processor_job\",instance=~\"$processor_instance\"} * 1000",
+          "legendFormat": "{{instance}}"
         }
       ],
-      "title": "Alerter Geocode Latency",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 12,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 2,
-            "pointSize": 4,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": true,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "decimals": 2,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 96
-      },
-      "id": 35,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "expr": "sum by(result) (rate(poracle_alerter_tile_total{job=~\"$alerter_job\",instance=~\"$alerter_instance\"}[$__rate_interval]))",
-          "legendFormat": "{{result}}"
-        },
-        {
-          "refId": "B",
-          "expr": "sum(poracle_alerter_tile_in_flight{job=~\"$alerter_job\",instance=~\"$alerter_instance\"})",
-          "legendFormat": "in flight"
-        }
-      ],
-      "title": "Alerter Tile Outcomes and In Flight",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 12,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 2,
-            "pointSize": 4,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": true,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "decimals": 2,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "s"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 96
-      },
-      "id": 36,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "expr": "sum(rate(poracle_alerter_tile_seconds_sum{job=~\"$alerter_job\",instance=~\"$alerter_instance\"}[$__rate_interval])) / clamp_min(sum(rate(poracle_alerter_tile_seconds_count{job=~\"$alerter_job\",instance=~\"$alerter_instance\"}[$__rate_interval])), 0.001)",
-          "legendFormat": "avg"
-        },
-        {
-          "refId": "B",
-          "expr": "histogram_quantile(0.95, sum by(le) (rate(poracle_alerter_tile_seconds_bucket{job=~\"$alerter_job\",instance=~\"$alerter_instance\"}[$__rate_interval])))",
-          "legendFormat": "p95"
-        }
-      ],
-      "title": "Alerter Tile Latency",
+      "title": "Last Successful Reload",
       "type": "timeseries"
     },
     {
@@ -2787,9 +3671,9 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 104
+        "y": 146
       },
-      "id": 37,
+      "id": 49,
       "panels": [],
       "title": "Runtime and Process Health",
       "type": "row"
@@ -2854,9 +3738,9 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 105
+        "y": 147
       },
-      "id": 38,
+      "id": 50,
       "options": {
         "legend": {
           "calcs": [],
@@ -2954,9 +3838,9 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 105
+        "y": 147
       },
-      "id": 39,
+      "id": 51,
       "options": {
         "legend": {
           "calcs": [],
@@ -3044,9 +3928,9 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 113
+        "y": 155
       },
-      "id": 40,
+      "id": 52,
       "options": {
         "legend": {
           "calcs": [],
@@ -3134,9 +4018,9 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 113
+        "y": 155
       },
-      "id": 41,
+      "id": 53,
       "options": {
         "legend": {
           "calcs": [],
@@ -3229,9 +4113,9 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 121
+        "y": 163
       },
-      "id": 42,
+      "id": 54,
       "options": {
         "legend": {
           "calcs": [],
@@ -3314,9 +4198,9 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 121
+        "y": 163
       },
-      "id": 43,
+      "id": 55,
       "options": {
         "legend": {
           "calcs": [],
@@ -3409,9 +4293,9 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 129
+        "y": 171
       },
-      "id": 44,
+      "id": 56,
       "options": {
         "legend": {
           "calcs": [],
@@ -3499,9 +4383,9 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 129
+        "y": 171
       },
-      "id": 45,
+      "id": 57,
       "options": {
         "legend": {
           "calcs": [],
@@ -3600,14 +4484,14 @@
           "type": "prometheus",
           "uid": "${DS_PROMETHEUS}"
         },
-        "definition": "label_values(poracle_alerter_matched_queue_depth, job)",
+        "definition": "label_values(process_resident_memory_bytes{job!~\"$processor_job\"}, job)",
         "hide": 0,
         "includeAll": true,
         "label": "Alerter job",
         "multi": true,
         "name": "alerter_job",
         "options": [],
-        "query": "label_values(poracle_alerter_matched_queue_depth, job)",
+        "query": "label_values(process_resident_memory_bytes{job!~\"$processor_job\"}, job)",
         "refresh": 1,
         "sort": 1,
         "type": "query"
@@ -3624,14 +4508,14 @@
           "type": "prometheus",
           "uid": "${DS_PROMETHEUS}"
         },
-        "definition": "label_values(poracle_alerter_matched_queue_depth{job=~\"$alerter_job\"}, instance)",
+        "definition": "label_values(process_resident_memory_bytes{job=~\"$alerter_job\"}, instance)",
         "hide": 0,
         "includeAll": true,
         "label": "Alerter instance",
         "multi": true,
         "name": "alerter_instance",
         "options": [],
-        "query": "label_values(poracle_alerter_matched_queue_depth{job=~\"$alerter_job\"}, instance)",
+        "query": "label_values(process_resident_memory_bytes{job=~\"$alerter_job\"}, instance)",
         "refresh": 2,
         "sort": 1,
         "type": "query"
@@ -3646,6 +4530,6 @@
   "timezone": "browser",
   "title": "PoracleNG Observability",
   "uid": "poracleng-observability",
-  "version": 2,
+  "version": 3,
   "weekStart": ""
 }

--- a/monitoring/grafana/poracle-operations-lite-dashboard.json
+++ b/monitoring/grafana/poracle-operations-lite-dashboard.json
@@ -351,11 +351,11 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "sum(rate(poracle_alerter_messages_sent_total{job=~\"$alerter_job\",instance=~\"$alerter_instance\"}[$__rate_interval]))",
+          "expr": "sum(rate(poracle_delivery_total{job=~\"$processor_job\",instance=~\"$processor_instance\"}[$__rate_interval]))",
           "legendFormat": ""
         }
       ],
-      "title": "Messages Sent/s",
+      "title": "Delivered/s",
       "type": "stat"
     },
     {
@@ -415,7 +415,7 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "100 * sum(rate(poracle_alerter_messages_failed_total{job=~\"$alerter_job\",instance=~\"$alerter_instance\"}[$__rate_interval])) / clamp_min(sum(rate(poracle_alerter_messages_sent_total{job=~\"$alerter_job\",instance=~\"$alerter_instance\"}[$__rate_interval])) + sum(rate(poracle_alerter_messages_failed_total{job=~\"$alerter_job\",instance=~\"$alerter_instance\"}[$__rate_interval])), 0.001)",
+          "expr": "100 * sum(rate(poracle_delivery_total{status!=\"ok\",job=~\"$processor_job\",instance=~\"$processor_instance\"}[$__rate_interval])) / clamp_min(sum(rate(poracle_delivery_total{job=~\"$processor_job\",instance=~\"$processor_instance\"}[$__rate_interval])), 0.001)",
           "legendFormat": ""
         }
       ],
@@ -504,10 +504,18 @@
               {
                 "color": "green",
                 "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 70
+              },
+              {
+                "color": "red",
+                "value": 90
               }
             ]
           },
-          "unit": "ops"
+          "unit": "percent"
         },
         "overrides": []
       },
@@ -535,11 +543,11 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "sum(rate(poracle_alerter_backpressure_events_total{job=~\"$alerter_job\",instance=~\"$alerter_instance\"}[$__rate_interval]))",
+          "expr": "100 * sum(poracle_render_queue_depth{job=~\"$processor_job\",instance=~\"$processor_instance\"}) / clamp_min(sum(poracle_render_queue_capacity{job=~\"$processor_job\",instance=~\"$processor_instance\"}), 1)",
           "legendFormat": ""
         }
       ],
-      "title": "Backpressure/s",
+      "title": "Render Queue %",
       "type": "stat"
     },
     {
@@ -642,7 +650,7 @@
           "legendFormat": "matched users {{type}}"
         }
       ],
-      "title": "Processor Intake and Match Rate",
+      "title": "Intake and Match Rate",
       "type": "timeseries"
     },
     {
@@ -728,8 +736,8 @@
         },
         {
           "refId": "B",
-          "expr": "sum(poracle_processor_sender_queue_depth{job=~\"$processor_job\",instance=~\"$processor_instance\"})",
-          "legendFormat": "sender queue"
+          "expr": "sum(poracle_render_queue_depth{job=~\"$processor_job\",instance=~\"$processor_instance\"})",
+          "legendFormat": "render queue"
         },
         {
           "refId": "C",
@@ -737,7 +745,7 @@
           "legendFormat": "workers in use"
         }
       ],
-      "title": "Processor Latency and Pressure",
+      "title": "Processing Latency and Pressure",
       "type": "timeseries"
     },
     {
@@ -818,31 +826,26 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "sum(poracle_alerter_matched_queue_depth{job=~\"$alerter_job\",instance=~\"$alerter_instance\"})",
-          "legendFormat": "matched"
+          "expr": "sum(poracle_delivery_queue_depth{job=~\"$processor_job\",instance=~\"$processor_instance\"})",
+          "legendFormat": "total"
         },
         {
           "refId": "B",
-          "expr": "sum(poracle_alerter_hook_queue_depth{job=~\"$alerter_job\",instance=~\"$alerter_instance\"})",
-          "legendFormat": "hook"
-        },
-        {
-          "refId": "C",
-          "expr": "sum(poracle_alerter_discord_queue_depth{job=~\"$alerter_job\",instance=~\"$alerter_instance\"})",
+          "expr": "sum(poracle_delivery_discord_queue_depth{job=~\"$processor_job\",instance=~\"$processor_instance\"})",
           "legendFormat": "discord"
         },
         {
-          "refId": "D",
-          "expr": "sum(poracle_alerter_discord_webhook_queue_depth{job=~\"$alerter_job\",instance=~\"$alerter_instance\"})",
+          "refId": "C",
+          "expr": "sum(poracle_delivery_webhook_queue_depth{job=~\"$processor_job\",instance=~\"$processor_instance\"})",
           "legendFormat": "discord webhook"
         },
         {
-          "refId": "E",
-          "expr": "sum(poracle_alerter_telegram_queue_depth{job=~\"$alerter_job\",instance=~\"$alerter_instance\"})",
+          "refId": "D",
+          "expr": "sum(poracle_delivery_telegram_queue_depth{job=~\"$processor_job\",instance=~\"$processor_instance\"})",
           "legendFormat": "telegram"
         }
       ],
-      "title": "Alerter Queues",
+      "title": "Delivery Queues",
       "type": "timeseries"
     },
     {
@@ -923,18 +926,18 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "sum by(destination_type) (rate(poracle_alerter_messages_sent_total{job=~\"$alerter_job\",instance=~\"$alerter_instance\"}[$__rate_interval]))",
-          "legendFormat": "sent {{destination_type}}"
+          "expr": "sum by(platform) (rate(poracle_delivery_total{status=\"ok\",job=~\"$processor_job\",instance=~\"$processor_instance\"}[$__rate_interval]))",
+          "legendFormat": "sent {{platform}}"
         },
         {
           "refId": "B",
-          "expr": "sum by(destination_type) (rate(poracle_alerter_messages_failed_total{job=~\"$alerter_job\",instance=~\"$alerter_instance\"}[$__rate_interval]))",
-          "legendFormat": "failed {{destination_type}}"
+          "expr": "sum by(platform) (rate(poracle_delivery_total{status!=\"ok\",job=~\"$processor_job\",instance=~\"$processor_instance\"}[$__rate_interval]))",
+          "legendFormat": "failed {{platform}}"
         },
         {
           "refId": "C",
-          "expr": "histogram_quantile(0.95, sum by(le) (rate(poracle_alerter_discord_webhook_delivery_seconds_bucket{job=~\"$alerter_job\",instance=~\"$alerter_instance\"}[$__rate_interval])))",
-          "legendFormat": "discord webhook p95"
+          "expr": "histogram_quantile(0.95, sum by(le, platform) (rate(poracle_delivery_duration_seconds_bucket{job=~\"$processor_job\",instance=~\"$processor_instance\"}[$__rate_interval])))",
+          "legendFormat": "{{platform}} p95"
         }
       ],
       "title": "Delivery Outcomes and Latency",
@@ -1019,22 +1022,17 @@
         {
           "refId": "A",
           "expr": "sum(rate(poracle_processor_rate_limit_dropped_total{job=~\"$processor_job\",instance=~\"$processor_instance\"}[$__rate_interval]))",
-          "legendFormat": "processor dropped"
+          "legendFormat": "alert rate limit dropped"
         },
         {
           "refId": "B",
           "expr": "sum(rate(poracle_processor_rate_limit_breaches_total{job=~\"$processor_job\",instance=~\"$processor_instance\"}[$__rate_interval]))",
-          "legendFormat": "processor breaches"
+          "legendFormat": "alert rate limit breaches"
         },
         {
           "refId": "C",
-          "expr": "sum by(source) (rate(poracle_alerter_discord_rate_limits_total{job=~\"$alerter_job\",instance=~\"$alerter_instance\"}[$__rate_interval]))",
-          "legendFormat": "discord {{source}}"
-        },
-        {
-          "refId": "D",
-          "expr": "sum(rate(poracle_alerter_telegram_rate_limits_total{job=~\"$alerter_job\",instance=~\"$alerter_instance\"}[$__rate_interval]))",
-          "legendFormat": "telegram"
+          "expr": "sum by(platform) (rate(poracle_delivery_rate_limited_total{job=~\"$processor_job\",instance=~\"$processor_instance\"}[$__rate_interval]))",
+          "legendFormat": "delivery rate limited {{platform}}"
         }
       ],
       "title": "Rate Limits and Drops",
@@ -1119,22 +1117,12 @@
         {
           "refId": "A",
           "expr": "sum by(result) (rate(poracle_processor_tile_total{job=~\"$processor_job\",instance=~\"$processor_instance\"}[$__rate_interval]))",
-          "legendFormat": "processor tile {{result}}"
+          "legendFormat": "tile {{result}}"
         },
         {
           "refId": "B",
           "expr": "sum by(result) (rate(poracle_processor_geocode_total{job=~\"$processor_job\",instance=~\"$processor_instance\"}[$__rate_interval]))",
-          "legendFormat": "processor geocode {{result}}"
-        },
-        {
-          "refId": "C",
-          "expr": "sum by(result) (rate(poracle_alerter_tile_total{job=~\"$alerter_job\",instance=~\"$alerter_instance\"}[$__rate_interval]))",
-          "legendFormat": "alerter tile {{result}}"
-        },
-        {
-          "refId": "D",
-          "expr": "sum by(result) (rate(poracle_alerter_geocode_total{job=~\"$alerter_job\",instance=~\"$alerter_instance\"}[$__rate_interval]))",
-          "legendFormat": "alerter geocode {{result}}"
+          "legendFormat": "geocode {{result}}"
         }
       ],
       "title": "Maps and Geocoding",
@@ -1404,14 +1392,14 @@
           "type": "prometheus",
           "uid": "${DS_PROMETHEUS}"
         },
-        "definition": "label_values(poracle_alerter_matched_queue_depth, job)",
+        "definition": "label_values(process_resident_memory_bytes{job!~\"$processor_job\"}, job)",
         "hide": 0,
         "includeAll": true,
         "label": "Alerter job",
         "multi": true,
         "name": "alerter_job",
         "options": [],
-        "query": "label_values(poracle_alerter_matched_queue_depth, job)",
+        "query": "label_values(process_resident_memory_bytes{job!~\"$processor_job\"}, job)",
         "refresh": 1,
         "sort": 1,
         "type": "query"
@@ -1428,14 +1416,14 @@
           "type": "prometheus",
           "uid": "${DS_PROMETHEUS}"
         },
-        "definition": "label_values(poracle_alerter_matched_queue_depth{job=~\"$alerter_job\"}, instance)",
+        "definition": "label_values(process_resident_memory_bytes{job=~\"$alerter_job\"}, instance)",
         "hide": 0,
         "includeAll": true,
         "label": "Alerter instance",
         "multi": true,
         "name": "alerter_instance",
         "options": [],
-        "query": "label_values(poracle_alerter_matched_queue_depth{job=~\"$alerter_job\"}, instance)",
+        "query": "label_values(process_resident_memory_bytes{job=~\"$alerter_job\"}, instance)",
         "refresh": 2,
         "sort": 1,
         "type": "query"
@@ -1450,6 +1438,6 @@
   "timezone": "browser",
   "title": "PoracleNG Operations Lite",
   "uid": "poracleng-ops-lite",
-  "version": 1,
+  "version": 2,
   "weekStart": ""
 }


### PR DESCRIPTION
## Summary
- Replace all `poracle_alerter_*` delivery/queue/geocode/tile metrics with processor-native `poracle_delivery_*` and `poracle_render_*` metrics
- Add new dashboard sections: Render Pipeline, Delivery (per-platform queues, outcomes, latency, in-flight, tracker), State & API (state size, reload breakdown, API request rate/latency, webhook batch size), circuit breakers, template rendering, shlink, uicons
- Add matching duration and enrichment duration panels to Processor Pipeline section
- Remove obsolete alerter sender/delivery/geocode/tile panels; retain alerter template vars for runtime/process health only
- Update both full observability and operations lite dashboards

## Test plan
- [x] Import `poracle-observability-dashboard.json` into Grafana and verify all panels render with live Prometheus data
- [x] Import `poracle-operations-lite-dashboard.json` and verify panels render
- [x] Confirm no "No data" on delivery, render, and state panels when processor is running
- [x] Verify alerter runtime panels (Node.js heap, event loop) still populate

🤖 Generated with [Claude Code](https://claude.com/claude-code)