### PR TITLE
Photon geocoder support + raymond-based address_format

### DIFF
--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -113,7 +113,29 @@ strict_locations = false
 timeformat = "en-gb"
 time = "LTS"
 date = "L"
-# address_format - how an address is constructed into the {{addr}} tag
+# address_format - Handlebars template used to build the {{addr}} tag from
+# the reverse-geocode result. Compiled once at startup; rendered per address.
+# Available fields (all providers):
+#   formattedAddress  - country-idiomatic string from OpenCage templates
+#   displayName       - the provider's own formatted string (Nominatim only)
+#   streetName, streetNumber, suburb, neighbourhood, city, town, village,
+#   county, state, zipcode, country, countryCode, flag
+#
+# Leaving this empty (or using "{{{formattedAddress}}}") renders the OpenCage
+# country-idiomatic default, which is usually what you want.
+#
+# Examples:
+#   address_format = "{{{streetName}}} {{streetNumber}}"
+#       Just the street line (current default for new installs).
+#   address_format = "{{{formattedAddress}}}"
+#       Full country-idiomatic address (e.g. "Unter den Linden 1, 10117 Berlin, Germany").
+#   address_format = "{{{displayName}}}"
+#       Nominatim's original display_name layout, for operators migrating from
+#       older PoracleJS installs who relied on that shape.
+#   address_format = "{{#if suburb}}{{suburb}}{{else}}{{city}}{{/if}}:{{#if streetName}} {{streetName}}{{#if streetNumber}} {{streetNumber}}{{/if}}{{/if}}{{#if suburb}}, {{city}}{{/if}}"
+#       Equivalent to the old Photon/PoracleJS compact format —
+#       "Mitte: Friedrichstrasse 42, Berlin" when suburb is present,
+#       "Springfield: Main Street 1" when only city is known.
 address_format = "{{{streetName}}} {{streetNumber}}"
 # language - secondary language used for 'alt' translation in DTS; useful for
 #   retrieving english language detail for web links

--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -136,7 +136,9 @@ date = "L"
 #       Equivalent to the old Photon/PoracleJS compact format —
 #       "Mitte: Friedrichstrasse 42, Berlin" when suburb is present,
 #       "Springfield: Main Street 1" when only city is known.
-address_format = "{{{streetName}}} {{streetNumber}}"
+#
+# Leave empty for the country-idiomatic default (recommended for new installs).
+address_format = ""
 # language - secondary language used for 'alt' translation in DTS; useful for
 #   retrieving english language detail for web links
 language = "en"

--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -298,10 +298,11 @@ register_on_start = false                # whether auto registration is attempte
 #   (https://github.com/komoot/photon), or 'google'
 provider = "none"
 provider_url = ""                               # nominatim or photon URL, e.g. "https://photon.example.com"
-# photon_address_format - how Photon builds formattedAddress:
-#   "opencage" (default) = country-specific formatting via OpenCage templates
-#   "compact"            = short "suburb: street, city" format
-#photon_address_format = "opencage"
+# formattedAddress is always populated using OpenCage country-specific
+# templates (https://github.com/OpenCageData/address-formatting). Use
+# address_format below to shape the final {{addr}} field — e.g. set it to
+# "{{{formattedAddress}}}" for the country-idiomatic string, or build your
+# own template like "{{{streetName}}} {{streetNumber}}, {{{city}}}".
 forward_only = false                     # when true, disable reverse geocoding lookup
 cache_detail = 3                         # decimal places of lon/lat for caching (3 or 4 for 100x more detail)
 # Styles for different times of day using tileservercache

--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -294,9 +294,14 @@ register_on_start = false                # whether auto registration is attempte
 
 [geocoding]
 # provider - address lookups: 'none', 'nominatim' (recommended, see
-#   https://github.com/mediagis/nominatim-docker) or 'google'
+#   https://github.com/mediagis/nominatim-docker), 'photon'
+#   (https://github.com/komoot/photon), or 'google'
 provider = "none"
-provider_url = ""
+provider_url = ""                               # nominatim or photon URL, e.g. "https://photon.example.com"
+# photon_address_format - how Photon builds formattedAddress:
+#   "opencage" (default) = country-specific formatting via OpenCage templates
+#   "compact"            = short "suburb: street, city" format
+#photon_address_format = "opencage"
 forward_only = false                     # when true, disable reverse geocoding lookup
 cache_detail = 3                         # decimal places of lon/lat for caching (3 or 4 for 100x more detail)
 # Styles for different times of day using tileservercache

--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -139,6 +139,11 @@ date = "L"
 #
 # Leave empty for the country-idiomatic default (recommended for new installs).
 address_format = ""
+# address_include_country controls whether the country name trails the
+# OpenCage-formatted {{{formattedAddress}}}. Defaults to false because most
+# operators serve a single country and the suffix is noise. Set true for
+# multi-country audiences.
+address_include_country = false
 # language - secondary language used for 'alt' translation in DTS; useful for
 #   retrieving english language detail for web links
 language = "en"

--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -121,23 +121,28 @@ date = "L"
 #   streetName, streetNumber, suburb, neighbourhood, city, town, village,
 #   county, state, zipcode, country, countryCode, flag
 #
-# Leaving this empty (or using "{{{formattedAddress}}}") renders the OpenCage
-# country-idiomatic default, which is usually what you want.
+# Helpers (in addition to every helper DTS templates have):
+#   {{coalesce a b c}}       - first non-empty argument
+#   {{compactAddress}}       - exact "Mitte: Friedrichstrasse 42, Berlin" /
+#                              "Springfield: Main Street 1" layout (the
+#                              PoracleJS/Photon compact format)
 #
 # Examples:
+#   address_format = ""
+#       Empty — skips template rendering entirely and uses the OpenCage
+#       country-idiomatic formattedAddress directly. Recommended default
+#       for new installs.
 #   address_format = "{{{streetName}}} {{streetNumber}}"
-#       Just the street line (current default for new installs).
+#       Just the street line (the previous shipped default).
 #   address_format = "{{{formattedAddress}}}"
-#       Full country-idiomatic address (e.g. "Unter den Linden 1, 10117 Berlin, Germany").
+#       Full country-idiomatic address (e.g. "Unter den Linden 1, 10117 Berlin").
 #   address_format = "{{{displayName}}}"
-#       Nominatim's original display_name layout, for operators migrating from
-#       older PoracleJS installs who relied on that shape.
-#   address_format = "{{#if suburb}}{{suburb}}{{else}}{{city}}{{/if}}:{{#if streetName}} {{streetName}}{{#if streetNumber}} {{streetNumber}}{{/if}}{{/if}}{{#if suburb}}, {{city}}{{/if}}"
-#       Equivalent to the old Photon/PoracleJS compact format —
+#       Nominatim's original display_name layout, for operators migrating
+#       from older PoracleJS installs who relied on that shape.
+#   address_format = "{{compactAddress}}"
+#       Exact equivalent of the PoracleJS/Photon compact format —
 #       "Mitte: Friedrichstrasse 42, Berlin" when suburb is present,
 #       "Springfield: Main Street 1" when only city is known.
-#
-# Leave empty for the country-idiomatic default (recommended for new installs).
 address_format = ""
 # address_include_country controls whether the country name trails the
 # OpenCage-formatted {{{formattedAddress}}}. Defaults to false because most

--- a/processor/cmd/processor/main.go
+++ b/processor/cmd/processor/main.go
@@ -1002,7 +1002,6 @@ func NewProcessorService(cfg *config.Config, stateMgr *state.Manager, database *
 			Provider:         cfg.Geocoding.Provider,
 			ProviderURL:      cfg.Geocoding.ProviderURL,
 			GeocodingKeys:    cfg.Geocoding.GeocodingKey,
-			PhotonAddrFormat: cfg.Geocoding.PhotonAddrFormat,
 			CacheDetail:      cfg.Geocoding.CacheDetail,
 			CachePath:        filepath.Join(cfg.BaseDir, "config", ".cache", "geocache"),
 			ForwardOnly:      cfg.Geocoding.ForwardOnly,

--- a/processor/cmd/processor/main.go
+++ b/processor/cmd/processor/main.go
@@ -1006,6 +1006,7 @@ func NewProcessorService(cfg *config.Config, stateMgr *state.Manager, database *
 			CachePath:        filepath.Join(cfg.BaseDir, "config", ".cache", "geocache"),
 			ForwardOnly:      cfg.Geocoding.ForwardOnly,
 			AddressFormat:    cfg.Locale.AddressFormat,
+			IncludeCountry:   cfg.Locale.AddressIncludeCountry,
 			Timeout:          cfg.Tuning.GeocodingTimeout,
 			FailureThreshold: cfg.Tuning.GeocodingFailureThreshold,
 			CooldownMs:       cfg.Tuning.GeocodingCooldownMs,

--- a/processor/cmd/processor/main.go
+++ b/processor/cmd/processor/main.go
@@ -1002,6 +1002,7 @@ func NewProcessorService(cfg *config.Config, stateMgr *state.Manager, database *
 			Provider:         cfg.Geocoding.Provider,
 			ProviderURL:      cfg.Geocoding.ProviderURL,
 			GeocodingKeys:    cfg.Geocoding.GeocodingKey,
+			PhotonAddrFormat: cfg.Geocoding.PhotonAddrFormat,
 			CacheDetail:      cfg.Geocoding.CacheDetail,
 			CachePath:        filepath.Join(cfg.BaseDir, "config", ".cache", "geocache"),
 			ForwardOnly:      cfg.Geocoding.ForwardOnly,

--- a/processor/go.mod
+++ b/processor/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/go-telegram-bot-api/telegram-bot-api/v5 v5.5.1
 	github.com/golang-migrate/migrate/v4 v4.19.1
 	github.com/golang/geo v0.0.0-20260302211937-87f5a40ea07a
+	github.com/google/uuid v1.6.0
 	github.com/guregu/null/v6 v6.0.0
 	github.com/jellydator/ttlcache/v3 v3.4.0
 	github.com/jmoiron/sqlx v1.4.0
@@ -22,6 +23,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/tidwall/rtree v1.10.0
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -40,7 +42,6 @@ require (
 	github.com/go-playground/validator/v10 v10.30.1 // indirect
 	github.com/goccy/go-json v0.10.5 // indirect
 	github.com/goccy/go-yaml v1.19.2 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
@@ -74,7 +75,6 @@ require (
 	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/text v0.34.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 replace github.com/mailgun/raymond/v2 => github.com/jfberry/raymond/v2 v2.0.49-0.20260406155408-23af5f270647

--- a/processor/internal/config/config.go
+++ b/processor/internal/config/config.go
@@ -134,14 +134,9 @@ type LocaleConfig struct {
 	TimeFormat    string `toml:"timeformat"`
 	Time          string `toml:"time"`
 	Date          string `toml:"date"`
-	AddressFormat string `toml:"address_format"`
-	// AddressIncludeCountry controls whether the OpenCage-formatted
-	// FormattedAddress includes the country name. Defaults to false so
-	// {{addr}} reads as "Unter den Linden 1, 10117 Berlin" rather than
-	// the more verbose "…, Germany" — set true for audiences who aren't
-	// all in the same country.
-	AddressIncludeCountry bool   `toml:"address_include_country"`
-	Language              string `toml:"language"` // alt language for DTS helpers (pokemonNameAlt, moveNameAlt, etc.) — default "en"
+	AddressFormat         string `toml:"address_format"`
+	AddressIncludeCountry bool   `toml:"address_include_country"` // see config.example.toml for defaults/rationale
+	Language              string `toml:"language"`                // alt language for DTS helpers — default "en"
 }
 
 type LoggingConfig struct {

--- a/processor/internal/config/config.go
+++ b/processor/internal/config/config.go
@@ -480,9 +480,10 @@ type WebhookLoggingConfig struct {
 // and address geocoding.
 type GeocodingConfig struct {
 	// Address geocoding provider
-	Provider     string   `toml:"provider"`      // "none", "nominatim", "google"
-	ProviderURL  string   `toml:"provider_url"`  // nominatim URL
-	GeocodingKey []string `toml:"geocoding_key"` // google API keys
+	Provider         string   `toml:"provider"`              // "none", "nominatim", "photon", "google"
+	ProviderURL      string   `toml:"provider_url"`          // nominatim/photon URL
+	GeocodingKey     []string `toml:"geocoding_key"`         // google API keys
+	PhotonAddrFormat string   `toml:"photon_address_format"` // "opencage" (default) or "compact"
 	CacheDetail  int      `toml:"cache_detail"`  // decimal places for cache key rounding (default 3)
 	ForwardOnly  bool     `toml:"forward_only"`  // if true, skip reverse geocoding
 

--- a/processor/internal/config/config.go
+++ b/processor/internal/config/config.go
@@ -613,11 +613,14 @@ func Load(baseDir string) (*Config, error) {
 			UltraRare:           0.01,
 		},
 		Locale: LocaleConfig{
-			TimeFormat:    "en-gb",
-			Time:          "LTS",
-			Date:          "L",
-			Language:      "en",
-			AddressFormat: "{{{streetName}}} {{streetNumber}}",
+			TimeFormat: "en-gb",
+			Time:       "LTS",
+			Date:       "L",
+			Language:   "en",
+			// AddressFormat left empty so {{addr}} gets the OpenCage-formatted
+			// FormattedAddress straight from the provider — the country-
+			// idiomatic default is what most operators want. Operators who
+			// need a specific shape override in config.toml.
 		},
 		Weather: WeatherConfig{
 			ShowAlteredPokemonMaxCount: 10,

--- a/processor/internal/config/config.go
+++ b/processor/internal/config/config.go
@@ -135,7 +135,13 @@ type LocaleConfig struct {
 	Time          string `toml:"time"`
 	Date          string `toml:"date"`
 	AddressFormat string `toml:"address_format"`
-	Language      string `toml:"language"` // alt language for DTS helpers (pokemonNameAlt, moveNameAlt, etc.) — default "en"
+	// AddressIncludeCountry controls whether the OpenCage-formatted
+	// FormattedAddress includes the country name. Defaults to false so
+	// {{addr}} reads as "Unter den Linden 1, 10117 Berlin" rather than
+	// the more verbose "…, Germany" — set true for audiences who aren't
+	// all in the same country.
+	AddressIncludeCountry bool   `toml:"address_include_country"`
+	Language              string `toml:"language"` // alt language for DTS helpers (pokemonNameAlt, moveNameAlt, etc.) — default "en"
 }
 
 type LoggingConfig struct {

--- a/processor/internal/config/config.go
+++ b/processor/internal/config/config.go
@@ -480,10 +480,9 @@ type WebhookLoggingConfig struct {
 // and address geocoding.
 type GeocodingConfig struct {
 	// Address geocoding provider
-	Provider         string   `toml:"provider"`              // "none", "nominatim", "photon", "google"
-	ProviderURL      string   `toml:"provider_url"`          // nominatim/photon URL
-	GeocodingKey     []string `toml:"geocoding_key"`         // google API keys
-	PhotonAddrFormat string   `toml:"photon_address_format"` // "opencage" (default) or "compact"
+	Provider     string   `toml:"provider"`      // "none", "nominatim", "photon", "google"
+	ProviderURL  string   `toml:"provider_url"`  // nominatim/photon URL
+	GeocodingKey []string `toml:"geocoding_key"` // google API keys
 	CacheDetail  int      `toml:"cache_detail"`  // decimal places for cache key rounding (default 3)
 	ForwardOnly  bool     `toml:"forward_only"`  // if true, skip reverse geocoding
 

--- a/processor/internal/enrichment/enrichment.go
+++ b/processor/internal/enrichment/enrichment.go
@@ -157,6 +157,7 @@ func (e *Enricher) addGeoResult(m map[string]any, lat, lon float64) {
 	m["streetNumber"] = addr.StreetNumber
 	m["city"] = addr.City
 	m["state"] = addr.State
+	m["county"] = addr.County
 	m["zipcode"] = addr.Zipcode
 	m["country"] = addr.Country
 	m["countryCode"] = addr.CountryCode

--- a/processor/internal/geocoding/address.go
+++ b/processor/internal/geocoding/address.go
@@ -1,44 +1,74 @@
 package geocoding
 
 import (
+	"fmt"
 	"strings"
+
+	"github.com/mailgun/raymond/v2"
 )
 
-// FormatAddress applies a simple template to an Address, replacing
-// {{fieldName}} placeholders with the corresponding field value.
-// This matches the alerter's Handlebars addressFormat behaviour.
-func FormatAddress(tmpl string, addr Address) string {
-	if tmpl == "" {
+// AddressTemplate is a pre-compiled address_format template. Compile once at
+// Geocoder construction; execute per address — parsing on every call would
+// re-allocate the Handlebars AST for what is typically a short static string.
+type AddressTemplate struct {
+	tmpl *raymond.Template
+}
+
+// CompileAddressTemplate parses the user-supplied address_format string. An
+// empty template is valid — the caller should treat it as "fall back to
+// FormattedAddress" rather than render anything. A parse error is surfaced
+// so the operator can fix their config; the caller should log+skip so the
+// processor starts with an unusable template rather than crash.
+func CompileAddressTemplate(src string) (*AddressTemplate, error) {
+	src = strings.TrimSpace(src)
+	if src == "" {
+		return nil, nil
+	}
+	t, err := raymond.Parse(src)
+	if err != nil {
+		return nil, fmt.Errorf("address_format: %w", err)
+	}
+	return &AddressTemplate{tmpl: t}, nil
+}
+
+// Render executes the compiled template against the Address's fields. If the
+// template is nil (i.e. operator left address_format empty), returns the
+// address's FormattedAddress so the default behaviour is "use the country-
+// idiomatic string from the provider".
+func (t *AddressTemplate) Render(addr Address) string {
+	if t == nil || t.tmpl == nil {
 		return addr.FormattedAddress
 	}
+	result, err := t.tmpl.Exec(addressFields(addr))
+	if err != nil {
+		// Runtime error means the template compiled but blew up against the
+		// data (unlikely once Parse succeeded). Fall back to the OpenCage
+		// string so operators don't see an empty addr in production.
+		return addr.FormattedAddress
+	}
+	return strings.TrimSpace(result)
+}
 
-	fields := map[string]string{
+// addressFields returns the Address's fields as a map keyed by the names
+// operators use in their address_format templates.
+func addressFields(addr Address) map[string]string {
+	return map[string]string{
 		"formattedAddress": addr.FormattedAddress,
+		"displayName":      addr.DisplayName,
 		"country":          addr.Country,
 		"countryCode":      addr.CountryCode,
 		"state":            addr.State,
+		"county":           addr.County,
 		"city":             addr.City,
 		"zipcode":          addr.Zipcode,
 		"streetName":       addr.StreetName,
 		"streetNumber":     addr.StreetNumber,
 		"neighbourhood":    addr.Neighbourhood,
-		"county":           addr.County,
 		"suburb":           addr.Suburb,
 		"town":             addr.Town,
 		"village":          addr.Village,
 		"flag":             addr.Flag,
 	}
-
-	result := tmpl
-	// Replace triple-braces FIRST to avoid partial matches
-	// (e.g., {{{streetName}}} must not become {value} from {{streetName}} match)
-	for field, value := range fields {
-		result = strings.ReplaceAll(result, "{{{"+field+"}}}", value)
-	}
-	for field, value := range fields {
-		result = strings.ReplaceAll(result, "{{"+field+"}}", value)
-	}
-	return strings.TrimSpace(result)
 }
 
 // CountryFlag returns the flag emoji for a two-letter country code.
@@ -61,6 +91,7 @@ func EscapeAddress(addr *Address) {
 	addr.StreetNumber = escapeString(addr.StreetNumber)
 	addr.Addr = escapeString(addr.Addr)
 	addr.FormattedAddress = escapeString(addr.FormattedAddress)
+	addr.DisplayName = escapeString(addr.DisplayName)
 	addr.City = escapeString(addr.City)
 	addr.State = escapeString(addr.State)
 	addr.Country = escapeString(addr.Country)

--- a/processor/internal/geocoding/address.go
+++ b/processor/internal/geocoding/address.go
@@ -22,6 +22,7 @@ func FormatAddress(tmpl string, addr Address) string {
 		"streetName":       addr.StreetName,
 		"streetNumber":     addr.StreetNumber,
 		"neighbourhood":    addr.Neighbourhood,
+		"county":           addr.County,
 		"suburb":           addr.Suburb,
 		"town":             addr.Town,
 		"village":          addr.Village,
@@ -64,10 +65,70 @@ func EscapeAddress(addr *Address) {
 	addr.State = escapeString(addr.State)
 	addr.Country = escapeString(addr.Country)
 	addr.Neighbourhood = escapeString(addr.Neighbourhood)
+	addr.County = escapeString(addr.County)
 	addr.Suburb = escapeString(addr.Suburb)
 	addr.Town = escapeString(addr.Town)
 	addr.Village = escapeString(addr.Village)
 	addr.Zipcode = escapeString(addr.Zipcode)
+}
+
+// FormatCompactAddress builds a compact formatted address string from an Address.
+//
+// It follows the Photon compact logic used in PoracleJS/Python migration:
+// - Start with suburb
+// - If suburb is missing and city exists, start with city
+// - Add street (optionally with house number)
+// - Add city when it is not already part of the result
+// - Add a colon after the first context part
+// - If still empty, fall back to splitting FormattedAddress into words
+func FormatCompactAddress(addr Address) string {
+	var parts []string
+	if addr.Suburb != "" {
+		parts = append(parts, addr.Suburb)
+	}
+
+	if addr.Suburb == "" && addr.City != "" {
+		parts = append(parts, addr.City)
+	}
+
+	colonsAt := len(parts) - 1
+
+	street := strings.TrimSpace(addr.StreetName)
+	if street != "" {
+		if addr.StreetNumber != "" {
+			street += " " + strings.TrimSpace(addr.StreetNumber)
+		}
+		parts = append(parts, street)
+	}
+
+	if addr.City != "" && !containsString(parts, addr.City) {
+		if street != "" && len(parts) > 0 {
+			parts[len(parts)-1] += ","
+		}
+		parts = append(parts, addr.City)
+	}
+
+	if colonsAt >= 0 && colonsAt < len(parts) {
+		parts[colonsAt] += ":"
+	}
+
+	if len(parts) == 0 && strings.TrimSpace(addr.FormattedAddress) != "" {
+		parts = strings.Fields(addr.FormattedAddress)
+	}
+
+	return strings.Join(parts, " ")
+}
+
+// containsString checks if a string slice contains a given string.
+func containsString(ss []string, s string) bool {
+	for _, v := range ss {
+		// Strip trailing punctuation for comparison
+		clean := strings.TrimRight(v, ":,")
+		if clean == s {
+			return true
+		}
+	}
+	return false
 }
 
 func escapeString(s string) string {

--- a/processor/internal/geocoding/address.go
+++ b/processor/internal/geocoding/address.go
@@ -19,11 +19,15 @@ type AddressTemplate struct {
 // FormattedAddress" rather than render anything. A parse error is surfaced
 // so the operator can fix their config; the caller should log+skip so the
 // processor starts with an unusable template rather than crash.
+//
+// Address helpers ({{coalesce}}, {{compactAddress}}) are registered lazily
+// on first call so operators don't need to worry about init order.
 func CompileAddressTemplate(src string) (*AddressTemplate, error) {
 	src = strings.TrimSpace(src)
 	if src == "" {
 		return nil, nil
 	}
+	registerAddressHelpers()
 	t, err := raymond.Parse(src)
 	if err != nil {
 		return nil, fmt.Errorf("address_format: %w", err)

--- a/processor/internal/geocoding/address.go
+++ b/processor/internal/geocoding/address.go
@@ -72,65 +72,6 @@ func EscapeAddress(addr *Address) {
 	addr.Zipcode = escapeString(addr.Zipcode)
 }
 
-// FormatCompactAddress builds a compact formatted address string from an Address.
-//
-// It follows the Photon compact logic used in PoracleJS/Python migration:
-// - Start with suburb
-// - If suburb is missing and city exists, start with city
-// - Add street (optionally with house number)
-// - Add city when it is not already part of the result
-// - Add a colon after the first context part
-// - If still empty, fall back to splitting FormattedAddress into words
-func FormatCompactAddress(addr Address) string {
-	var parts []string
-	if addr.Suburb != "" {
-		parts = append(parts, addr.Suburb)
-	}
-
-	if addr.Suburb == "" && addr.City != "" {
-		parts = append(parts, addr.City)
-	}
-
-	colonsAt := len(parts) - 1
-
-	street := strings.TrimSpace(addr.StreetName)
-	if street != "" {
-		if addr.StreetNumber != "" {
-			street += " " + strings.TrimSpace(addr.StreetNumber)
-		}
-		parts = append(parts, street)
-	}
-
-	if addr.City != "" && !containsString(parts, addr.City) {
-		if street != "" && len(parts) > 0 {
-			parts[len(parts)-1] += ","
-		}
-		parts = append(parts, addr.City)
-	}
-
-	if colonsAt >= 0 && colonsAt < len(parts) {
-		parts[colonsAt] += ":"
-	}
-
-	if len(parts) == 0 && strings.TrimSpace(addr.FormattedAddress) != "" {
-		parts = strings.Fields(addr.FormattedAddress)
-	}
-
-	return strings.Join(parts, " ")
-}
-
-// containsString checks if a string slice contains a given string.
-func containsString(ss []string, s string) bool {
-	for _, v := range ss {
-		// Strip trailing punctuation for comparison
-		clean := strings.TrimRight(v, ":,")
-		if clean == s {
-			return true
-		}
-	}
-	return false
-}
-
 func escapeString(s string) string {
 	if s == "" {
 		return s

--- a/processor/internal/geocoding/address.go
+++ b/processor/internal/geocoding/address.go
@@ -7,21 +7,16 @@ import (
 	"github.com/mailgun/raymond/v2"
 )
 
-// AddressTemplate is a pre-compiled address_format template. Compile once at
-// Geocoder construction; execute per address — parsing on every call would
-// re-allocate the Handlebars AST for what is typically a short static string.
+// AddressTemplate wraps a pre-compiled Handlebars template so we parse
+// address_format once at Geocoder construction rather than per render.
 type AddressTemplate struct {
 	tmpl *raymond.Template
 }
 
-// CompileAddressTemplate parses the user-supplied address_format string. An
-// empty template is valid — the caller should treat it as "fall back to
-// FormattedAddress" rather than render anything. A parse error is surfaced
-// so the operator can fix their config; the caller should log+skip so the
-// processor starts with an unusable template rather than crash.
-//
-// Address helpers ({{coalesce}}, {{compactAddress}}) are registered lazily
-// on first call so operators don't need to worry about init order.
+// CompileAddressTemplate parses the user-supplied address_format. An empty
+// src returns a nil template — Render then falls back to FormattedAddress.
+// Address helpers ({{coalesce}}, {{compactAddress}}) register lazily here
+// so init order doesn't matter.
 func CompileAddressTemplate(src string) (*AddressTemplate, error) {
 	src = strings.TrimSpace(src)
 	if src == "" {
@@ -35,26 +30,22 @@ func CompileAddressTemplate(src string) (*AddressTemplate, error) {
 	return &AddressTemplate{tmpl: t}, nil
 }
 
-// Render executes the compiled template against the Address's fields. If the
-// template is nil (i.e. operator left address_format empty), returns the
-// address's FormattedAddress so the default behaviour is "use the country-
-// idiomatic string from the provider".
+// Render executes the compiled template against addr's fields, falling back
+// to addr.FormattedAddress for empty/nil template and for runtime errors
+// (so operators don't see an empty addr if a template blows up in prod).
 func (t *AddressTemplate) Render(addr Address) string {
 	if t == nil || t.tmpl == nil {
 		return addr.FormattedAddress
 	}
 	result, err := t.tmpl.Exec(addressFields(addr))
 	if err != nil {
-		// Runtime error means the template compiled but blew up against the
-		// data (unlikely once Parse succeeded). Fall back to the OpenCage
-		// string so operators don't see an empty addr in production.
 		return addr.FormattedAddress
 	}
 	return strings.TrimSpace(result)
 }
 
-// addressFields returns the Address's fields as a map keyed by the names
-// operators use in their address_format templates.
+// addressFields exposes addr as the key/value pairs operators reference in
+// their templates. Kept in sync with the Address struct's json tags.
 func addressFields(addr Address) map[string]string {
 	return map[string]string{
 		"formattedAddress": addr.FormattedAddress,

--- a/processor/internal/geocoding/address.go
+++ b/processor/internal/geocoding/address.go
@@ -46,6 +46,8 @@ func (t *AddressTemplate) Render(addr Address) string {
 
 // addressFields exposes addr as the key/value pairs operators reference in
 // their templates. Kept in sync with the Address struct's json tags.
+// compactAddress is pre-computed here rather than being a helper — no
+// args, fixed output, no reason for the helper round-trip.
 func addressFields(addr Address) map[string]string {
 	return map[string]string{
 		"formattedAddress": addr.FormattedAddress,
@@ -63,6 +65,7 @@ func addressFields(addr Address) map[string]string {
 		"town":             addr.Town,
 		"village":          addr.Village,
 		"flag":             addr.Flag,
+		"compactAddress":   formatCompactAddress(addr),
 	}
 }
 

--- a/processor/internal/geocoding/address_test.go
+++ b/processor/internal/geocoding/address_test.go
@@ -1,0 +1,137 @@
+package geocoding
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestAddressTemplateEmpty — no template means "render the country-idiomatic
+// string the provider already built via ocfmt".
+func TestAddressTemplateEmpty(t *testing.T) {
+	tmpl, err := CompileAddressTemplate("")
+	if err != nil {
+		t.Fatalf("compile empty: %v", err)
+	}
+	addr := Address{FormattedAddress: "Unter den Linden 1, 10117 Berlin, Germany"}
+	if got := tmpl.Render(addr); got != addr.FormattedAddress {
+		t.Errorf("empty template should fall through to FormattedAddress; got %q", got)
+	}
+}
+
+// TestAddressTemplateSimpleSubstitution — legacy {{{field}}} template keeps
+// working unchanged after the raymond switch.
+func TestAddressTemplateSimpleSubstitution(t *testing.T) {
+	tmpl, err := CompileAddressTemplate("{{{streetName}}} {{streetNumber}}")
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	addr := Address{StreetName: "Unter den Linden", StreetNumber: "1"}
+	if got := tmpl.Render(addr); got != "Unter den Linden 1" {
+		t.Errorf("got %q, want %q", got, "Unter den Linden 1")
+	}
+}
+
+// TestAddressTemplateCompactEquivalent — reproducing the old
+// FormatCompactAddress behaviour with raymond's {{#if}} / {{#unless}}. This
+// is the canonical example we point operators at in config.example.toml.
+func TestAddressTemplateCompactEquivalent(t *testing.T) {
+	const src = `{{#if suburb}}{{suburb}}{{else}}{{city}}{{/if}}:{{#if streetName}} {{streetName}}{{#if streetNumber}} {{streetNumber}}{{/if}}{{/if}}{{#unless suburb}}{{else}}, {{city}}{{/unless}}`
+
+	tmpl, err := CompileAddressTemplate(src)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	cases := []struct {
+		name string
+		addr Address
+		want string
+	}{
+		{
+			name: "suburb street number city",
+			addr: Address{Suburb: "Mitte", StreetName: "Friedrichstrasse", StreetNumber: "42", City: "Berlin"},
+			want: "Mitte: Friedrichstrasse 42, Berlin",
+		},
+		{
+			name: "city fills in when no suburb",
+			addr: Address{StreetName: "Main Street", StreetNumber: "1", City: "Springfield"},
+			want: "Springfield: Main Street 1",
+		},
+		{
+			name: "city only — no street block",
+			addr: Address{City: "Munich"},
+			want: "Munich:",
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tmpl.Render(tt.addr); got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestAddressTemplateMissingFields — empty field references render as empty
+// string with raymond (standard Handlebars). Template stays valid.
+func TestAddressTemplateMissingFields(t *testing.T) {
+	tmpl, err := CompileAddressTemplate("{{streetName}} {{streetNumber}}")
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	// Neither field populated — template still renders (to whitespace).
+	got := tmpl.Render(Address{})
+	if strings.TrimSpace(got) != "" {
+		t.Errorf("expected empty rendering for empty address, got %q", got)
+	}
+}
+
+// TestAddressTemplateParseError surfaces a bad template as an error at
+// compile time (so the operator sees it in startup logs, not at first
+// render).
+func TestAddressTemplateParseError(t *testing.T) {
+	_, err := CompileAddressTemplate("{{#if suburb}}missing closing tag")
+	if err == nil {
+		t.Fatal("expected parse error for unclosed block")
+	}
+}
+
+// TestAddressTemplateFallbackOnRuntimeError — template that passes parse but
+// blows up at render falls back to FormattedAddress so production addresses
+// don't render as empty strings.
+func TestAddressTemplateFormattedAddressAccessible(t *testing.T) {
+	tmpl, err := CompileAddressTemplate("Prefix: {{{formattedAddress}}}")
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	addr := Address{FormattedAddress: "A, B, C"}
+	if got := tmpl.Render(addr); got != "Prefix: A, B, C" {
+		t.Errorf("got %q", got)
+	}
+}
+
+// TestAddressTemplateDisplayNameAccessible — operators who preferred
+// Nominatim's raw display_name can opt back in via {{{displayName}}}.
+func TestAddressTemplateDisplayNameAccessible(t *testing.T) {
+	tmpl, err := CompileAddressTemplate("{{{displayName}}}")
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	addr := Address{DisplayName: "Houses of Parliament, Westminster, London"}
+	if got := tmpl.Render(addr); got != addr.DisplayName {
+		t.Errorf("got %q, want %q", got, addr.DisplayName)
+	}
+}
+
+// TestCountryFlag guards the well-known flag mapping the alerter used so any
+// refactor of the unicode offsets doesn't silently change output.
+func TestCountryFlag(t *testing.T) {
+	if got := CountryFlag("GB"); got != "🇬🇧" {
+		t.Errorf("GB got %q", got)
+	}
+	if got := CountryFlag("US"); got != "🇺🇸" {
+		t.Errorf("US got %q", got)
+	}
+	if got := CountryFlag(""); got != "" {
+		t.Errorf("empty should be empty, got %q", got)
+	}
+}

--- a/processor/internal/geocoding/geocoder.go
+++ b/processor/internal/geocoding/geocoder.go
@@ -36,7 +36,8 @@ type Geocoder struct {
 	provider Provider
 	cache    *Cache
 	config   Config
-	sem      chan struct{} // concurrency limiter
+	addrTmpl *AddressTemplate // compiled once from config.AddressFormat
+	sem      chan struct{}    // concurrency limiter
 
 	// Circuit breaker state
 	consecutiveErrors   int
@@ -92,10 +93,19 @@ func New(config Config) (*Geocoder, error) {
 		}
 	}
 
+	// Compile the address_format template once so we don't re-parse on every
+	// lookup. A parse error is logged; rendering then falls back to
+	// FormattedAddress (what ocfmt produced per-provider).
+	addrTmpl, err := CompileAddressTemplate(config.AddressFormat)
+	if err != nil {
+		log.Warnf("Geocoder: %s — falling back to formattedAddress", err)
+	}
+
 	return &Geocoder{
 		provider: provider,
 		cache:    cache,
 		config:   config,
+		addrTmpl: addrTmpl,
 		sem:      make(chan struct{}, config.Concurrency),
 	}, nil
 }
@@ -179,9 +189,10 @@ func (g *Geocoder) GetAddress(lat, lon float64) *Address {
 	g.statTotalMs.Add(duration.Milliseconds())
 	metrics.GeocodeTotal.WithLabelValues("success").Inc()
 
-	// Add flag and formatted address
+	// Add flag and formatted address (template rendered via raymond so
+	// operators get {{#if}}/{{#unless}}/helpers for conditional layout).
 	addr.Flag = CountryFlag(addr.CountryCode)
-	addr.Addr = FormatAddress(g.config.AddressFormat, *addr)
+	addr.Addr = g.addrTmpl.Render(*addr)
 
 	log.Debugf("Geocode %.4f,%.4f → street=%q number=%q city=%q addr=%q (%dms)",
 		lat, lon, addr.StreetName, addr.StreetNumber, addr.City, addr.Addr, duration.Milliseconds())

--- a/processor/internal/geocoding/geocoder.go
+++ b/processor/internal/geocoding/geocoder.go
@@ -12,13 +12,12 @@ import (
 
 // Config holds all geocoder settings.
 type Config struct {
-	Provider         string   // "none", "nominatim", "photon", "google"
-	ProviderURL      string   // nominatim/photon URL
-	GeocodingKeys    []string // google API keys
-	PhotonAddrFormat string // "opencage" (default) or "compact"
-	CacheDetail      int    // decimal places for cache key rounding (default 3)
-	CachePath        string // pogreb database path
-	ForwardOnly      bool   // if true, skip reverse geocoding
+	Provider      string   // "none", "nominatim", "photon", "google"
+	ProviderURL   string   // nominatim/photon URL
+	GeocodingKeys []string // google API keys
+	CacheDetail   int      // decimal places for cache key rounding (default 3)
+	CachePath     string   // pogreb database path
+	ForwardOnly   bool     // if true, skip reverse geocoding
 	AddressFormat string   // template for addr field, e.g. "{{{streetName}}} {{streetNumber}}"
 	Timeout       int      // HTTP timeout in ms (default 5000)
 
@@ -76,7 +75,7 @@ func New(config Config) (*Geocoder, error) {
 	case "nominatim":
 		provider = NewNominatim(config.ProviderURL, timeout)
 	case "photon":
-		provider = NewPhoton(config.ProviderURL, timeout, config.PhotonAddrFormat == "compact")
+		provider = NewPhoton(config.ProviderURL, timeout)
 	case "google":
 		provider = NewGoogle(config.GeocodingKeys, timeout)
 	default:

--- a/processor/internal/geocoding/geocoder.go
+++ b/processor/internal/geocoding/geocoder.go
@@ -12,9 +12,10 @@ import (
 
 // Config holds all geocoder settings.
 type Config struct {
-	Provider      string   // "none", "nominatim", "google"
-	ProviderURL   string   // nominatim URL
-	GeocodingKeys []string // google API keys
+	Provider         string   // "none", "nominatim", "photon", "google"
+	ProviderURL      string   // nominatim/photon URL
+	GeocodingKeys    []string // google API keys
+	PhotonAddrFormat string   // "opencage" (default) or "compact"
 	CacheDetail   int      // decimal places for cache key rounding (default 3)
 	CachePath     string   // pogreb database path
 	ForwardOnly   bool     // if true, skip reverse geocoding
@@ -74,6 +75,8 @@ func New(config Config) (*Geocoder, error) {
 	switch config.Provider {
 	case "nominatim":
 		provider = NewNominatim(config.ProviderURL, timeout)
+	case "photon":
+		provider = NewPhoton(config.ProviderURL, timeout, config.PhotonAddrFormat == "compact")
 	case "google":
 		provider = NewGoogle(config.GeocodingKeys, timeout)
 	default:

--- a/processor/internal/geocoding/geocoder.go
+++ b/processor/internal/geocoding/geocoder.go
@@ -15,10 +15,10 @@ type Config struct {
 	Provider         string   // "none", "nominatim", "photon", "google"
 	ProviderURL      string   // nominatim/photon URL
 	GeocodingKeys    []string // google API keys
-	PhotonAddrFormat string   // "opencage" (default) or "compact"
-	CacheDetail   int      // decimal places for cache key rounding (default 3)
-	CachePath     string   // pogreb database path
-	ForwardOnly   bool     // if true, skip reverse geocoding
+	PhotonAddrFormat string // "opencage" (default) or "compact"
+	CacheDetail      int    // decimal places for cache key rounding (default 3)
+	CachePath        string // pogreb database path
+	ForwardOnly      bool   // if true, skip reverse geocoding
 	AddressFormat string   // template for addr field, e.g. "{{{streetName}}} {{streetNumber}}"
 	Timeout       int      // HTTP timeout in ms (default 5000)
 

--- a/processor/internal/geocoding/geocoder.go
+++ b/processor/internal/geocoding/geocoder.go
@@ -19,7 +19,11 @@ type Config struct {
 	CachePath     string   // pogreb database path
 	ForwardOnly   bool     // if true, skip reverse geocoding
 	AddressFormat string   // template for addr field, e.g. "{{{streetName}}} {{streetNumber}}"
-	Timeout       int      // HTTP timeout in ms (default 5000)
+	// IncludeCountry controls whether ocfmt renders the country name into
+	// FormattedAddress. Defaults to false — the country tends to be noise
+	// for single-country operator audiences.
+	IncludeCountry bool
+	Timeout        int // HTTP timeout in ms (default 5000)
 
 	// Circuit breaker
 	FailureThreshold int // consecutive errors before circuit opens (default 5)
@@ -74,9 +78,9 @@ func New(config Config) (*Geocoder, error) {
 	var provider Provider
 	switch config.Provider {
 	case "nominatim":
-		provider = NewNominatim(config.ProviderURL, timeout)
+		provider = NewNominatim(config.ProviderURL, timeout, config.IncludeCountry)
 	case "photon":
-		provider = NewPhoton(config.ProviderURL, timeout)
+		provider = NewPhoton(config.ProviderURL, timeout, config.IncludeCountry)
 	case "google":
 		provider = NewGoogle(config.GeocodingKeys, timeout)
 	default:

--- a/processor/internal/geocoding/geocoder.go
+++ b/processor/internal/geocoding/geocoder.go
@@ -97,9 +97,6 @@ func New(config Config) (*Geocoder, error) {
 		}
 	}
 
-	// Compile the address_format template once so we don't re-parse on every
-	// lookup. A parse error is logged; rendering then falls back to
-	// FormattedAddress (what ocfmt produced per-provider).
 	addrTmpl, err := CompileAddressTemplate(config.AddressFormat)
 	if err != nil {
 		log.Warnf("Geocoder: %s — falling back to formattedAddress", err)

--- a/processor/internal/geocoding/geocoding.go
+++ b/processor/internal/geocoding/geocoding.go
@@ -15,6 +15,7 @@ type Address struct {
 	StreetName       string  `json:"streetName"`
 	StreetNumber     string  `json:"streetNumber"`
 	Neighbourhood    string  `json:"neighbourhood"`
+	County           string  `json:"county"`
 	Suburb           string  `json:"suburb"`
 	Town             string  `json:"town"`
 	Village          string  `json:"village"`

--- a/processor/internal/geocoding/geocoding.go
+++ b/processor/internal/geocoding/geocoding.go
@@ -5,8 +5,16 @@
 package geocoding
 
 // Address holds reverse geocode result fields matching the alerter's format.
+//
+// FormattedAddress is populated by every provider using OpenCage country-
+// specific templates (via the ocfmt package), so it gives the same country-
+// idiomatic layout regardless of which provider is configured. DisplayName
+// carries the provider's own pre-formatted string when it has one — today
+// that's Nominatim's display_name — so users who preferred the original
+// Nominatim layout can set address_format = "{{{displayName}}}".
 type Address struct {
 	FormattedAddress string  `json:"formattedAddress"`
+	DisplayName      string  `json:"displayName"`
 	Country          string  `json:"country"`
 	CountryCode      string  `json:"countryCode"`
 	State            string  `json:"state"`

--- a/processor/internal/geocoding/helpers.go
+++ b/processor/internal/geocoding/helpers.go
@@ -1,0 +1,125 @@
+package geocoding
+
+import (
+	"strings"
+	"sync"
+
+	"github.com/mailgun/raymond/v2"
+)
+
+var helpersOnce sync.Once
+
+// registerAddressHelpers registers raymond helpers used by address_format
+// templates. Called lazily from CompileAddressTemplate so operators don't
+// need to know about init order; also means tests that touch address
+// templates pick up the helpers automatically.
+//
+// Registration is process-global (raymond's model). Safe to call multiple
+// times thanks to the once guard — re-registering the same helper name
+// panics in raymond.
+func registerAddressHelpers() {
+	helpersOnce.Do(func() {
+		// coalesce — return the first non-empty argument. Useful for
+		// "suburb, else city" style openers and similar fallback chains.
+		//
+		//   {{coalesce suburb city}}               → "Mitte" or "Berlin"
+		//   {{coalesce streetName road name}}      → whichever is set
+		raymond.RegisterHelper("coalesce", func(args ...any) string {
+			for _, a := range args {
+				if s, ok := a.(string); ok && strings.TrimSpace(s) != "" {
+					return s
+				}
+			}
+			return ""
+		})
+
+		// compactAddress — drop-in equivalent for PoracleJS/ccev's
+		// FormatCompactAddress. Operators migrating from that layout set
+		//   address_format = "{{compactAddress}}"
+		// and get the exact "Mitte: Friedrichstrasse 42, Berlin" shape,
+		// including the de-duplication of city when suburb == city and
+		// the all-empty-components fallback to FormattedAddress. Lives as
+		// a helper rather than a config knob so the spec stays in Go
+		// (testable) while the call site stays in the template where
+		// operators already customise.
+		raymond.RegisterHelper("compactAddress", func(options *raymond.Options) string {
+			addr := extractAddressFromContext(options)
+			return formatCompactAddress(addr)
+		})
+	})
+}
+
+// extractAddressFromContext reconstructs an Address from the per-field
+// string map that Render passes to Exec. Only the fields compactAddress
+// consults need to be populated — this keeps the helper independent of
+// Address struct layout changes elsewhere.
+func extractAddressFromContext(options *raymond.Options) Address {
+	field := func(name string) string {
+		v := options.Value(name)
+		if s, ok := v.(string); ok {
+			return s
+		}
+		return ""
+	}
+	return Address{
+		Suburb:           field("suburb"),
+		City:             field("city"),
+		StreetName:       field("streetName"),
+		StreetNumber:     field("streetNumber"),
+		FormattedAddress: field("formattedAddress"),
+	}
+}
+
+// formatCompactAddress builds the compact "suburb: street number, city"
+// layout from ccev's PR. Retained here as the implementation behind the
+// {{compactAddress}} raymond helper — operators who want this shape write
+// address_format = "{{compactAddress}}" rather than hand-authoring the
+// Handlebars equivalent (which runs into edge cases around suburb==city
+// and fully-empty components).
+func formatCompactAddress(addr Address) string {
+	var parts []string
+	if addr.Suburb != "" {
+		parts = append(parts, addr.Suburb)
+	}
+	if addr.Suburb == "" && addr.City != "" {
+		parts = append(parts, addr.City)
+	}
+	colonsAt := len(parts) - 1
+
+	street := strings.TrimSpace(addr.StreetName)
+	if street != "" {
+		if addr.StreetNumber != "" {
+			street += " " + strings.TrimSpace(addr.StreetNumber)
+		}
+		parts = append(parts, street)
+	}
+
+	if addr.City != "" && !compactContains(parts, addr.City) {
+		if street != "" && len(parts) > 0 {
+			parts[len(parts)-1] += ","
+		}
+		parts = append(parts, addr.City)
+	}
+
+	if colonsAt >= 0 && colonsAt < len(parts) {
+		parts[colonsAt] += ":"
+	}
+
+	if len(parts) == 0 && strings.TrimSpace(addr.FormattedAddress) != "" {
+		parts = strings.Fields(addr.FormattedAddress)
+	}
+
+	return strings.Join(parts, " ")
+}
+
+// compactContains returns true if `s` appears in the slice after stripping
+// any trailing punctuation (":" or ",") we may have already appended to a
+// previous element.
+func compactContains(ss []string, s string) bool {
+	for _, v := range ss {
+		if strings.TrimRight(v, ":,") == s {
+			return true
+		}
+	}
+	return false
+}

--- a/processor/internal/geocoding/helpers.go
+++ b/processor/internal/geocoding/helpers.go
@@ -9,21 +9,12 @@ import (
 
 var helpersOnce sync.Once
 
-// registerAddressHelpers registers raymond helpers used by address_format
-// templates. Called lazily from CompileAddressTemplate so operators don't
-// need to know about init order; also means tests that touch address
-// templates pick up the helpers automatically.
-//
-// Registration is process-global (raymond's model). Safe to call multiple
-// times thanks to the once guard — re-registering the same helper name
-// panics in raymond.
+// registerAddressHelpers registers the raymond helpers address_format
+// templates can use. Called lazily from CompileAddressTemplate; the once
+// guard protects against raymond's panic on re-registering the same name.
 func registerAddressHelpers() {
 	helpersOnce.Do(func() {
-		// coalesce — return the first non-empty argument. Useful for
-		// "suburb, else city" style openers and similar fallback chains.
-		//
-		//   {{coalesce suburb city}}               → "Mitte" or "Berlin"
-		//   {{coalesce streetName road name}}      → whichever is set
+		// {{coalesce a b c}} — first non-empty argument.
 		raymond.RegisterHelper("coalesce", func(args ...any) string {
 			for _, a := range args {
 				if s, ok := a.(string); ok && strings.TrimSpace(s) != "" {
@@ -33,26 +24,18 @@ func registerAddressHelpers() {
 			return ""
 		})
 
-		// compactAddress — drop-in equivalent for PoracleJS/ccev's
-		// FormatCompactAddress. Operators migrating from that layout set
-		//   address_format = "{{compactAddress}}"
-		// and get the exact "Mitte: Friedrichstrasse 42, Berlin" shape,
-		// including the de-duplication of city when suburb == city and
-		// the all-empty-components fallback to FormattedAddress. Lives as
-		// a helper rather than a config knob so the spec stays in Go
-		// (testable) while the call site stays in the template where
-		// operators already customise.
+		// {{compactAddress}} — PoracleJS-equivalent compact layout
+		// ("Mitte: Friedrichstrasse 42, Berlin"). Lives here rather
+		// than as a config flag so operators opt in via template.
 		raymond.RegisterHelper("compactAddress", func(options *raymond.Options) string {
-			addr := extractAddressFromContext(options)
-			return formatCompactAddress(addr)
+			return formatCompactAddress(extractAddressFromContext(options))
 		})
 	})
 }
 
-// extractAddressFromContext reconstructs an Address from the per-field
-// string map that Render passes to Exec. Only the fields compactAddress
-// consults need to be populated — this keeps the helper independent of
-// Address struct layout changes elsewhere.
+// extractAddressFromContext pulls the fields compactAddress needs out of
+// the raymond context. Kept deliberately minimal — only reads what the
+// helper uses, not the whole Address.
 func extractAddressFromContext(options *raymond.Options) Address {
 	field := func(name string) string {
 		v := options.Value(name)
@@ -70,12 +53,10 @@ func extractAddressFromContext(options *raymond.Options) Address {
 	}
 }
 
-// formatCompactAddress builds the compact "suburb: street number, city"
-// layout from ccev's PR. Retained here as the implementation behind the
-// {{compactAddress}} raymond helper — operators who want this shape write
-// address_format = "{{compactAddress}}" rather than hand-authoring the
-// Handlebars equivalent (which runs into edge cases around suburb==city
-// and fully-empty components).
+// formatCompactAddress — vendored from ccev's PR as the implementation
+// behind {{compactAddress}}. Handles the suburb==city dedup and the
+// all-empty-components fallback to FormattedAddress, which stock
+// Handlebars can't express cleanly.
 func formatCompactAddress(addr Address) string {
 	var parts []string
 	if addr.Suburb != "" {

--- a/processor/internal/geocoding/helpers.go
+++ b/processor/internal/geocoding/helpers.go
@@ -12,6 +12,10 @@ var helpersOnce sync.Once
 // registerAddressHelpers registers the raymond helpers address_format
 // templates can use. Called lazily from CompileAddressTemplate; the once
 // guard protects against raymond's panic on re-registering the same name.
+//
+// Only truly variadic helpers live here. Fixed-output helpers like
+// compactAddress get pre-computed by addressFields into a regular map
+// key instead — simpler, same cost, no helper-context round-trip.
 func registerAddressHelpers() {
 	helpersOnce.Do(func() {
 		// {{coalesce a b c}} — first non-empty argument.
@@ -23,40 +27,14 @@ func registerAddressHelpers() {
 			}
 			return ""
 		})
-
-		// {{compactAddress}} — PoracleJS-equivalent compact layout
-		// ("Mitte: Friedrichstrasse 42, Berlin"). Lives here rather
-		// than as a config flag so operators opt in via template.
-		raymond.RegisterHelper("compactAddress", func(options *raymond.Options) string {
-			return formatCompactAddress(extractAddressFromContext(options))
-		})
 	})
 }
 
-// extractAddressFromContext pulls the fields compactAddress needs out of
-// the raymond context. Kept deliberately minimal — only reads what the
-// helper uses, not the whole Address.
-func extractAddressFromContext(options *raymond.Options) Address {
-	field := func(name string) string {
-		v := options.Value(name)
-		if s, ok := v.(string); ok {
-			return s
-		}
-		return ""
-	}
-	return Address{
-		Suburb:           field("suburb"),
-		City:             field("city"),
-		StreetName:       field("streetName"),
-		StreetNumber:     field("streetNumber"),
-		FormattedAddress: field("formattedAddress"),
-	}
-}
-
-// formatCompactAddress — vendored from ccev's PR as the implementation
-// behind {{compactAddress}}. Handles the suburb==city dedup and the
-// all-empty-components fallback to FormattedAddress, which stock
-// Handlebars can't express cleanly.
+// formatCompactAddress — vendored from ccev's PR. Used by addressFields
+// to populate the "compactAddress" template key, so operators writing
+// address_format = "{{compactAddress}}" get the PoracleJS-equivalent
+// "Mitte: Friedrichstrasse 42, Berlin" layout. Handles suburb==city
+// dedup and the all-empty-components fallback to FormattedAddress.
 func formatCompactAddress(addr Address) string {
 	var parts []string
 	if addr.Suburb != "" {

--- a/processor/internal/geocoding/helpers_test.go
+++ b/processor/internal/geocoding/helpers_test.go
@@ -1,0 +1,109 @@
+package geocoding
+
+import "testing"
+
+// TestCoalesceOnlyApproaches — how close do we get to compactAddress with
+// only {{coalesce}} (no eq/ne/compactAddress helpers)? Documents which
+// edge cases stock Handlebars plus coalesce can't reach.
+func TestCoalesceOnlyApproaches(t *testing.T) {
+	// With conditional-colon guard via (coalesce …) in an #if.
+	const src = `{{#if (coalesce suburb city)}}{{coalesce suburb city}}:{{/if}}{{#if streetName}} {{streetName}}{{#if streetNumber}} {{streetNumber}}{{/if}}{{/if}}{{#if suburb}}{{#if city}}{{#if streetName}},{{/if}} {{city}}{{/if}}{{/if}}`
+
+	tmpl, err := CompileAddressTemplate(src)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+
+	cases := []struct {
+		name string
+		addr Address
+		want string
+	}{
+		{"full", Address{Suburb: "Mitte", StreetName: "F", StreetNumber: "42", City: "Berlin"}, "Mitte: F 42, Berlin"},
+		{"no suburb", Address{StreetName: "Main", StreetNumber: "1", City: "Springfield"}, "Springfield: Main 1"},
+		{"city only", Address{City: "Munich"}, "Munich:"},
+		{"suburb+city no street", Address{Suburb: "Mitte", City: "Berlin"}, "Mitte: Berlin"},
+		{"suburb only", Address{Suburb: "Mitte"}, "Mitte:"},
+		{"street only", Address{StreetName: "Main", StreetNumber: "1"}, "Main 1"},
+		{"nothing", Address{}, ""},
+		// These still diverge without eq or a FormattedAddress fallback:
+		{"suburb==city (DIVERGES)", Address{Suburb: "Berlin", City: "Berlin"}, "Berlin: Berlin"}, // Go: "Berlin:"
+		{"fall back (DIVERGES)", Address{FormattedAddress: "Somewhere"}, ""},                    // Go: "Somewhere"
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := tmpl.Render(c.addr)
+			if got != c.want {
+				t.Errorf("got %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+// TestCompactAddressHelperParity guards that {{compactAddress}} produces the
+// same output as the original PoracleJS/ccev FormatCompactAddress function
+// across every case we care about — including the edge cases a pure
+// Handlebars template struggles with (suburb==city de-dup, fully-empty
+// components falling back to FormattedAddress).
+func TestCompactAddressHelperParity(t *testing.T) {
+	tmpl, err := CompileAddressTemplate(`{{compactAddress}}`)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+
+	cases := []struct {
+		name string
+		addr Address
+		want string
+	}{
+		{"full: suburb + street + num + city", Address{Suburb: "Mitte", StreetName: "Friedrichstrasse", StreetNumber: "42", City: "Berlin"}, "Mitte: Friedrichstrasse 42, Berlin"},
+		{"no suburb, street + num + city", Address{StreetName: "Main Street", StreetNumber: "1", City: "Springfield"}, "Springfield: Main Street 1"},
+		{"city only", Address{City: "Munich"}, "Munich:"},
+		{"suburb + city, no street", Address{Suburb: "Mitte", City: "Berlin"}, "Mitte: Berlin"},
+		{"suburb == city (de-dup)", Address{Suburb: "Berlin", City: "Berlin"}, "Berlin:"},
+		{"suburb + city + street, no number", Address{Suburb: "Mitte", StreetName: "Friedrichstrasse", City: "Berlin"}, "Mitte: Friedrichstrasse, Berlin"},
+		{"suburb + street, no city", Address{Suburb: "Mitte", StreetName: "Main St"}, "Mitte: Main St"},
+		{"nothing", Address{}, ""},
+		{"street + number only", Address{StreetName: "Main St", StreetNumber: "1"}, "Main St 1"},
+		{"suburb only", Address{Suburb: "Mitte"}, "Mitte:"},
+		{"fall back to FormattedAddress when components empty", Address{FormattedAddress: "Somewhere Far Away"}, "Somewhere Far Away"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := tmpl.Render(c.addr)
+			if got != c.want {
+				t.Errorf("got %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+// TestCoalesceHelper — verifies the generic "first non-empty" helper works
+// in an address_format context. Useful for operators writing their own
+// templates: {{coalesce suburb city neighbourhood}} picks the best
+// available opener without a nested if/else cascade.
+func TestCoalesceHelper(t *testing.T) {
+	tmpl, err := CompileAddressTemplate(`{{coalesce suburb city}}:{{#if streetName}} {{streetName}}{{/if}}`)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+
+	cases := []struct {
+		addr Address
+		want string
+	}{
+		{Address{Suburb: "Mitte", City: "Berlin", StreetName: "X"}, "Mitte: X"},
+		{Address{City: "Berlin", StreetName: "X"}, "Berlin: X"},
+		{Address{Suburb: "Mitte"}, "Mitte:"},
+		{Address{}, ":"}, // coalesce returns empty, trailing ':' per literal
+	}
+
+	for _, c := range cases {
+		got := tmpl.Render(c.addr)
+		if got != c.want {
+			t.Errorf("addr=%+v: got %q want %q", c.addr, got, c.want)
+		}
+	}
+}

--- a/processor/internal/geocoding/nominatim.go
+++ b/processor/internal/geocoding/nominatim.go
@@ -19,17 +19,20 @@ const userAgent = "PoracleNG/1.0"
 
 // Nominatim implements Provider using the Nominatim API (OpenStreetMap).
 type Nominatim struct {
-	baseURL string
-	client  *http.Client
+	baseURL        string
+	includeCountry bool // render country into FormattedAddress via ocfmt
+	client         *http.Client
 }
 
-// NewNominatim creates a Nominatim provider.
-func NewNominatim(baseURL string, timeout time.Duration) *Nominatim {
+// NewNominatim creates a Nominatim provider. includeCountry controls whether
+// the OpenCage-formatted FormattedAddress trails with the country name.
+func NewNominatim(baseURL string, timeout time.Duration, includeCountry bool) *Nominatim {
 	if timeout == 0 {
 		timeout = 10 * time.Second
 	}
 	return &Nominatim{
-		baseURL: strings.TrimRight(baseURL, "/"),
+		baseURL:        strings.TrimRight(baseURL, "/"),
+		includeCountry: includeCountry,
 		client: &http.Client{
 			Timeout: timeout,
 		},
@@ -120,6 +123,9 @@ func (n *Nominatim) Reverse(lat, lon float64) (*Address, error) {
 	streetName := firstNonEmpty(result.Address.Road, result.Address.Quarter, result.Address.Cycleway)
 
 	components := nominatimToOCFMT(result.Address, streetName, city)
+	if !n.includeCountry {
+		delete(components, "country")
+	}
 	formatted := ocfmt.Global().Format(components)
 	if strings.TrimSpace(formatted) == "" {
 		// Fall back to Nominatim's own display_name if OpenCage can't produce

--- a/processor/internal/geocoding/nominatim.go
+++ b/processor/internal/geocoding/nominatim.go
@@ -9,6 +9,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/pokemon/poracleng/processor/internal/geocoding/ocfmt"
 )
 
 // userAgent identifies the application to Nominatim per their usage policy.
@@ -47,6 +49,7 @@ type nominatimAddress struct {
 	Country       string `json:"country"`
 	CountryCode   string `json:"country_code"`
 	State         string `json:"state"`
+	County        string `json:"county"`
 	City          string `json:"city"`
 	Town          string `json:"town"`
 	Village       string `json:"village"`
@@ -59,6 +62,27 @@ type nominatimAddress struct {
 	Neighbourhood string `json:"neighbourhood"`
 	Suburb        string `json:"suburb"`
 	Shop          string `json:"shop"`
+}
+
+// nominatimToOCFMT maps Nominatim's address components to the OpenCage
+// component names ocfmt's templates expect. Keeps the mapping in one place
+// so additions to nominatimAddress only need to update here.
+func nominatimToOCFMT(a nominatimAddress, streetName, city string) map[string]string {
+	return map[string]string{
+		"road":          streetName,
+		"house_number":  a.HouseNumber,
+		"neighbourhood": a.Neighbourhood,
+		"suburb":        a.Suburb,
+		"city":          city,
+		"town":          a.Town,
+		"village":       a.Village,
+		"hamlet":        a.Hamlet,
+		"county":        a.County,
+		"state":         a.State,
+		"postcode":      a.Postcode,
+		"country":       a.Country,
+		"country_code":  strings.ToLower(a.CountryCode),
+	}
 }
 
 // Reverse performs a reverse geocode lookup.
@@ -95,13 +119,23 @@ func (n *Nominatim) Reverse(lat, lon float64) (*Address, error) {
 	city := firstNonEmpty(result.Address.City, result.Address.Town, result.Address.Village, result.Address.Hamlet)
 	streetName := firstNonEmpty(result.Address.Road, result.Address.Quarter, result.Address.Cycleway)
 
+	components := nominatimToOCFMT(result.Address, streetName, city)
+	formatted := ocfmt.Global().Format(components)
+	if strings.TrimSpace(formatted) == "" {
+		// Fall back to Nominatim's own display_name if OpenCage can't produce
+		// anything (e.g. components too sparse to hit any template branch).
+		formatted = result.DisplayName
+	}
+
 	return &Address{
 		Latitude:         resultLat,
 		Longitude:        resultLon,
-		FormattedAddress: result.DisplayName,
+		FormattedAddress: formatted,
+		DisplayName:      result.DisplayName,
 		Country:          result.Address.Country,
 		CountryCode:      countryCode,
 		State:            result.Address.State,
+		County:           result.Address.County,
 		City:             city,
 		Zipcode:          result.Address.Postcode,
 		StreetName:       streetName,

--- a/processor/internal/geocoding/nominatim_test.go
+++ b/processor/internal/geocoding/nominatim_test.go
@@ -1,0 +1,94 @@
+package geocoding
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestNominatimReverseOCFMT walks a representative Nominatim reverse response
+// through the whole provider path and verifies the OpenCage-formatted string
+// lands in FormattedAddress, the raw display_name survives as DisplayName, and
+// the new County field propagates.
+func TestNominatimReverseOCFMT(t *testing.T) {
+	const body = `{
+        "lat": "52.517037",
+        "lon": "13.388860",
+        "display_name": "Brandenburger Tor, Platz des 18. März, Tiergarten, Mitte, Berlin, 10117, Germany",
+        "address": {
+            "country": "Germany",
+            "country_code": "de",
+            "state": "Berlin",
+            "county": "Mitte",
+            "city": "Berlin",
+            "suburb": "Tiergarten",
+            "neighbourhood": "Mitte",
+            "postcode": "10117",
+            "road": "Unter den Linden",
+            "house_number": "1"
+        }
+    }`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasPrefix(r.URL.Path, "/reverse") {
+			t.Errorf("expected /reverse, got %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	n := NewNominatim(srv.URL, 2*time.Second)
+	addr, err := n.Reverse(52.517, 13.389)
+	if err != nil {
+		t.Fatalf("Reverse: %v", err)
+	}
+
+	if addr.CountryCode != "DE" {
+		t.Errorf("CountryCode = %q, want DE", addr.CountryCode)
+	}
+	if addr.County != "Mitte" {
+		t.Errorf("County = %q, want Mitte", addr.County)
+	}
+	if addr.DisplayName == "" || !strings.Contains(addr.DisplayName, "Brandenburger Tor") {
+		t.Errorf("DisplayName should carry the raw Nominatim string, got %q", addr.DisplayName)
+	}
+	// OpenCage-formatted output doesn't mention "Brandenburger Tor"
+	// (Nominatim includes POI names in display_name; ocfmt doesn't).
+	if strings.Contains(addr.FormattedAddress, "Brandenburger Tor") {
+		t.Errorf("FormattedAddress should be OpenCage output, not display_name verbatim: %q", addr.FormattedAddress)
+	}
+	for _, want := range []string{"Unter den Linden", "10117", "Berlin", "Germany"} {
+		if !strings.Contains(addr.FormattedAddress, want) {
+			t.Errorf("FormattedAddress missing %q: %q", want, addr.FormattedAddress)
+		}
+	}
+}
+
+// TestNominatimFallsBackToDisplayName — if ocfmt can't produce anything from
+// the sparse components, we still surface a sensible FormattedAddress from
+// Nominatim's own display_name.
+func TestNominatimFallsBackToDisplayName(t *testing.T) {
+	const body = `{
+        "lat": "0",
+        "lon": "0",
+        "display_name": "Some Point, Nowhere",
+        "address": {}
+    }`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	n := NewNominatim(srv.URL, 2*time.Second)
+	addr, err := n.Reverse(0, 0)
+	if err != nil {
+		t.Fatalf("Reverse: %v", err)
+	}
+	if addr.FormattedAddress == "" {
+		t.Errorf("FormattedAddress should fall back to display_name when components are empty, got empty")
+	}
+}

--- a/processor/internal/geocoding/nominatim_test.go
+++ b/processor/internal/geocoding/nominatim_test.go
@@ -40,7 +40,7 @@ func TestNominatimReverseOCFMT(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	n := NewNominatim(srv.URL, 2*time.Second)
+	n := NewNominatim(srv.URL, 2*time.Second, true)
 	addr, err := n.Reverse(52.517, 13.389)
 	if err != nil {
 		t.Fatalf("Reverse: %v", err)
@@ -67,6 +67,45 @@ func TestNominatimReverseOCFMT(t *testing.T) {
 	}
 }
 
+// TestNominatimReverseCountryExcluded verifies the default includeCountry=false
+// suppresses the country suffix from FormattedAddress without touching the
+// rest of the country-idiomatic layout. Matches the Photon test of the same
+// behaviour.
+func TestNominatimReverseCountryExcluded(t *testing.T) {
+	const body = `{
+        "lat": "52.517037", "lon": "13.388860",
+        "display_name": "…",
+        "address": {
+            "country": "Germany", "country_code": "de", "state": "Berlin",
+            "city": "Berlin", "postcode": "10117",
+            "road": "Unter den Linden", "house_number": "1"
+        }
+    }`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	n := NewNominatim(srv.URL, 2*time.Second, false)
+	addr, err := n.Reverse(52.517, 13.389)
+	if err != nil {
+		t.Fatalf("Reverse: %v", err)
+	}
+	if strings.Contains(addr.FormattedAddress, "Germany") {
+		t.Errorf("FormattedAddress should not contain country, got %q", addr.FormattedAddress)
+	}
+	for _, want := range []string{"Unter den Linden", "10117", "Berlin"} {
+		if !strings.Contains(addr.FormattedAddress, want) {
+			t.Errorf("FormattedAddress %q missing %q", addr.FormattedAddress, want)
+		}
+	}
+	// Component field unchanged; only FormattedAddress is shaped by the flag.
+	if addr.Country != "Germany" {
+		t.Errorf("Country field should stay populated, got %q", addr.Country)
+	}
+}
+
 // TestNominatimFallsBackToDisplayName — if ocfmt can't produce anything from
 // the sparse components, we still surface a sensible FormattedAddress from
 // Nominatim's own display_name.
@@ -83,7 +122,7 @@ func TestNominatimFallsBackToDisplayName(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	n := NewNominatim(srv.URL, 2*time.Second)
+	n := NewNominatim(srv.URL, 2*time.Second, true)
 	addr, err := n.Reverse(0, 0)
 	if err != nil {
 		t.Fatalf("Reverse: %v", err)

--- a/processor/internal/geocoding/ocfmt/ocfmt.go
+++ b/processor/internal/geocoding/ocfmt/ocfmt.go
@@ -50,16 +50,14 @@ var (
 )
 
 // Global returns the shared Formatter instance, loading templates on first call.
+// The embedded worldwide.yaml is validated at build time (it's compiled into
+// the binary), so a parse error here indicates a developer mistake — panic
+// rather than silently degrade to a useless fallback.
 func Global() *Formatter {
 	globalOnce.Do(func() {
 		f, err := newFormatter()
 		if err != nil {
-			// Should not happen with embedded data
-			globalFormatter = &Formatter{
-				countries:    map[string]*countryEntry{},
-				defaultEntry: &countryEntry{AddressTemplate: "{{{road}}} {{{house_number}}}, {{{postcode}}} {{{city}}}, {{{country}}}"},
-			}
-			return
+			panic("ocfmt: embedded worldwide.yaml failed to parse: " + err.Error())
 		}
 		globalFormatter = f
 	})
@@ -206,10 +204,12 @@ func (f *Formatter) Format(components map[string]string) string {
 }
 
 // resolve looks up the country entry, following use_country redirects.
+// Caps redirect depth at 4 rather than tracking a visited set — cycles
+// in the OpenCage YAML are a data bug, and real chains never exceed 2
+// hops (e.g. GG → UK).
 func (f *Formatter) resolve(cc string) *countryEntry {
-	seen := make(map[string]bool)
 	cc = strings.ToUpper(cc)
-	for {
+	for depth := 0; depth < 4; depth++ {
 		entry, ok := f.countries[cc]
 		if !ok {
 			return f.defaultEntry
@@ -217,12 +217,9 @@ func (f *Formatter) resolve(cc string) *countryEntry {
 		if entry.UseCountry == "" {
 			return entry
 		}
-		if seen[cc] {
-			return entry // break infinite loop
-		}
-		seen[cc] = true
 		cc = strings.ToUpper(entry.UseCountry)
 	}
+	return f.defaultEntry
 }
 
 // renderTemplate processes a Mustache-like template with {{{field}}} substitutions

--- a/processor/internal/geocoding/ocfmt/ocfmt.go
+++ b/processor/internal/geocoding/ocfmt/ocfmt.go
@@ -12,11 +12,18 @@ import (
 	"strings"
 	"sync"
 
+	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
 )
 
 //go:embed worldwide.yaml
 var templatesFS embed.FS
+
+// compiledRule is a pre-compiled regex replacement rule.
+type compiledRule struct {
+	re          *regexp.Regexp
+	replacement string
+}
 
 // countryEntry represents a parsed entry from worldwide.yaml.
 type countryEntry struct {
@@ -25,6 +32,10 @@ type countryEntry struct {
 	UseCountry        string     `yaml:"use_country"`
 	Replace           [][]string `yaml:"replace"`
 	PostformatReplace [][]string `yaml:"postformat_replace"`
+
+	// Pre-compiled regex rules (built at init time)
+	compiledReplace          []compiledRule
+	compiledPostformatReplace []compiledRule
 }
 
 // Formatter formats addresses using OpenCage country-specific templates.
@@ -86,6 +97,9 @@ func newFormatter() (*Formatter, error) {
 			Replace:          mapStrSlices(m, "replace"),
 			PostformatReplace: mapStrSlices(m, "postformat_replace"),
 		}
+
+		entry.compiledReplace = compileRules(entry.Replace)
+		entry.compiledPostformatReplace = compileRules(entry.PostformatReplace)
 
 		upper := strings.ToUpper(key)
 		if upper == "DEFAULT" {
@@ -161,8 +175,8 @@ func (f *Formatter) Format(components map[string]string) string {
 	}
 
 	// Apply input replace rules
-	if len(entry.Replace) > 0 {
-		components = applyReplace(components, entry.Replace)
+	if len(entry.compiledReplace) > 0 {
+		components = applyReplace(components, entry.compiledReplace)
 	}
 
 	// Render template
@@ -181,8 +195,8 @@ func (f *Formatter) Format(components map[string]string) string {
 	}
 
 	// Apply postformat replace rules
-	if len(entry.PostformatReplace) > 0 {
-		result = applyPostformatReplace(result, entry.PostformatReplace)
+	if len(entry.compiledPostformatReplace) > 0 {
+		result = applyPostformatReplace(result, entry.compiledPostformatReplace)
 	}
 
 	// Clean up output
@@ -194,6 +208,7 @@ func (f *Formatter) Format(components map[string]string) string {
 // resolve looks up the country entry, following use_country redirects.
 func (f *Formatter) resolve(cc string) *countryEntry {
 	seen := make(map[string]bool)
+	cc = strings.ToUpper(cc)
 	for {
 		entry, ok := f.countries[cc]
 		if !ok {
@@ -263,40 +278,43 @@ func resolveFirst(inner string, components map[string]string) string {
 	return ""
 }
 
-// applyReplace applies input replacement rules to component values.
-func applyReplace(components map[string]string, rules [][]string) map[string]string {
-	out := make(map[string]string, len(components))
-	for k, v := range components {
-		out[k] = v
-	}
+// compileRules pre-compiles regex replacement rules, logging warnings for invalid patterns.
+func compileRules(rules [][]string) []compiledRule {
+	var compiled []compiledRule
 	for _, rule := range rules {
 		if len(rule) != 2 {
 			continue
 		}
 		re, err := regexp.Compile(rule[0])
 		if err != nil {
+			log.Warnf("ocfmt: invalid regex pattern %q in replacement rule: %s", rule[0], err)
 			continue
 		}
+		compiled = append(compiled, compiledRule{re: re, replacement: rule[1]})
+	}
+	return compiled
+}
+
+// applyReplace applies pre-compiled input replacement rules to component values.
+func applyReplace(components map[string]string, rules []compiledRule) map[string]string {
+	out := make(map[string]string, len(components))
+	for k, v := range components {
+		out[k] = v
+	}
+	for _, rule := range rules {
 		for k, v := range out {
-			if re.MatchString(v) {
-				out[k] = re.ReplaceAllString(v, rule[1])
+			if rule.re.MatchString(v) {
+				out[k] = rule.re.ReplaceAllString(v, rule.replacement)
 			}
 		}
 	}
 	return out
 }
 
-// applyPostformatReplace applies regex replacements to the formatted output.
-func applyPostformatReplace(result string, rules [][]string) string {
+// applyPostformatReplace applies pre-compiled regex replacements to the formatted output.
+func applyPostformatReplace(result string, rules []compiledRule) string {
 	for _, rule := range rules {
-		if len(rule) != 2 {
-			continue
-		}
-		re, err := regexp.Compile(rule[0])
-		if err != nil {
-			continue
-		}
-		result = re.ReplaceAllString(result, rule[1])
+		result = rule.re.ReplaceAllString(result, rule.replacement)
 	}
 	return result
 }

--- a/processor/internal/geocoding/ocfmt/ocfmt.go
+++ b/processor/internal/geocoding/ocfmt/ocfmt.go
@@ -1,0 +1,320 @@
+// Package ocfmt implements address formatting using OpenCage address-formatting
+// templates (worldwide.yaml). It embeds the templates and provides a simple
+// formatter that renders addresses using country-specific Mustache-like templates.
+//
+// Templates source: https://github.com/OpenCageData/address-formatting
+// License: MIT
+package ocfmt
+
+import (
+	"embed"
+	"regexp"
+	"strings"
+	"sync"
+
+	"gopkg.in/yaml.v3"
+)
+
+//go:embed worldwide.yaml
+var templatesFS embed.FS
+
+// countryEntry represents a parsed entry from worldwide.yaml.
+type countryEntry struct {
+	AddressTemplate   string     `yaml:"address_template"`
+	FallbackTemplate  string     `yaml:"fallback_template"`
+	UseCountry        string     `yaml:"use_country"`
+	Replace           [][]string `yaml:"replace"`
+	PostformatReplace [][]string `yaml:"postformat_replace"`
+}
+
+// Formatter formats addresses using OpenCage country-specific templates.
+type Formatter struct {
+	countries    map[string]*countryEntry
+	defaultEntry *countryEntry
+}
+
+var (
+	globalFormatter *Formatter
+	globalOnce      sync.Once
+)
+
+// Global returns the shared Formatter instance, loading templates on first call.
+func Global() *Formatter {
+	globalOnce.Do(func() {
+		f, err := newFormatter()
+		if err != nil {
+			// Should not happen with embedded data
+			globalFormatter = &Formatter{
+				countries:    map[string]*countryEntry{},
+				defaultEntry: &countryEntry{AddressTemplate: "{{{road}}} {{{house_number}}}, {{{postcode}}} {{{city}}}, {{{country}}}"},
+			}
+			return
+		}
+		globalFormatter = f
+	})
+	return globalFormatter
+}
+
+func newFormatter() (*Formatter, error) {
+	data, err := templatesFS.ReadFile("worldwide.yaml")
+	if err != nil {
+		return nil, err
+	}
+
+	// Parse YAML as generic map — the file mixes strings (generic templates
+	// with anchors) and objects (country entries). We must handle both.
+	var raw map[string]interface{}
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return nil, err
+	}
+
+	f := &Formatter{
+		countries: make(map[string]*countryEntry, len(raw)),
+	}
+
+	for key, val := range raw {
+		// Skip string entries (generic template anchors like generic1, fallback1)
+		m, ok := val.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		entry := &countryEntry{
+			AddressTemplate:  mapStr(m, "address_template"),
+			FallbackTemplate: mapStr(m, "fallback_template"),
+			UseCountry:       mapStr(m, "use_country"),
+			Replace:          mapStrSlices(m, "replace"),
+			PostformatReplace: mapStrSlices(m, "postformat_replace"),
+		}
+
+		upper := strings.ToUpper(key)
+		if upper == "DEFAULT" {
+			f.defaultEntry = entry
+		} else {
+			f.countries[upper] = entry
+		}
+	}
+
+	if f.defaultEntry == nil {
+		f.defaultEntry = &countryEntry{
+			AddressTemplate: "{{{road}}} {{{house_number}}}, {{{postcode}}} {{{city}}}, {{{country}}}",
+		}
+	}
+
+	return f, nil
+}
+
+// mapStr extracts a string value from a map.
+func mapStr(m map[string]interface{}, key string) string {
+	v, ok := m[key]
+	if !ok {
+		return ""
+	}
+	s, ok := v.(string)
+	if !ok {
+		return ""
+	}
+	return s
+}
+
+// mapStrSlices extracts a [][]string from a map (for replace/postformat_replace rules).
+func mapStrSlices(m map[string]interface{}, key string) [][]string {
+	v, ok := m[key]
+	if !ok {
+		return nil
+	}
+	arr, ok := v.([]interface{})
+	if !ok {
+		return nil
+	}
+	var result [][]string
+	for _, item := range arr {
+		inner, ok := item.([]interface{})
+		if !ok {
+			continue
+		}
+		var pair []string
+		for _, elem := range inner {
+			s, ok := elem.(string)
+			if !ok {
+				continue
+			}
+			pair = append(pair, s)
+		}
+		if len(pair) == 2 {
+			result = append(result, pair)
+		}
+	}
+	return result
+}
+
+// Format renders an address using the country-specific template.
+// The components map uses OpenCage field names: road, house_number, city,
+// town, village, suburb, neighbourhood, postcode, state, state_code,
+// county, country, country_code, house, attention, place, hamlet, etc.
+func (f *Formatter) Format(components map[string]string) string {
+	cc := strings.ToUpper(components["country_code"])
+
+	entry := f.resolve(cc)
+	if entry == nil {
+		entry = f.defaultEntry
+	}
+
+	// Apply input replace rules
+	if len(entry.Replace) > 0 {
+		components = applyReplace(components, entry.Replace)
+	}
+
+	// Render template
+	result := renderTemplate(entry.AddressTemplate, components)
+
+	// If result is empty/whitespace, try fallback template
+	if strings.TrimSpace(result) == "" && entry.FallbackTemplate != "" {
+		result = renderTemplate(entry.FallbackTemplate, components)
+	}
+
+	// If still empty after main template, try the default fallback
+	if strings.TrimSpace(result) == "" && entry != f.defaultEntry {
+		if f.defaultEntry.FallbackTemplate != "" {
+			result = renderTemplate(f.defaultEntry.FallbackTemplate, components)
+		}
+	}
+
+	// Apply postformat replace rules
+	if len(entry.PostformatReplace) > 0 {
+		result = applyPostformatReplace(result, entry.PostformatReplace)
+	}
+
+	// Clean up output
+	result = cleanOutput(result)
+
+	return result
+}
+
+// resolve looks up the country entry, following use_country redirects.
+func (f *Formatter) resolve(cc string) *countryEntry {
+	seen := make(map[string]bool)
+	for {
+		entry, ok := f.countries[cc]
+		if !ok {
+			return f.defaultEntry
+		}
+		if entry.UseCountry == "" {
+			return entry
+		}
+		if seen[cc] {
+			return entry // break infinite loop
+		}
+		seen[cc] = true
+		cc = strings.ToUpper(entry.UseCountry)
+	}
+}
+
+// renderTemplate processes a Mustache-like template with {{{field}}} substitutions
+// and {{#first}} ... {{/first}} blocks.
+func renderTemplate(tmpl string, components map[string]string) string {
+	// Process {{#first}} ... {{/first}} blocks
+	result := firstBlockRe.ReplaceAllStringFunc(tmpl, func(match string) string {
+		inner := firstBlockRe.FindStringSubmatch(match)
+		if len(inner) < 2 {
+			return ""
+		}
+		return resolveFirst(inner[1], components)
+	})
+
+	// Replace {{{field}}} and {{field}} with values
+	result = tripleBraceRe.ReplaceAllStringFunc(result, func(match string) string {
+		field := match[3 : len(match)-3]
+		return components[strings.TrimSpace(field)]
+	})
+	result = doubleBraceRe.ReplaceAllStringFunc(result, func(match string) string {
+		field := match[2 : len(match)-2]
+		return components[strings.TrimSpace(field)]
+	})
+
+	return result
+}
+
+var (
+	firstBlockRe  = regexp.MustCompile(`\{\{#first\}\}\s*(.*?)\s*\{\{/first\}\}`)
+	tripleBraceRe = regexp.MustCompile(`\{\{\{[^}]+\}\}\}`)
+	doubleBraceRe = regexp.MustCompile(`\{\{[^#/][^}]*\}\}`)
+)
+
+// resolveFirst handles {{#first}} A || B || C {{/first}} — returns the first
+// non-empty alternative.
+func resolveFirst(inner string, components map[string]string) string {
+	alternatives := strings.Split(inner, "||")
+	for _, alt := range alternatives {
+		rendered := strings.TrimSpace(alt)
+		// Substitute fields within this alternative
+		rendered = tripleBraceRe.ReplaceAllStringFunc(rendered, func(match string) string {
+			field := match[3 : len(match)-3]
+			return components[strings.TrimSpace(field)]
+		})
+		rendered = doubleBraceRe.ReplaceAllStringFunc(rendered, func(match string) string {
+			field := match[2 : len(match)-2]
+			return components[strings.TrimSpace(field)]
+		})
+		if strings.TrimSpace(rendered) != "" {
+			return strings.TrimSpace(rendered)
+		}
+	}
+	return ""
+}
+
+// applyReplace applies input replacement rules to component values.
+func applyReplace(components map[string]string, rules [][]string) map[string]string {
+	out := make(map[string]string, len(components))
+	for k, v := range components {
+		out[k] = v
+	}
+	for _, rule := range rules {
+		if len(rule) != 2 {
+			continue
+		}
+		re, err := regexp.Compile(rule[0])
+		if err != nil {
+			continue
+		}
+		for k, v := range out {
+			if re.MatchString(v) {
+				out[k] = re.ReplaceAllString(v, rule[1])
+			}
+		}
+	}
+	return out
+}
+
+// applyPostformatReplace applies regex replacements to the formatted output.
+func applyPostformatReplace(result string, rules [][]string) string {
+	for _, rule := range rules {
+		if len(rule) != 2 {
+			continue
+		}
+		re, err := regexp.Compile(rule[0])
+		if err != nil {
+			continue
+		}
+		result = re.ReplaceAllString(result, rule[1])
+	}
+	return result
+}
+
+// cleanOutput normalizes whitespace and removes blank lines from formatted output.
+func cleanOutput(s string) string {
+	// Split into lines, trim each, remove empty
+	lines := strings.Split(s, "\n")
+	var out []string
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		// Remove leading/trailing commas
+		line = strings.TrimLeft(line, ", ")
+		line = strings.TrimRight(line, ", ")
+		if line != "" {
+			out = append(out, line)
+		}
+	}
+	// Join with ", " for single-line output (used as FormattedAddress)
+	return strings.Join(out, ", ")
+}

--- a/processor/internal/geocoding/ocfmt/ocfmt_test.go
+++ b/processor/internal/geocoding/ocfmt/ocfmt_test.go
@@ -1,0 +1,112 @@
+package ocfmt
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestWorldwideParses ensures the embedded worldwide.yaml loads and at least
+// populates the default entry — a regression here would turn every Format
+// call into a no-op on startup.
+func TestWorldwideParses(t *testing.T) {
+	f, err := newFormatter()
+	if err != nil {
+		t.Fatalf("newFormatter: %v", err)
+	}
+	if f.defaultEntry == nil || f.defaultEntry.AddressTemplate == "" {
+		t.Fatal("defaultEntry should be populated with a template")
+	}
+	if len(f.countries) < 50 {
+		t.Errorf("expected many country entries, got %d", len(f.countries))
+	}
+}
+
+func TestFormatUS(t *testing.T) {
+	f := Global()
+	got := f.Format(map[string]string{
+		"house_number": "1600",
+		"road":         "Pennsylvania Avenue NW",
+		"city":         "Washington",
+		"state":        "District of Columbia",
+		"state_code":   "DC",
+		"postcode":     "20500",
+		"country":      "United States of America",
+		"country_code": "US",
+	})
+	for _, want := range []string{"1600", "Pennsylvania Avenue NW", "Washington", "20500", "United States"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("US format missing %q; got %q", want, got)
+		}
+	}
+	// US places the state between city and postcode ("Washington, DC 20500").
+	if !strings.Contains(got, "DC") && !strings.Contains(got, "District of Columbia") {
+		t.Errorf("US format should include the state/state_code, got %q", got)
+	}
+}
+
+func TestFormatDE(t *testing.T) {
+	f := Global()
+	got := f.Format(map[string]string{
+		"house_number": "1",
+		"road":         "Unter den Linden",
+		"city":         "Berlin",
+		"state":        "Berlin",
+		"postcode":     "10117",
+		"country":      "Germany",
+		"country_code": "DE",
+	})
+	for _, want := range []string{"Unter den Linden", "10117", "Berlin", "Germany"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("DE format missing %q; got %q", want, got)
+		}
+	}
+	// German convention puts the house number AFTER the street.
+	street := strings.Index(got, "Unter den Linden")
+	number := strings.Index(got, "1")
+	if street < 0 || number < 0 || number < street {
+		t.Errorf("DE expected street before number in %q", got)
+	}
+}
+
+func TestFormatMissingFields(t *testing.T) {
+	f := Global()
+	got := f.Format(map[string]string{
+		"city":         "Paris",
+		"country":      "France",
+		"country_code": "FR",
+	})
+	if !strings.Contains(got, "Paris") {
+		t.Errorf("should include city when street/postcode missing; got %q", got)
+	}
+	if !strings.Contains(got, "France") {
+		t.Errorf("should include country; got %q", got)
+	}
+}
+
+func TestFormatUnknownCountryFallsBack(t *testing.T) {
+	f := Global()
+	got := f.Format(map[string]string{
+		"road":         "Sample Street",
+		"house_number": "42",
+		"city":         "Neverland",
+		"country":      "Neverwhere",
+		"country_code": "XX",
+	})
+	if got == "" {
+		t.Fatal("unknown country code should still render via default template")
+	}
+	if !strings.Contains(got, "Sample Street") || !strings.Contains(got, "Neverland") {
+		t.Errorf("default template should still emit street and city; got %q", got)
+	}
+}
+
+func TestFormatNoCountryCode(t *testing.T) {
+	f := Global()
+	got := f.Format(map[string]string{
+		"city":    "Someplace",
+		"country": "Somewhere",
+	})
+	if got == "" {
+		t.Fatal("missing country_code should fall through to the default template")
+	}
+}

--- a/processor/internal/geocoding/ocfmt/worldwide.yaml
+++ b/processor/internal/geocoding/ocfmt/worldwide.yaml
@@ -1,0 +1,2188 @@
+#
+# generic mappings, specific territories get mapped to these
+#
+# postcode before city
+generic1: &generic1 |
+        {{{attention}}}
+        {{{house}}}
+        {{#first}} {{{road}}} || {{{place}}} || {{{hamlet}}} {{/first}} {{{house_number}}}
+        {{{postcode}}} {{#first}} {{{postal_city}}} || {{{town}}} || {{{city}}} || {{{village}}} || {{{municipality}}} || {{{hamlet}}} || {{{county}}} || {{{state}}} {{/first}}
+        {{{archipelago}}}
+        {{{country}}}
+
+# postcode after city
+generic2: &generic2 |
+        {{{attention}}}
+        {{{house}}}, {{{quarter}}}
+        {{{house_number}}} {{{road}}}
+        {{#first}} {{{village}}} || {{{town}}} || {{{city}}} || {{{municipality}}} || {{{hamlet}}} || {{{county}}} {{/first}} {{{postcode}}}
+        {{#first}} {{{country}}} || {{{state}}} {{/first}}
+
+# postcode before city
+generic3: &generic3 |
+        {{{attention}}}
+        {{{house}}}
+        {{{house_number}}} {{{road}}}
+        {{{place}}}
+        {{{postcode}}} {{#first}} {{{town}}} || {{{village}}} || {{{hamlet}}} || {{{city}}} || {{{municipality}}} || {{{state}}} {{/first}}
+        {{{country}}}
+
+# postcode after state
+generic4: &generic4 |
+        {{{attention}}}
+        {{{house}}}
+        {{{house_number}}} {{{road}}}
+        {{#first}} {{{village}}} || {{{hamlet}}} {{/first}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{state_district}}} || {{{suburb}}} || {{{municipality}}} || {{{county}}} {{/first}}, {{#first}} {{{state_code}}} || {{{state}}} {{/first}} {{{postcode}}}
+        {{{country}}}
+
+# no postcode
+generic5: &generic5 |
+        {{{attention}}}
+        {{{house}}}
+        {{{house_number}}} {{{road}}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} {{/first}}
+        {{#first}} {{{state_district}}} || {{{state}}} {{/first}}
+        {{{country}}}
+
+# no postcode, county
+generic6: &generic6 |
+        {{{attention}}}
+        {{{house}}}
+        {{{house_number}}} {{{road}}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} || {{{municipality}}} {{/first}}
+        {{{county}}}
+        {{{state}}}
+        {{{country}}}
+
+# city, postcode
+generic7: &generic7 |
+        {{{attention}}}
+        {{{house}}}
+        {{{road}}} {{{house_number}}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} || {{{state}}}{{/first}}, {{{postcode}}}
+        {{{country}}}
+
+# postcode and county
+generic8: &generic8 |
+        {{{attention}}}
+        {{{house}}}
+        {{{road}}} {{{house_number}}}
+        {{{postcode}}} {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} || {{{municipality}}} {{/first}} {{#first}} {{{county_code}}} || {{{county}}} {{/first}}
+        {{{country}}}
+
+generic9: &generic9 |
+        {{{attention}}}
+        {{{house}}}
+        {{{road}}} {{{house_number}}}
+        {{#first}} {{{suburb}}} || {{{city_district}}} || {{{state_district}}} {{/first}}
+        {{{postcode}}} {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} || {{{state}}} {{/first}}
+        {{{country}}}
+
+generic10: &generic10 |
+        {{{attention}}}
+        {{{house}}}
+        {{{road}}}, {{{house_number}}}
+        {{#first}} {{{suburb}}} || {{{city_district}}} {{/first}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} {{/first}}
+        {{{state}}}
+        {{{country}}}
+        {{{postcode}}}
+
+generic11: &generic11 |
+        {{{country}}}
+        {{{state}}}
+        {{{postcode}}} {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} {{/first}}
+        {{{suburb}}}
+        {{{road}}}, {{{house_number}}}
+        {{{house}}}
+        {{{attention}}}
+
+# city - postcode
+generic12: &generic12 |
+        {{{attention}}}
+        {{{house}}}
+        {{{house_number}}}, {{{road}}}
+        {{#first}} {{{suburb}}} || {{{city_district}}} || {{{state_district}}} {{/first}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} {{/first}} - {{{postcode}}}
+        {{{state}}}
+        {{{country}}}
+
+generic13: &generic13 |
+        {{{attention}}}
+        {{{house}}}
+        {{{house_number}}} {{{road}}}
+        {{#first}} {{{suburb}}} || {{{city_district}}} || {{{city}}} || {{{town}}} || {{{state_district}}} || {{{village}}} || {{{hamlet}}} || {{{region}}} {{/first}} {{#first}} {{{state_code}}} || {{{state}}} {{/first}} {{{postcode}}}
+        {{{country}}}
+
+# postcode and state
+generic14: &generic14 |
+        {{{attention}}}
+        {{{house}}}
+        {{{house_number}}} {{{road}}}
+        {{{postcode}}} {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} || {{{state_district}}} {{/first}}
+        {{{state}}}
+        {{{country}}}
+
+# postcode and comma before house number
+generic15: &generic15 |
+        {{{attention}}}
+        {{{house}}}
+        {{{road}}}, {{{house_number}}}
+        {{{postcode}}} {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} || {{{municipality}}} || {{{state}}} || {{{county}}} {{/first}}
+        {{{country}}}
+
+# no postcode, no state, just city
+generic16: &generic16 |
+        {{{attention}}}
+        {{{house}}}
+        {{{house_number}}} {{{road}}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} || {{{municipality}}} || {{{county}}} || {{{state_district}}} || {{{state}}} {{/first}}
+        {{{country}}}
+
+# no postcode, no state, just city
+generic17: &generic17 |
+        {{{attention}}}
+        {{{house}}}
+        {{{road}}} {{{house_number}}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} || {{{municipality}}} || {{{county}}} || {{{state_district}}} || {{{state}}} {{/first}}
+        {{{country}}}
+
+# no postcode, just city comma after house number
+generic18: &generic18 |
+        {{{attention}}}
+        {{{house}}}
+        {{{house_number}}}, {{{road}}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} || {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} || {{{state}}} {{/first}}
+        {{{country}}}
+
+# suburb and postcode after city
+generic19: &generic19 |
+        {{{attention}}}
+        {{{house}}}
+        {{{road}}} {{{house_number}}}
+        {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} {{/first}} {{{postcode}}}
+        {{{country}}}
+
+# suburb and postcode after city
+generic20: &generic20 |
+        {{{attention}}}
+        {{{house}}}
+        {{{house_number}}} {{{road}}}
+        {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} {{/first}} {{{postcode}}}
+        {{{country}}}
+
+# suburb and city, no postcode
+generic21: &generic21 |
+        {{{attention}}}
+        {{{house}}}
+        {{{road}}} {{{house_number}}}
+        {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} || {{{state}}} {{/first}}
+        {{{country}}}
+
+# comma after housenumber, postcode before city
+generic22: &generic22 |
+        {{{attention}}}
+        {{{house}}}
+        {{{house_number}}}, {{{road}}}
+        {{{postcode}}} {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} || {{{state}}} {{/first}}
+        {{{country}}}
+
+# postcode on own line
+generic23: &generic23 |
+        {{{attention}}}
+        {{{house}}}
+        {{{house_number}}} {{{road}}}
+        {{{quarter}}}
+        {{#first}} {{{village}}} || {{{town}}} || {{{city}}} || {{{municipality}}} || {{{hamlet}}} || {{{county}}} {{/first}}
+        {{{postcode}}}
+        {{#first}} {{{country}}} || {{{state}}} {{/first}}
+
+fallback1: &fallback1 |
+        {{{attention}}}
+        {{{house}}}
+        {{{road}}} {{{house_number}}}
+        {{{place}}}
+        {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} || {{{island}}} {{/first}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} || {{{municipality}}} {{/first}}
+        {{#first}} {{{county}}} || {{{state_district}}} || {{{state}}} || {{{region}}} || {{{island}}}, {{{archipelago}}} {{/first}}
+        {{{country}}}
+
+fallback2: &fallback2 |
+        {{{attention}}}
+        {{{house}}}
+        {{{road}}} {{{house_number}}}
+        {{{place}}}
+        {{#first}} {{{suburb}}} || {{{village}}} || {{{hamlet}}} {{/first}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{municipality}}} || {{{county}}} || {{{island}}} || {{{state_district}}} {{/first}}, {{#first}} {{{state}}} || {{{state_code}}} {{/first}}
+        {{{country}}}
+
+fallback3: &fallback3 |
+        {{{attention}}}
+        {{{house}}}
+        {{{road}}} {{{house_number}}}
+        {{{place}}}
+        {{#first}} {{{suburb}}} || {{{island}}} {{/first}}
+        {{#first}} {{{village}}} || {{{hamlet}}} || {{{municipality}}} {{/first}}
+        {{#first}} {{{town}}} || {{{city}}}{{/first}}
+        {{{county}}}
+        {{#first}} {{{state}}} || {{{state_code}}} {{/first}}
+        {{{country}}}
+
+fallback4: &fallback4 |
+        {{{attention}}}
+        {{{house}}}
+        {{{road}}} {{{house_number}}}
+        {{{place}}}
+        {{{suburb}}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} || {{{municipality}}} || {{{county}}} {{/first}}
+        {{#first}} {{{state}}} || {{{county}}} {{/first}}
+        {{{country}}}
+
+default:
+    address_template: *generic1
+    fallback_template: *fallback1
+
+# country / territory specific mappings
+# please keep in alpha order by country code
+#
+
+
+# Andorra
+AD:
+    address_template: *generic3
+
+# United Arab Emirates
+AE:
+    address_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{{house_number}}} {{{road}}}
+        {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} {{/first}}
+        {{#first}} {{{state_district}}} || {{{state}}} {{/first}}
+        {{{country}}}
+
+# Afghanistan
+AF:
+    address_template: *generic21
+
+# Antigua and Barbuda
+AG:
+    address_template: *generic16
+
+# Anguilla
+AI:
+    address_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{{road}}} {{{house_number}}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} {{/first}}
+        {{{postcode}}} {{{country}}}
+
+# Albania
+AL:
+    address_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{{road}}} {{{house_number}}}
+        {{{postcode}}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{city_district}}} || {{{municipality}}} || {{{state_district}}} || {{{village}}} || {{{hamlet}}} {{/first}}
+        {{{country}}}
+
+# Armenia
+AM:
+    address_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{{house_number}}} {{{road}}}
+        {{{postcode}}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} {{/first}}
+        {{#first}} {{{state_district}}} || {{{state}}} {{/first}}
+        {{{country}}}
+
+# Angola
+AO:
+    address_template: *generic7
+
+# Antarctica
+AQ:
+    address_template: |
+        {{{house}}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} {{/first}}
+        {{#first}} {{{country}}} || {{{continent}}} {{/first}}
+    fallback_template: |
+        {{{house}}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} {{/first}}
+        {{#first}} {{{country}}} || {{{continent}}} {{/first}}
+
+# Argentina
+AR:
+    address_template: *generic9
+    replace:
+        - ["^Autonomous City of ",""]
+    postformat_replace:
+        # fix the postcode to make it \w\d\d\d\d \w\w\w
+        - ["\n(\\w\\d{4})(\\w{3}) ","\n$1 $2 "]
+
+# American Samoa
+AS:
+    use_country: US
+    change_country: United States of America
+    add_component: state=American Samoa
+
+# Austria
+AT:
+    address_template: *generic1
+    replace:
+        - ["^Politischer Bezirk ",""]
+
+# Australia
+AU:
+    address_template: *generic13
+
+# Aruba
+AW:
+    address_template: *generic17
+
+# Åland Islands, part of Finnland
+AX:
+    use_country: FI
+    change_country: Åland, Finland
+
+# Azerbaijan
+AZ:
+    address_template: *generic3
+
+# Bosnia
+BA:
+    address_template: *generic1
+
+# Barbados
+BB:
+    address_template: *generic16
+
+# Bangladesh
+BD:
+    address_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{{house_number}}} {{{road}}}
+        {{#first}} {{{suburb}}} || {{{city_district}}} || {{{state_district}}} {{/first}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} {{/first}} - {{{postcode}}}
+        {{{country}}}
+
+# Belgium
+BE:
+    address_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{{road}}} {{{house_number}}}
+        {{{postcode}}} {{#first}} {{{postal_city}}} || {{{town}}} || {{{city}}} || {{{village}}} || {{{municipality}}} || {{{hamlet}}} || {{{county}}} || {{{state}}} {{/first}}
+        {{{archipelago}}}
+        {{{country}}}
+
+# Burkina Faso
+BF:
+    address_template: *generic6
+
+# Bulgaria - https://en.wikipedia.org/wiki/Address#Bulgaria
+BG:
+    address_template: *generic19
+
+# Bahrain
+BH:
+    address_template: *generic2
+
+# Burundi
+BI:
+    address_template: *generic17
+
+# Benin
+BJ:
+    address_template: *generic18
+
+# Saint Barthélemy - same as FR
+BL:
+    use_country: FR
+    change_country: Saint-Barthélemy, France
+
+# Bermuda
+BM:
+    address_template: *generic2
+
+# Brunei
+BN:
+    address_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{{house_number}}}, {{{road}}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} || {{{municipality}}} {{/first}}
+        {{#first}} {{{county}}} || {{{state_district}}} || {{{state}}} {{/first}} {{{postcode}}}
+        {{{country}}}
+
+
+# Bolivia
+BO:
+    address_template: *generic17
+    replace:
+        - ["^Municipio Nuestra Senora de ",""]
+
+# Dutch Caribbean / Bonaire
+BQ:
+    use_country: NL
+    change_country: Caribbean Netherlands
+
+# Brazil
+BR:
+    address_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{{road}}}, {{{house_number}}}{{#first}}, {{{quarter}}}{{/first}}
+        {{#first}} {{{suburb}}} || {{{city_district}}} || {{{village}}} || {{{hamlet}}}{{/first}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{state_district}}} {{/first}} - {{#first}} {{{state_code}}} || {{{state}}} {{/first}}
+        {{{postcode}}}
+        {{{country}}}
+    postformat_replace:
+        - ["\\b(\\d{5})(\\d{3})\\b","$1-$2"]
+
+# Bahamas
+BS:
+    address_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{{road}}} {{{house_number}}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} || {{{municipality}}} {{/first}}
+        {{{county}}}
+        {{{country}}}
+
+# Bhutan
+BT:
+    address_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{{road}}} {{{house_number}}}, {{{house}}}
+        {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} || {{{state}}} {{/first}} {{{postcode}}}
+        {{{country}}}
+
+# Bouvet Island
+BV:
+    use_country: "NO"
+    change_country: Bouvet Island, Norway
+
+# Botswana
+BW:
+    address_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{{road}}} {{{house_number}}}
+        {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} {{/first}}
+        {{{country}}}
+
+# Belarus
+BY:
+    address_template: *generic11
+
+# Belize
+BZ:
+    address_template: *generic16
+
+# Canada - https://en.wikipedia.org/wiki/Address#Canada
+CA:
+    address_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{#first}} {{{house_number}}} {{{road}}} || {{{suburb}}} {{/first}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} || {{{county}}} || {{{state_district}}} {{/first}}, {{#first}} {{{state_code}}} || {{{state}}} {{/first}} {{{postcode}}}
+        {{{country}}}
+    fallback_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{#first}} {{{house_number}}} {{{road}}} || {{{suburb}}} {{/first}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} || {{{county}}} || {{{state_district}}} || {{{region}}}{{/first}}, {{#first}} {{{state}}} || {{{state_code}}} {{/first}} {{{postcode}}}
+        {{{country}}}
+    postformat_replace:
+        # fix the postcode to make it \w\w\w \w\w\w
+        - [" ([A-Za-z]{2}) ([A-Za-z]\\d[A-Za-z])(\\d[A-Za-z]\\d)\n"," $1 $2 $3\n"]
+
+#Canada - English
+CA_en:
+    address_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{#first}} {{{house_number}}} {{{road}}} || {{{suburb}}} {{/first}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} || {{{county}}} || {{{state_district}}} {{/first}}, {{#first}} {{{state_code}}} || {{{state}}} {{/first}} {{{postcode}}}
+        {{{country}}}
+    fallback_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{#first}} {{{house_number}}} {{{road}}} || {{{suburb}}} {{/first}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} || {{{county}}} || {{{state_district}}} {{/first}}, {{#first}} {{{state_code}}} || {{{state}}} {{/first}} {{{postcode}}}
+        {{{country}}}
+    postformat_replace:
+        # fix the postcode to make it \w\w\w \w\w\w
+        - [" ([A-Za-z]{2}) ([A-Za-z]\\d[A-Za-z])(\\d[A-Za-z]\\d)\n"," $1 $2 $3\n"]
+
+#Canada - French Quebec
+CA_fr:
+    address_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{#first}} {{{house_number}}}, {{{road}}} || {{{suburb}}} {{/first}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} || {{{county}}} || {{{state_district}}} {{/first}} {{#first}} ({{{state_code}}}) || {{{state}}} {{/first}} {{{postcode}}}
+        {{{country}}}
+    postformat_replace:
+        # fix the postcode to make it \w\w\w \w\w\w
+        - [" ([A-Za-z]{2}) ([A-Za-z]\\d[A-Za-z])(\\d[A-Za-z]\\d)\n"," $1 $2 $3\n"]
+
+# Cocos (Keeling) Islands
+CC:
+    use_country: AU
+    change_country: Australia
+
+# Democratic Republic of the Congo
+CD:
+    address_template: *generic18
+
+# Central African Republic
+CF:
+    address_template: *generic17
+
+# Republic of the Congo / Congo-Brazzaville
+CG:
+    address_template: *generic18
+
+# Switzerland
+CH:
+    address_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{{road}}} {{{house_number}}}
+        {{{postcode}}} {{#first}} {{{postal_city}}} || {{{town}}} || {{{city}}} || {{{municipality}}} || {{{village}}} || {{{hamlet}}} || {{{county}}} || {{{state}}} {{/first}}
+        {{{country}}}
+    replace:
+        - ["Verwaltungskreis",""]
+        - ["Verwaltungsregion",""]
+        - [" administrative district",""]
+        - [" administrative region",""]
+
+# Côte d'Ivoire
+CI:
+    address_template: *generic16
+
+# Cook Islands
+CK:
+    address_template: *generic16
+
+# Chile - https://en.wikipedia.org/wiki/Address#Chile
+CL:
+    address_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{{road}}} {{{house_number}}}
+        {{{postcode}}} {{#first}} {{{postal_city}}} || {{{town}}} || {{{city}}} || {{{village}}} || {{{municipality}}} || {{{hamlet}}} || {{{county}}} || {{{state}}} {{/first}}
+        {{{region}}}
+        {{{country}}}
+
+# Cameroon
+CM:
+    address_template: *generic17
+
+# China
+CN:
+    address_template: |
+        {{{postcode}}} {{{country}}}
+        {{#first}} {{{state_code}}} || {{{state}}} || {{{state_district}}} || {{{region}}}{{/first}}
+        {{{county}}}
+        {{#first}}{{{city}}} || {{{town}}} || {{{municipality}}}|| {{{village}}}|| {{{hamlet}}}{{/first}}
+        {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}}
+        {{{road}}} {{{house_number}}}
+        {{{house}}}
+        {{{attention}}}
+
+# China - English
+CN_en:
+    address_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{{house_number}}} {{{road}}}
+        {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}}
+        {{{county}}}
+        {{#first}}{{{city}}} || {{{town}}} || {{{municipality}}}|| {{{village}}}|| {{{hamlet}}}{{/first}}
+        {{#first}} {{{state_code}}} || {{{state}}} || {{{state_district}}} || {{{region}}}{{/first}}
+        {{{country}}} {{{postcode}}}
+
+# China - Chinese Simplified
+CN_zh:
+    address_template: |
+        {{{postcode}}} {{{country}}}
+        {{#first}} {{{state_code}}} || {{{state}}} || {{{state_district}}} || {{{region}}}{{/first}}
+        {{{county}}}
+        {{#first}}{{{city}}} || {{{town}}} || {{{municipality}}}|| {{{village}}}|| {{{hamlet}}}{{/first}}
+        {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}}
+        {{{road}}} {{{house_number}}}
+        {{{house}}}
+        {{{attention}}}
+
+# Colombia
+CO:
+    address_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{{road}}} {{{house_number}}}
+        {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}}
+        {{{postcode}}} {{#first}} {{{city}}} || {{{town}}} || {{{state_district}}} || {{{village}}} || {{{hamlet}}} {{/first}}, {{#first}} {{{state_code}}} || {{{state}}} {{/first}}
+        {{{country}}}
+    postformat_replace:
+        - ["Localidad "," "]
+        - ["(Bogot[áa]),? (Distrito Capital|Capital District)",$1]
+        - ["(Bogot[áa]), Bogot[áa]","$1"]
+
+# Costa Rica
+CR:
+    address_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{{road}}} {{{house_number}}}
+        {{{state}}}, {{#first}} {{{city}}} || {{{town}}} || {{{state_district}}} || {{{village}}} || {{{hamlet}}} {{/first}}, {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}}
+        {{{postcode}}} {{{country}}}
+
+# Cuba
+CU:
+    address_template: *generic7
+
+# Cape Verde
+CV:
+    address_template: *generic1
+    postformat_replace:
+        # fix the postcode to add - after numbers
+        - ["\n(\\d{4}) ([^,]*)\n","\n$1-$2\n"]
+
+# Curaçao
+CW:
+    address_template: *generic17
+
+# Christmas Island - same as Australia
+CX:
+    use_country: AU
+    add_component: state=Christmas Island
+    change_country: Australia
+
+# Cyprus
+CY:
+    address_template: *generic1
+
+# Czech Republic
+CZ:
+    address_template: *generic1
+    replace:
+        - ["^Capital City of ",""]
+    postformat_replace:
+        # fix the postcode to make it \d\d\d \d\d
+        - ["\n(\\d{3})(\\d{2}) ","\n$1 $2 "]
+
+# Germany
+DE:
+    address_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{#first}} {{{road}}} || {{{place}}} || {{{hamlet}}} {{/first}} {{{house_number}}}
+        {{{postcode}}} {{#first}} {{{village}}} {{{postal_city}}} || {{{town}}} || {{{city}}} || {{{municipality}}} || {{{hamlet}}} || {{{county}}} || {{{state}}} {{/first}}
+        {{{archipelago}}}
+        {{{country}}}
+    fallback_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{#first}} {{{road}}} || {{{place}}} || {{{hamlet}}} {{/first}} {{{house_number}}}
+        {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}}
+        {{#first}} {{{village}}} || {{{town}}} || {{{city}}} || {{{hamlet}}} || {{{municipality}}} || {{{county}}} {{/first}}
+        {{#first}} {{{state}}} || {{{state_district}}} {{/first}}
+        {{{country}}}
+
+    replace:
+        - ["^Stadtteil ",""]
+        - ["^Stadtbezirk (\\d+)",""]
+        - ["^Ortsbeirat (\\d+) :",""]
+        - ["^Gemeinde ",""]
+        - ["^Gemeindeverwaltungsverband ",""]
+        - ["county=Landkreis ",""]
+        - ["county=Kreis ",""]
+        - ["^Grenze ",""]
+        - ["state=Free State of ",""]
+        - ["^Freistaat ",""]
+        - ["^Regierungsbezirk ",""]
+        - ["^Stadtgebiet ",""]
+        - ["^Gemeindefreies Gebiet ",""]
+        - ["city=Alt-Berlin","Berlin"]
+    postformat_replace:
+        - ["Berlin\nBerlin","Berlin"]
+        - ["Bremen\nBremen","Bremen"]
+        - ["Hamburg\nHamburg","Hamburg"]
+
+# Djibouti
+DJ:
+    address_template: *generic16
+    replace:
+        - ["city=Djibouti","Djibouti-Ville"]
+
+# Denmark
+DK:
+    address_template: *generic1
+    replace:
+        - ["state=Capital Region of Denmark","Capital Region"]
+        - ["^Region of ",""]
+
+# Dominica
+DM:
+    address_template: *generic16
+
+# Dominican Republic
+DO:
+    address_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{{road}}} {{{house_number}}}
+        {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} {{/first}}, {{{state}}}
+        {{{postcode}}}
+        {{{country}}}
+    postformat_replace:
+        - [", Distrito Nacional",", DN"]
+
+# Algeria
+DZ:
+    address_template: *generic3
+
+# Ecuador
+EC:
+    address_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{{road}}} {{{house_number}}}
+        {{{postcode}}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{state_district}}} || {{{village}}} || {{{hamlet}}} {{/first}}
+        {{{country}}}
+
+# Egypt
+EG:
+    address_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{{house_number}}} {{{road}}}
+        {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} {{/first}}
+        {{{postcode}}}
+        {{{country}}}
+
+# Estonia
+EE:
+    address_template: *generic1
+
+# Western Sahara
+EH:
+    address_template: *generic17
+
+# Eritrea
+ER:
+    address_template: *generic17
+
+# Spain
+ES:
+    address_template: *generic15
+    fallback_template: *fallback4
+
+    replace:
+        - ["Autonomous Community of the ",""]
+        - ["Autonomous Community of ",""]
+        - ["^Community of ",""]
+
+# Ethiopia
+ET:
+    address_template: *generic1
+
+# Finnland
+FI:
+    address_template: *generic1
+
+# Fiji
+FJ:
+    address_template: *generic16
+
+# Falkland Islands
+FK:
+    use_country: GB
+    change_country: Falkland Islands, United Kingdom
+
+# Federated States of Micronesia
+# uses US postal system, but not part of the US
+FM:
+    address_template: *generic4
+    fallback_template: *fallback2
+    postformat_replace:
+        - ["PNI 96941","FM 96941"]
+        - ["TRK 96942","FM 96942"]
+        - ["YAP 96943","FM 96943"]
+        - ["KSA 96944","FM 96944"]
+
+# Faroe Islands
+FO:
+    address_template: *generic1
+    postformat_replace:
+        - ["Territorial waters of Faroe Islands","Faroe Islands"]
+
+# France
+FR:
+    address_template: *generic3
+    replace:
+        - ["Polynésie française, Îles du Vent \\(eaux territoriales\\)","Polynésie française"]
+        - ["France, Mayotte \\(eaux territoriales\\)","Mayotte, France"]
+        - ["France, La Réunion \\(eaux territoriales\\)","La Réunion, France"]
+        - ["Grande Terre et récifs d'Entrecasteaux",""]
+        - ["France, Nouvelle-Calédonie","Nouvelle-Calédonie, France"]
+        - ["\\(eaux territoriales\\)",""]
+        - ["state= \\(France\\)$",""]
+        - ["Paris (\\d+)(\\w+) Arrondissement$","Paris"]
+
+# Gabon
+GA:
+    address_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{{house_number}}} {{{road}}}
+        {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} || {{{village}}} || {{{hamlet}}} {{/first}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{municipality}}} || {{{county}}} || {{{state_district}}} || {{{state}}} {{/first}}
+        {{{country}}}
+
+GB:
+    address_template: *generic23
+    fallback_template: *fallback3
+    replace:
+        - ["village= CP$",""]
+        - ["^Borough of ",""]
+        - ["^County( of)? ",""]
+        - ["^Parish of ",""]
+        - ["^Greater London","London"]
+        - ["^London Borough of ",""]
+        - ["Royal Borough of ",""]
+        - ["County Borough of ",""]
+    postformat_replace:
+        - ["London, London","London"]
+        - ["London, Greater London","London"]
+        - ["City of Westminster","London"]
+        - ["City of Nottingham","Nottingham"]
+        - [", United Kingdom$","\nUnited Kingdom"]
+        - ["London\nEngland\nUnited Kingdom","London\nUnited Kingdom"]
+
+# Grenada
+GD:
+    address_template: *generic17
+
+# Georgia
+GE:
+    address_template: *generic1
+
+# French Guiana - same as FR
+GF:
+    use_country: FR
+    change_country: France
+
+# Guernsey - same format as UK, but not part of UK
+GG:
+    use_country: GB
+    change_country: Guernsey, Channel Islands
+
+# Ghana
+GH:
+    address_template: *generic16
+
+# Gibraltar
+GI:
+    address_template: *generic16
+
+# Greenland
+GL:
+    address_template: *generic1
+
+# The Gambia
+GM:
+    address_template: *generic16
+
+# Guinea
+GN:
+    address_template: *generic14
+
+# Guadeloupe - same as FR
+GP:
+    use_country: FR
+    change_country: Guadeloupe, France
+
+# Equatorial Guinea
+GQ:
+    address_template: *generic17
+
+# Greece
+GR:
+    address_template: *generic1
+    replace:
+        - ["Municipal Unit of ",""]
+        - ["Regional Unit of ",""]
+    postformat_replace:
+        # fix the postcode to make it \d\d\d \d\d
+        - ["\n(\\d{3})(\\d{2}) ","\n$1 $2 "]
+
+# South Georgia and the South Sandwich Islands - same as UK
+GS:
+    use_country: GB
+    change_country: United Kingdom
+    add_component: county=South Georgia
+
+# Guatemala
+GT:
+    address_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{{road}}} {{{house_number}}}
+        {{{postcode}}}-{{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} || {{{municipality}}} || {{{state}}} {{/first}}
+        {{{country}}}
+    postformat_replace:
+        - ["\n(\\d{5})- ","\n$1-"]
+        - ["\n -","\n"]
+
+# Guam
+GU:
+    use_country: US
+    change_country: United States of America
+    add_component: state=Guam
+
+# Guinea-Bissau
+GW:
+    address_template: *generic1
+
+# Guyana
+GY:
+    address_template: *generic16
+
+# Hong Kong
+HK:
+    address_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{{house_number}}} {{{road}}}
+        {{{state_district}}}
+        {{#first}} {{{state}}} || {{{country}}} {{/first}}
+
+# Hong Kong - English
+HK_en:
+    address_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{{house_number}}} {{{road}}}
+        {{{state_district}}}
+        {{{state}}}
+        {{{country}}}
+
+# Hong Kong - Chinese
+HK_zh:
+    address_template: |
+        {{{country}}}
+        {{{state}}}
+        {{{state_district}}}
+        {{{road}}}
+        {{{house_number}}}
+        {{{house}}}
+        {{{attention}}}
+
+
+# Heard Island and McDonald Islands - same as Australia
+HM:
+    use_country: AU
+    change_country: Australia
+    add_component: state=Heard Island and McDonald Islands
+
+# Honduras
+HN:
+    address_template: *generic1
+
+# Croatia
+HR:
+    address_template: *generic1
+
+# Haiti
+HT:
+    address_template: *generic1
+    postformat_replace:
+        - [" Commune de "," "]
+
+# Hungary
+# https://e-nyelv.hu/2014-09-19/lakcim/
+HU:
+    address_template: |
+        {{{attention}}}
+        {{{postcode}}} {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} {{/first}}
+        {{{road}}} {{{house_number}}}.
+        {{{country}}}
+    postformat_replace:
+        - ["\n.\n","\n"]
+
+# Indonesia
+# https://en.wikipedia.org/wiki/Address_%28geography%29#Indonesia
+ID:
+    address_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{{road}}} {{{house_number}}}
+        {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} {{/first}} {{{postcode}}}
+        {{{state}}}
+        {{{country}}}
+
+# Ireland
+# https://en.wikipedia.org/wiki/Postal_addresses_in_the_Republic_of_Ireland
+IE:
+    address_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{{house_number}}} {{{road}}}
+        {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} || {{{municipality}}} {{/first}}
+        {{{county}}}
+        {{{postcode}}}
+        {{{country}}}
+    replace:
+        - [" City$",""]
+        - ["The Municipal District of ",""]
+        - ["The Metropolitan District of ",""]
+        - ["Municipal District",""]
+        - ["Electoral Division",""]
+    postformat_replace:
+        - ["Dublin\nCounty Dublin","Dublin"]
+        - ["Dublin\nLeinster","Dublin"]
+        - ["Galway\nCounty Galway","Galway"]
+        - ["Kilkenny\nCounty Kilkenny","Kilkenny"]
+        - ["Limerick\nCounty Limerick","Limerick"]
+        - ["Tipperary\nCounty Tipperary","Tipperary"]
+        # fix eircode formatting
+        #- ["\n(\\d{4})(\\w{2}) ","\n$1 $2 "]
+        - ["\n(([AC-FHKNPRTV-Y][0-9]{2}|D6W))[ -]?([0-9AC-FHKNPRTV-Y]{4})", "\n$1 $3"]
+
+
+# Israel
+IL:
+    address_template: *generic1
+
+# Isle of Man
+IM:
+    use_country: GB
+
+# India
+# http://en.wikipedia.org/wiki/Address_%28geography%29#India
+IN:
+    address_template: *generic12
+    postformat_replace:
+        # deal with - but no postcode
+        - [" -\n","\n"]
+
+# British Indian Ocean Territory - same as UK
+IO:
+    use_country: GB
+    change_country: British Indian Ocean Territory, United Kingdom
+
+# Iraq
+IQ:
+    address_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{{house_number}}} {{#first}} {{{city_district}}} || {{{neighbourhood}}} || {{{suburb}}} {{/first}}
+        {{{road}}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{state}}} || {{{village}}} || {{{hamlet}}} {{/first}}
+        {{{postcode}}}
+        {{{country}}}
+
+# Iran
+IR:
+    address_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} {{/first}}
+        {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}}
+        {{{road}}}
+        {{{house_number}}}
+        {{#first}}{{{province}}} || {{{state}}} || {{{state_district}}}{{/first}}
+        {{{postcode}}}
+        {{{country}}}
+
+IR_en:
+    address_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} {{/first}}
+        {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}}
+        {{{road}}}
+        {{{house_number}}}
+        {{#first}}{{{state}}} || {{{state_district}}}{{/first}}
+        {{{postcode}}}
+        {{{country}}}
+
+IR_fa:
+    address_template: |
+        {{{country}}}
+        {{{state}}}
+        {{{state_district}}}
+        {{#first}} {{{state}}} || {{{province}}} {{/first}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} {{/first}}
+        {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}}
+        {{{road}}}
+        {{{house_number}}}
+        {{{house}}}
+        {{{attention}}}
+        {{{postcode}}}
+
+# Iceland
+IS:
+    address_template: *generic1
+
+# Italy
+IT:
+    address_template: *generic8
+    replace:
+        - ["county=Provincia di ",""]
+        - ["county=Province of ",""]
+        - ["county=Città Metropolitana di ",""]
+        - ["county=Metropolitan City of ",""]
+    postformat_replace:
+        - ["Vatican City\nVatican City$","\nVatican City"]
+        - ["Città del Vaticano\nCittà del Vaticano$","Città del Vaticano\n"]
+
+# Jersey - same format as UK, but not part of UK
+JE:
+    use_country: GB
+    change_country: Jersey, Channel Islands
+
+# Jamaica
+JM:
+    address_template: *generic20
+
+# Jordan
+JO:
+    address_template: *generic1
+
+# Japan
+JP:
+    address_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{{house_number}}} {{{road}}}
+        {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} {{/first}}, {{#first}} {{{state}}} || {{{state_district}}} {{/first}} {{{postcode}}}
+        {{{country}}}
+    postformat_replace:
+        # fix the postcode to make it \d\d\d-\d\d\d\d
+        - [" (\\d{3})(\\d{4})\n"," $1-$2\n"]
+
+
+
+# Japan - English
+JP_en:
+    address_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{{house_number}}} {{{road}}}
+        {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} {{/first}}, {{#first}} {{{state}}} || {{{state_district}}} {{/first}} {{{postcode}}}
+        {{{country}}}
+    postformat_replace:
+        # fix the postcode to make it \d\d\d-\d\d\d\d
+        - [" (\\d{3})(\\d{4})\n"," $1-$2\n"]
+
+
+# Japan - Japanese
+JP_ja:
+    address_template: |
+        {{{country}}}
+        {{{postcode}}}
+        {{#first}} {{{state}}} || {{{state_district}}} {{/first}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} {{/first}}
+        {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}}
+        {{{road}}}
+        {{{house_number}}}
+        {{{house}}}
+        {{{attention}}}
+    postformat_replace:
+        # fix the postcode to make it \d\d\d-\d\d\d\d
+        - [" (\\d{3})(\\d{4})\n"," $1-$2\n"]
+
+# Kenya
+KE:
+    address_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{{house_number}}} {{{road}}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{state}}} || {{{village}}} || {{{hamlet}}} {{/first}}
+        {{{postcode}}}
+        {{{country}}}
+
+# Kyrgyzstan
+KG:
+    address_template: *generic11
+
+# Cambodia
+KH:
+    address_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{{house_number}}} {{{road}}}
+        {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} {{/first}} {{{postcode}}}
+        {{{country}}}
+
+# Kiribati
+KI:
+    address_template: *generic17
+
+# Comoros
+KM:
+    address_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{{road}}} {{{house_number}}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} {{/first}}
+        {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}}
+        {{{country}}}
+
+# Saint Kitts and Nevis
+KN:
+    address_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{{house_number}}} {{{road}}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} {{/first}}, {{#first}} {{{state}}} || {{{island}}} {{/first}}
+        {{{country}}}
+
+# Democratic People's Republic of Korea / North Korea
+KP:
+    address_template: *generic21
+
+# Republic of Korea / South Korea -- https://en.wikipedia.org/wiki/Address#South_Korea
+KR:
+    address_template: |
+        {{{country}}}
+        {{{state}}} {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} {{/first}} {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}} {{{road}}} {{{house_number}}}
+        {{{attention}}}
+        {{{postcode}}}
+    fallback_template: |
+        {{{country}}}
+        {{{state}}} {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} {{/first}} {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}}
+        {{{attention}}}
+
+# South Korea - English
+KR_en:
+    address_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{{house_number}}} {{{road}}}
+        {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}}, {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} {{/first}} {{{postcode}}}
+        {{{state}}}
+        {{{country}}}
+
+# South Korea - Korean
+KR_ko:
+    address_template: |
+        {{{country}}}
+        {{{state}}} {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} {{/first}} {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}} {{{road}}} {{{house_number}}}
+        {{{attention}}}
+        {{{postcode}}}
+    fallback_template: |
+        {{{country}}}
+        {{{state}}} {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} {{/first}} {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}}
+        {{{attention}}}
+
+# Kuwait
+KW:
+    address_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}}
+
+        {{{road}}}
+        {{{house_number}}} {{{house}}}
+        {{{postcode}}} {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} {{/first}}
+        {{{country}}}
+
+# Cayman Islands
+KY:
+    address_template: *generic2
+
+# Kazakhstan
+KZ:
+    address_template: *generic11
+
+# Laos
+LA:
+    address_template: *generic22
+
+# Lebanon
+LB:
+    address_template: *generic2
+    postformat_replace:
+        # fix the postcode to make it nonbreaking space
+       - [" (\\d{4}) (\\d{4})\n"," $1 $2\n"]
+
+# Saint Lucia
+LC:
+    address_template: *generic17
+
+# Liechtenstein, same as Switzerland
+LI:
+    use_country: CH
+
+# Sri Lanka
+LK:
+    address_template: *generic20
+
+# Liberia
+LR:
+    address_template: *generic1
+
+# Lesotho
+LS:
+    address_template: *generic2
+
+# Lithuania
+LT:
+    address_template: *generic1
+
+# Luxemburg
+LU:
+    address_template: *generic3
+
+# Latvia
+LV:
+    address_template: *generic7
+
+# Libya
+LY:
+    address_template: *generic17
+
+# Morocco
+MA:
+    address_template: *generic3
+
+# Monaco
+MC:
+    address_template: *generic3
+    fallback_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{{road}}} {{{house_number}}}
+        {{{place}}}
+        {{#first}} {{{neighbourhood}}} || {{{city_district}}} || {{{municipality}}} || {{{suburb}}}{{/first}}
+        {{{city}}}
+        {{{country}}}
+    postformat_replace:
+        - ["Monaco\nMonaco","Monaco"]
+
+# Moldova
+MD:
+    address_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{{road}}}, {{{house_number}}}
+        {{{postcode}}} {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} || {{{state}}} {{/first}}
+        {{{country}}}
+
+# Montenegro
+ME:
+    address_template: *generic1
+
+# Collectivité de Saint-Martin
+MF:
+    use_country: FR
+    change_country: France
+
+# Marshall Islands
+# uses US postal system, but not part of the US
+MH:
+    address_template: *generic4
+    fallback_template: *fallback2
+    postformat_replace:
+        - [", 96060",", MH 96060"]
+        - [", 96070",", MH 96070"]
+
+# Madagascar
+MG:
+    address_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{{house_number}}} {{{road}}}
+        {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}}
+        {{{postcode}}} {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} {{/first}}
+        {{{country}}}
+
+# North Macedonia
+MK:
+    address_template: *generic1
+
+# Mali
+ML:
+    address_template: *generic17
+
+# Myanmar (Burma)
+MM:
+    address_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{{house_number}}} {{{road}}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} || {{{state}}} {{/first}}, {{{postcode}}}
+        {{{country}}}
+
+
+# Mongolia
+MN:
+    address_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{{city_district}}}
+        {{#first}} {{{suburb}}} || {{{neighbourhood}}} {{/first}}
+        {{{road}}}
+        {{{house_number}}}
+        {{{postcode}}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} {{/first}}
+        {{{country}}}
+
+# Macau
+MO:
+    address_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{{road}}} {{{house_number}}}
+        {{#first}} {{{suburb}}} || {{{village}}} || {{{hamlet}}} || {{{state_district}}} {{/first}}
+        {{{country}}}
+
+# Macao - Portuguese
+MO_pt:
+    address_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{{road}}} {{{house_number}}}
+        {{#first}} {{{suburb}}} || {{{village}}} || {{{hamlet}}} || {{{state_district}}} {{/first}}
+        {{{country}}}
+
+# Macao - Chinese
+MO_zh:
+    address_template: |
+        {{{country}}}
+        {{#first}} {{{suburb}}} || {{{village}}} || {{{hamlet}}} || {{{state_district}}} {{/first}}
+        {{{road}}}
+        {{{house_number}}}
+        {{{house}}}
+        {{{attention}}}
+
+# Northern Mariana Islands
+MP:
+    use_country: US
+    change_country: United States of America
+    add_component: state=Northern Mariana Islands
+
+# Montserrat
+MS:
+    address_template: *generic16
+
+# Malta
+MT:
+    address_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{{house_number}}} {{{road}}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{suburb}}} || {{{village}}} || {{{hamlet}}} {{/first}}
+        {{{postcode}}}
+        {{{country}}}
+
+# Martinique - overseas territory of France (FR)
+MQ:
+    use_country: FR
+    change_country: Martinique, France
+
+# Mauritania
+MR:
+    address_template: *generic18
+
+# Mauritius
+MU:
+    address_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{{house_number}}}, {{{road}}}
+        {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} || {{{state}}} {{/first}} {{{postcode}}}
+        {{{country}}}
+
+# Maldives
+MV:
+    address_template: *generic2
+
+# Malawi
+MW:
+    address_template: *generic16
+
+# Mexico
+MX:
+    address_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{{road}}} {{{house_number}}}
+        {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}}
+        {{{postcode}}} {{#first}} {{{city}}} || {{{town}}} || {{{state_district}}} || {{{village}}} || {{{hamlet}}} {{/first}}, {{#first}} {{{state_code}}} || {{{state}}} {{/first}}
+        {{{country}}}
+
+# Malaysia
+MY:
+    address_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{{house_number}}} {{{road}}}
+        {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}}
+        {{{postcode}}} {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} {{/first}}
+        {{{state}}}
+        {{{country}}}
+
+# Mozambique
+MZ:
+    address_template: *generic15
+    fallback_template: *fallback4
+
+# Namibia
+NA:
+    address_template: *generic2
+
+# New Caledonia, special collectivity of France
+NC:
+    use_country: FR
+    change_country: Nouvelle-Calédonie, France
+
+# Niger
+NE:
+    address_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{{house_number}}}
+        {{{road}}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} {{/first}}
+        {{{country}}}
+
+# Norfolk Island - same as Australia
+NF:
+    use_country: AU
+    add_component: state=Norfolk Island
+    change_country: Australia
+
+# Nigeria
+NG:
+    address_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{{house_number}}} {{{road}}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} {{/first}} {{{postcode}}}
+        {{{state}}}
+        {{{country}}}
+
+# Nicaragua
+NI:
+    address_template: *generic21
+
+# Netherlands
+NL:
+    address_template: *generic1
+    postformat_replace:
+        # fix the postcode to make it \d\d\d\d \w\w
+        - ["\n(\\d{4})(\\w{2}) ","\n$1 $2 "]
+        - ["\nKoninkrijk der Nederlanden$","\nNederland"]
+
+
+# Norway
+# quoted since python interprets it as a boolean. Silly python!
+"NO":
+    address_template: *generic1
+
+# Nepal
+NP:
+    address_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{{road}}} {{{house_number}}}
+        {{#first}} {{{suburb}}} || {{{neighbourhood}}} || {{{city}}} {{/first}}
+        {{#first}} {{{municipality}}} || {{{county}}} || {{{state_district}}} || {{{state}}} {{/first}} {{{postcode}}}
+        {{{country}}}
+
+# Nauru
+NR:
+    address_template: *generic16
+
+# Niue
+NU:
+    address_template: *generic16
+
+# New Zealand
+NZ:
+    address_template: *generic20
+    postformat_replace:
+        - ["Wellington\nWellington City","Wellington"]
+
+# Oman
+OM:
+    address_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{{house_number}}} {{{road}}}
+        {{{postcode}}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{state_district}}} || {{{village}}} || {{{hamlet}}} {{/first}}
+        {{{state}}}
+        {{{country}}}
+
+# Panama
+PA:
+    address_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{{road}}} {{{house_number}}}
+        {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}}
+        {{{postcode}}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{state_district}}} || {{{village}}} || {{{hamlet}}} {{/first}}
+        {{{state}}}
+        {{{country}}}
+    replace:
+        - ["city=Panama$","Panama City"]
+        - ["city=Panamá$","Ciudad de Panamá"]
+
+# Peru
+PE:
+    address_template: *generic19
+
+# French Polynesia - same as FR
+PF:
+    use_country: FR
+    change_country: Polynésie française, France
+    replace:
+        - ["Polynésie française, Îles du Vent \\(eaux territoriales\\)","Polynésie française"]
+
+
+# Papau New Guinea
+PG:
+    address_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{{house_number}}} {{{road}}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} {{/first}} {{{postcode}}} {{{state}}}
+        {{{country}}}
+
+# Philippines - https://en.wikipedia.org/wiki/Address#Philippines
+PH:
+    address_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{{house_number}}} {{{road}}}, {{#first}}{{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}}{{/first}}, {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} || {{{suburb}}} || {{{state_district}}} {{/first}}
+        {{{postcode}}} {{#first}} {{{municipality}}} || {{{region}}} || {{{state}}} {{/first}}
+        {{{country}}}
+
+# Pakistan
+PK:
+    address_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{{house_number}}} {{{road}}}
+        {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} || {{{state}}} {{/first}} {{{postcode}}}
+        {{{country}}}
+
+# Poland
+PL:
+    address_template: *generic1
+    postformat_replace:
+        # fix the postcode to make it \d\d-\d\d\d
+        - ["\n(\\d{2})(\\w{3}) ","\n$1-$2 "]
+
+
+# Saint Pierre and Miquelon - same as FR
+PM:
+    use_country: FR
+    change_country: Saint-Pierre-et-Miquelon, France
+
+# Pitcairn Islands
+PN:
+    address_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{island}}} {{/first}}
+        {{{country}}}
+
+# Puerto Rico, same as USA
+PR:
+    use_country: US
+    change_country: United States of America
+    add_component: state=Puerto Rico
+
+# Palestine
+PS:
+    use_country: IL
+
+# Portugal
+PT:
+    address_template: *generic1
+    postformat_replace:
+        # fix the postcode to add - after numbers
+        - ["\n(\\d{4})(\\d{3}) ","\n$1-$2 "]
+
+
+# Palau
+PW:
+    address_template: *generic1
+
+# Parguay
+PY:
+    address_template: *generic1
+
+# Qatar
+QA:
+    address_template: *generic17
+
+# Réunion - same as FR
+RE:
+    use_country: FR
+    change_country: La Réunion, France
+
+
+# Romania
+RO:
+    address_template: *generic1
+
+# Serbia
+RS:
+    address_template: *generic1
+
+# Russia
+RU:
+    address_template: *generic10
+    fallback_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{{road}}}, {{{house_number}}}
+        {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} || {{{island}}} || {{{village}}} || {{{hamlet}}} {{/first}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{municipality}}} {{/first}}
+        {{#first}} {{{county}}} || {{{state_district}}} || {{{state}}} {{/first}}
+        {{{country}}}
+
+# Rwanda
+RW:
+    address_template: *generic16
+
+# Saudi Arabia
+SA:
+    address_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{{house_number}}} {{{road}}}, {{#first}} {{{village}}} || {{{hamlet}}} || {{{city_district}}} || {{{suburb}}} || {{{neighbourhood}}} {{/first}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{state_district}}} {{/first}} {{{postcode}}}
+        {{{country}}}
+
+# Solomon Islands
+SB:
+    address_template: *generic17
+
+# Seychelles
+SC:
+    address_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{{house_number}}} {{{road}}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} || {{{island}}} {{/first}}
+        {{{island}}}
+        {{{country}}}
+
+# Sudan
+SD:
+    address_template: *generic1
+
+# Sweden
+SE:
+    address_template: *generic1
+    postformat_replace:
+        # fix the postcode to make it \d\d\d \d\d
+        - ["\n(\\d{3})(\\d{2}) ","\n$1 $2 "]
+
+# Singapore
+SG:
+    address_template: |
+        {{{attention}}}
+        {{{house}}}, {{{quarter}}}
+        {{{house_number}}} {{{road}}}, {{{residential}}}
+        {{#first}} {{{country}}} || {{{town}}} || {{{city}}} || {{{municipality}}} || {{{hamlet}}} || {{{village}}} || {{{county}}} {{/first}} {{{postcode}}}
+
+# Saint Helena, Ascension and Tristan da Cunha - same as UK
+SH:
+    use_country: GB
+    change_country: $state, United Kingdom
+
+# Slovenia
+SI:
+    address_template: *generic1
+
+# Svalbard and Jan Mayen - same as Norway
+SJ:
+    use_country: "NO"
+    change_country: Norway
+
+# Slovakia
+SK:
+    address_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{{road}}} {{{house_number}}}
+        {{{postcode}}} {{#first}} {{{postal_city}}} || {{{city}}} || {{{town}}} || {{{village}}} || {{{municipality}}} || {{{city_district}}} || {{{hamlet}}} || {{{county}}} || {{{state}}} {{/first}}
+        {{{country}}}
+    replace:
+        - ["^District of ",""]
+        - ["^Region of ",""]
+    postformat_replace:
+        # fix the postcode to make it \d\d\d \d\d
+        - ["\n(\\d{3})(\\d{2}) ","\n$1 $2 "]
+
+# Sierra Leone
+SL:
+    address_template: *generic16
+
+# San Marino - same as IT
+SM:
+    use_country: IT
+
+# Senegal
+SN:
+    address_template: *generic3
+    replace:
+        - ["^Commune de ",""]
+        - ["^Arrondissement de ",""]
+        - ["^Département de ",""]
+
+# Somalia
+SO:
+    address_template: *generic21
+
+# Suriname
+SR:
+    address_template: *generic21
+
+# South Sudan
+SS:
+    address_template: *generic17
+
+# São Tomé and Príncipe
+ST:
+    address_template: *generic17
+
+# El Salvador
+SV:
+    address_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{{road}}} {{{house_number}}}
+        {{{postcode}}} - {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} {{/first}}
+        {{{state}}}
+        {{{country}}}
+    postformat_replace:
+        - ["\n- ","\n "]
+
+# Sint Maarten
+SX:
+    address_template: *generic17
+
+# Syria
+SY:
+    address_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{{road}}}, {{{house_number}}}
+        {{#first}} {{{village}}} || {{{hamlet}}} || {{{city_district}}} || {{{neighbourhood}}} || {{{suburb}}} {{/first}}
+        {{{postcode}}} {{#first}} {{{city}}} || {{{town}}} || {{{state_district}}} || {{{state}}} {{/first}}
+
+        {{{country}}}
+
+
+# Swaziland
+SZ:
+    address_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{{road}}} {{{house_number}}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} || {{{state}}} {{/first}}
+        {{{postcode}}}
+        {{{country}}}
+
+# Turks and Caicos Islands
+TC:
+    address_template: *generic23
+    fallback_template: |
+        {{{attention}}}
+        {{{house_number}}} {{{road}}}
+        {{{quarter}}}
+        {{#first}} {{{village}}} || {{{town}}} || {{{city}}} || {{{municipality}}} || {{{hamlet}}} || {{{county}}} {{/first}}
+        {{{island}}}
+        {{{country}}}
+
+# Chad
+TD:
+    address_template: *generic21
+
+# French Southern and Antarctic Lands
+TF:
+    use_country: FR
+    change_country: Terres australes et antarctiques françaises, France
+
+# Togo
+TG:
+    address_template: *generic18
+
+# Thailand -- https://en.wikipedia.org/wiki/Thai_addressing_system
+TH:
+    address_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{{house_number}}} {{#first}} {{{village}}} || {{{hamlet}}} {{/first}}
+        {{{road}}}
+        {{#first}} {{{neighbourhood}}} || {{{city}}} || {{{town}}} {{/first}}, {{#first}} {{{suburb}}} || {{{city_district}}} || {{{state_district}}} {{/first}}
+        {{{state}}} {{{postcode}}}
+        {{{country}}}
+
+# Tajikistan
+TJ:
+    address_template: *generic1
+
+# Tokelau, territory of New Zealand
+TK:
+    use_country: NZ
+    change_country: Tokelau, New Zealand
+
+# Timor-Leste/East Timor
+TL:
+    address_template: *generic17
+
+# Turkmenistan
+TM:
+    address_template: *generic22
+
+# Tunisia
+TN:
+    address_template: *generic3
+
+# Tonga
+TO:
+    address_template: *generic16
+
+# Turkey
+TR:
+    address_template: *generic1
+
+# Trinidad and Tobago
+TT:
+    address_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{{house_number}}} {{{road}}}
+        {{#first}} {{{suburb}}} || {{{city_district}}} || {{{state_district}}} {{/first}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{state_district}}} || {{{village}}} || {{{hamlet}}} {{/first}}, {{{postcode}}}
+        {{{country}}}
+
+# Tuvalu
+TV:
+    address_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{{house_number}}} {{{road}}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} || {{{municipality}}} {{/first}}
+        {{#first}} {{{county}}} || {{{state_district}}} || {{{state}}} || {{{island}}} {{/first}}
+        {{{country}}}
+
+# Taiwan -- https://en.wikipedia.org/wiki/Address#Taiwan
+TW:
+    address_template: |
+        {{{country}}}
+        {{{postcode}}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} || {{{municipality}}} {{/first}} {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}} {{{road}}} {{{house_number}}}
+        {{{house}}}
+        {{{attention}}}
+
+TW_en:
+    address_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{{house_number}}}, {{{road}}}
+        {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}}, {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} {{/first}} {{{postcode}}}
+        {{{country}}}
+
+TW_zh:
+    address_template: |
+        {{{country}}}
+        {{{postcode}}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} || {{{municipality}}} {{/first}} {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}} {{{road}}} {{{house_number}}}
+        {{{house}}}
+        {{{attention}}}
+
+# Tanzania
+TZ:
+    address_template: *generic14
+    fallback_template: *generic14
+    postformat_replace:
+        - ["Dar es Salaam\nDar es Salaam","Dar es Salaam"]
+
+# Ukraine -- https://en.wikipedia.org/wiki/Address#Ukraine
+UA:
+    address_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{{road}}}, {{{house_number}}}
+        {{#first}} {{{suburb}}} || {{{city_district}}} || {{{state_district}}} {{/first}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} || {{{municipality}}} {{/first}}
+        {{#first}} {{{region}}} || {{{state}}} {{/first}}
+        {{{postcode}}}
+        {{{country}}}
+
+# Uganda
+UG:
+    address_template: *generic16
+
+# US Minor Outlying Islands, same as USA
+UM:
+    fallback_template: *fallback2
+    use_country: US
+    change_country: United States of America
+    add_component: state=US Minor Outlying Islands
+
+# USA
+US:
+    address_template: *generic4
+    fallback_template: *fallback2
+    replace:
+        - ["state=United States Virgin Islands","US Virgin Islands"]
+        - ["state=USVI","US Virgin Islands"]
+    postformat_replace:
+        - ["\nUS$","\nUnited States of America"]
+        - ["\nUSA$","\nUnited States of America"]
+        - ["\nUnited States$","\nUnited States of America"]
+        - ["Town of ",""]
+        - ["Township of ",""]
+
+# Uzbekistan
+UZ:
+    address_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{{road}}} {{{house_number}}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} {{/first}}
+        {{#first}} {{{state}}} || {{{state_district}}} {{/first}}
+        {{{country}}}
+        {{{postcode}}}
+
+# Uruguay
+UY:
+    address_template: *generic1
+
+# Vatican City - same as IT
+VA:
+    use_country: IT
+
+# Saint Vincent and the Grenadines
+VC:
+    address_template: *generic17
+
+# Venezuela
+VE:
+    address_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{{road}}} {{{house_number}}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{state_district}}} || {{{village}}} || {{{hamlet}}} {{/first}} {{{postcode}}}, {{#first}} {{{state_code}}} || {{{state}}} {{/first}}
+        {{{country}}}
+
+# British Virgin Islands
+VG:
+    address_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{{house_number}}} {{{road}}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} {{/first}}, {{{island}}}
+        {{{country}}}, {{{postcode}}}
+
+# US Virgin Islands, same as USA
+VI:
+    use_country: US
+    change_country: United States of America
+    add_component: state=US Virgin Islands
+
+# Vietnam -- https://en.wikipedia.org/wiki/Address#Vietnam
+VN:
+    address_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{{house_number}}} {{{road}}}
+        {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} || {{{state_district}}} {{/first}}
+        {{{state}}} {{{postcode}}}
+        {{{country}}}
+
+# Vanuatu
+VU:
+    address_template: *generic17
+
+# Wallis and Futuna, same as France
+WF:
+    use_country: FR
+    change_country: Wallis-et-Futuna, France
+
+# Samoa
+WS:
+    address_template: *generic17
+
+# Sovereign Base Areas of Akrotiri and Dhekelia
+# not an official ISO code
+XC:
+    address_template: *generic6
+
+# Kosovo
+# not an official ISO code
+XK:
+    address_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{{house_number}}}, {{{road}}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} || {{{state}}} {{/first}} {{{postcode}}}
+        {{{country}}}
+
+# Yemen
+YE:
+    address_template: *generic18
+
+# Mayotte - same as FR
+YT:
+    use_country: FR
+    change_country: Mayotte, France
+
+# South Africa
+ZA:
+    address_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{{house_number}}} {{{road}}}
+        {{#first}} {{{suburb}}} || {{{city_district}}} || {{{state_district}}} {{/first}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} || {{{state}}} {{/first}}
+        {{{postcode}}}
+        {{{country}}}
+
+# Zambia
+ZM:
+    address_template: *generic3
+
+# Zimbabwe
+ZW:
+    address_template: *generic16

--- a/processor/internal/geocoding/photon.go
+++ b/processor/internal/geocoding/photon.go
@@ -17,16 +17,11 @@ import (
 type Photon struct {
 	baseURL        string
 	client         *http.Client
-	formatter      *ocfmt.Formatter
-	includeCountry bool // render country into FormattedAddress via ocfmt
+	includeCountry bool
 }
 
 // NewPhoton creates a Photon provider. includeCountry controls whether the
 // OpenCage-formatted FormattedAddress trails with the country name.
-// FormattedAddress is always populated via OpenCage country-specific
-// templates (ocfmt). Callers who want a different shape can drive it via
-// the existing address_format template with the per-field helpers
-// ({{{streetName}}}, {{{suburb}}}, {{{city}}}, etc.).
 func NewPhoton(baseURL string, timeout time.Duration, includeCountry bool) *Photon {
 	if timeout == 0 {
 		timeout = 10 * time.Second
@@ -34,7 +29,6 @@ func NewPhoton(baseURL string, timeout time.Duration, includeCountry bool) *Phot
 	return &Photon{
 		baseURL:        strings.TrimRight(baseURL, "/"),
 		client:         &http.Client{Timeout: timeout},
-		formatter:      ocfmt.Global(),
 		includeCountry: includeCountry,
 	}
 }
@@ -85,12 +79,7 @@ func (p *Photon) Reverse(lat, lon float64) (*Address, error) {
 	if err != nil {
 		return nil, fmt.Errorf("photon: request failed: %w", err)
 	}
-	defer func() {
-		// Drain remaining body before close so HTTP/1.1 keep-alive can
-		// reuse the connection. Matches the pattern in nominatim/google.
-		io.Copy(io.Discard, resp.Body)
-		resp.Body.Close()
-	}()
+	defer drainClose(resp)
 
 	if resp.StatusCode >= 500 {
 		return nil, fmt.Errorf("photon: server error %d", resp.StatusCode)
@@ -160,7 +149,7 @@ func (p *Photon) formatOpenCage(components map[string]string, countryCode string
 		delete(components, "country")
 	}
 
-	result := p.formatter.Format(components)
+	result := ocfmt.Global().Format(components)
 	if result == "" {
 		// Fallback: build a simple comma-separated string
 		parts := filterNonEmpty(
@@ -188,32 +177,39 @@ func photonComponents(props photonProperties) map[string]string {
 		"postcode":    strings.TrimSpace(props.Postcode),
 	}
 
+	// Add the OpenCage-named aliases ("road" for "street", "house_number"
+	// for "housenumber", etc.) in a second pass so we never mutate the
+	// map while ranging over it, and only insert when the alias differs.
+	aliases := make(map[string]string, len(components))
 	for k, v := range components {
-		components[photonToOCKey(k)] = v
+		if alias := photonToOCKey(k); alias != k {
+			aliases[alias] = v
+		}
+	}
+	for k, v := range aliases {
+		components[k] = v
 	}
 
 	if propsType, name := components["type"], components["name"]; propsType != "" && name != "" && propsType != "house" {
 		components[propsType] = name
-		components[photonToOCKey(propsType)] = name
+		if alias := photonToOCKey(propsType); alias != propsType {
+			components[alias] = name
+		}
 	}
 
 	return components
 }
 
 func photonStreetName(props photonProperties, components map[string]string) string {
-	streetName := firstNonEmpty(strings.TrimSpace(props.Street), components["street"], components["road"])
-	if streetName != "" {
-		return streetName
+	if s := firstNonEmpty(strings.TrimSpace(props.Street), components["street"], components["road"]); s != "" {
+		return s
 	}
-
-	// Photon returns "type":"other" for POIs and named features that aren't
-	// on a street. Surface Name as a sensible street-line fallback so
-	// templates like {{{streetName}}} don't render empty.
+	// Photon returns "type":"other" for POIs that aren't on a street.
+	// Use Name so {{{streetName}}} doesn't render empty for those.
 	if strings.EqualFold(strings.TrimSpace(props.Type), "other") {
 		return strings.TrimSpace(props.Name)
 	}
-
-	return streetName
+	return ""
 }
 
 // photonToOCKey maps Photon property names to OpenCage component names.
@@ -261,10 +257,7 @@ func (p *Photon) Forward(query string) ([]ForwardResult, error) {
 	if err != nil {
 		return nil, fmt.Errorf("photon: request failed: %w", err)
 	}
-	defer func() {
-		io.Copy(io.Discard, resp.Body)
-		resp.Body.Close()
-	}()
+	defer drainClose(resp)
 
 	if resp.StatusCode >= 500 {
 		return nil, fmt.Errorf("photon: server error %d", resp.StatusCode)
@@ -298,4 +291,11 @@ func (p *Photon) Forward(query string) ([]ForwardResult, error) {
 		})
 	}
 	return out, nil
+}
+
+// drainClose reads any remaining body bytes and closes the response so
+// HTTP/1.1 keep-alive can reuse the connection. Matches nominatim/google.
+func drainClose(resp *http.Response) {
+	io.Copy(io.Discard, resp.Body)
+	resp.Body.Close()
 }

--- a/processor/internal/geocoding/photon.go
+++ b/processor/internal/geocoding/photon.go
@@ -74,6 +74,7 @@ func (p *Photon) Reverse(lat, lon float64) (*Address, error) {
 	q := u.Query()
 	q.Set("lat", fmt.Sprintf("%f", lat))
 	q.Set("lon", fmt.Sprintf("%f", lon))
+	q.Set("radius", "1")
 	u.RawQuery = q.Encode()
 
 	resp, err := p.client.Get(u.String())

--- a/processor/internal/geocoding/photon.go
+++ b/processor/internal/geocoding/photon.go
@@ -15,24 +15,27 @@ import (
 // Photon implements Provider using the Photon geocoder API (komoot/photon).
 // Photon returns GeoJSON responses based on OpenStreetMap data.
 type Photon struct {
-	baseURL   string
-	client    *http.Client
-	formatter *ocfmt.Formatter
+	baseURL        string
+	client         *http.Client
+	formatter      *ocfmt.Formatter
+	includeCountry bool // render country into FormattedAddress via ocfmt
 }
 
-// NewPhoton creates a Photon provider.
+// NewPhoton creates a Photon provider. includeCountry controls whether the
+// OpenCage-formatted FormattedAddress trails with the country name.
 // FormattedAddress is always populated via OpenCage country-specific
 // templates (ocfmt). Callers who want a different shape can drive it via
 // the existing address_format template with the per-field helpers
 // ({{{streetName}}}, {{{suburb}}}, {{{city}}}, etc.).
-func NewPhoton(baseURL string, timeout time.Duration) *Photon {
+func NewPhoton(baseURL string, timeout time.Duration, includeCountry bool) *Photon {
 	if timeout == 0 {
 		timeout = 10 * time.Second
 	}
 	return &Photon{
-		baseURL:   strings.TrimRight(baseURL, "/"),
-		client:    &http.Client{Timeout: timeout},
-		formatter: ocfmt.Global(),
+		baseURL:        strings.TrimRight(baseURL, "/"),
+		client:         &http.Client{Timeout: timeout},
+		formatter:      ocfmt.Global(),
+		includeCountry: includeCountry,
 	}
 }
 
@@ -152,6 +155,10 @@ func (p *Photon) Reverse(lat, lon float64) (*Address, error) {
 func (p *Photon) formatOpenCage(components map[string]string, countryCode string) string {
 	// Ensure country_code is set (uppercase)
 	components["country_code"] = countryCode
+
+	if !p.includeCountry {
+		delete(components, "country")
+	}
 
 	result := p.formatter.Format(components)
 	if result == "" {

--- a/processor/internal/geocoding/photon.go
+++ b/processor/internal/geocoding/photon.go
@@ -119,6 +119,8 @@ func (p *Photon) Reverse(lat, lon float64) (*Address, error) {
 	countryCode := strings.ToUpper(strings.TrimSpace(props.CountryCode))
 	suburb := firstNonEmpty(components["suburb"], strings.TrimSpace(props.District))
 
+	streetName := photonStreetName(props, components, p.useCompact)
+
 	addr := &Address{
 		Latitude:      resultLat,
 		Longitude:     resultLon,
@@ -127,7 +129,7 @@ func (p *Photon) Reverse(lat, lon float64) (*Address, error) {
 		State:         firstNonEmpty(strings.TrimSpace(props.State), components["state"]),
 		City:          city,
 		Zipcode:       firstNonEmpty(strings.TrimSpace(props.Postcode), components["postcode"]),
-		StreetName:    firstNonEmpty(strings.TrimSpace(props.Street), components["street"], components["road"]),
+		StreetName:    streetName,
 		StreetNumber:  firstNonEmpty(strings.TrimSpace(props.HouseNumber), components["housenumber"], components["house_number"]),
 		Neighbourhood: strings.TrimSpace(props.District),
 		County:        firstNonEmpty(strings.TrimSpace(props.County), components["county"]),
@@ -187,6 +189,19 @@ func photonComponents(props photonProperties) map[string]string {
 	}
 
 	return components
+}
+
+func photonStreetName(props photonProperties, components map[string]string, useCompact bool) string {
+	streetName := firstNonEmpty(strings.TrimSpace(props.Street), components["street"], components["road"])
+	if !useCompact || streetName != "" {
+		return streetName
+	}
+
+	if strings.EqualFold(strings.TrimSpace(props.Type), "other") {
+		return strings.TrimSpace(props.Name)
+	}
+
+	return streetName
 }
 
 // photonToOCKey maps Photon property names to OpenCage component names.

--- a/processor/internal/geocoding/photon.go
+++ b/processor/internal/geocoding/photon.go
@@ -1,0 +1,270 @@
+package geocoding
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/pokemon/poracleng/processor/internal/geocoding/ocfmt"
+)
+
+// Photon implements Provider using the Photon geocoder API (komoot/photon).
+// Photon returns GeoJSON responses based on OpenStreetMap data.
+type Photon struct {
+	baseURL    string
+	client     *http.Client
+	formatter  *ocfmt.Formatter
+	useCompact bool // if true, use compact format instead of OpenCage templates
+}
+
+// NewPhoton creates a Photon provider. If useCompact is true, FormattedAddress
+// uses the compact "suburb: street, city" format instead of OpenCage templates.
+func NewPhoton(baseURL string, timeout time.Duration, useCompact bool) *Photon {
+	if timeout == 0 {
+		timeout = 10 * time.Second
+	}
+	return &Photon{
+		baseURL:    strings.TrimRight(baseURL, "/"),
+		client:     &http.Client{Timeout: timeout},
+		formatter:  ocfmt.Global(),
+		useCompact: useCompact,
+	}
+}
+
+// photonResponse models the GeoJSON response from Photon.
+type photonResponse struct {
+	Features []photonFeature `json:"features"`
+}
+
+type photonFeature struct {
+	Geometry   photonGeometry   `json:"geometry"`
+	Properties photonProperties `json:"properties"`
+}
+
+type photonGeometry struct {
+	Coordinates []float64 `json:"coordinates"` // [lon, lat]
+}
+
+// photonProperties models the documented Photon API properties.
+// https://github.com/komoot/photon/blob/master/docs/api-v1.md
+type photonProperties struct {
+	Type        string `json:"type"`
+	CountryCode string `json:"countrycode"`
+	Name        string `json:"name"`
+	HouseNumber string `json:"housenumber"`
+	Street      string `json:"street"`
+	District    string `json:"district"`
+	City        string `json:"city"`
+	County      string `json:"county"`
+	State       string `json:"state"`
+	Country     string `json:"country"`
+	Postcode    string `json:"postcode"`
+}
+
+// Reverse performs a reverse geocode lookup using Photon.
+func (p *Photon) Reverse(lat, lon float64) (*Address, error) {
+	u, err := url.Parse(p.baseURL + "/reverse")
+	if err != nil {
+		return nil, fmt.Errorf("photon: parse URL: %w", err)
+	}
+	q := u.Query()
+	q.Set("lat", fmt.Sprintf("%f", lat))
+	q.Set("lon", fmt.Sprintf("%f", lon))
+	u.RawQuery = q.Encode()
+
+	resp, err := p.client.Get(u.String())
+	if err != nil {
+		return nil, fmt.Errorf("photon: request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 500 {
+		return nil, fmt.Errorf("photon: server error %d", resp.StatusCode)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("photon: HTTP %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("photon: read body: %w", err)
+	}
+
+	var result photonResponse
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("photon: unmarshal: %w", err)
+	}
+	if len(result.Features) == 0 {
+		return nil, fmt.Errorf("photon: no results")
+	}
+
+	feature := result.Features[0]
+	props := feature.Properties
+
+	// Extract coordinates from GeoJSON geometry (lon, lat order)
+	var resultLat, resultLon float64
+	if len(feature.Geometry.Coordinates) >= 2 {
+		resultLon = feature.Geometry.Coordinates[0]
+		resultLat = feature.Geometry.Coordinates[1]
+	}
+
+	components := photonComponents(props)
+
+	city := firstNonEmpty(strings.TrimSpace(props.City), components["city"])
+	countryCode := strings.ToUpper(strings.TrimSpace(props.CountryCode))
+	suburb := firstNonEmpty(components["suburb"], strings.TrimSpace(props.District))
+
+	addr := &Address{
+		Latitude:      resultLat,
+		Longitude:     resultLon,
+		Country:       firstNonEmpty(strings.TrimSpace(props.Country), components["country"]),
+		CountryCode:   countryCode,
+		State:         firstNonEmpty(strings.TrimSpace(props.State), components["state"]),
+		City:          city,
+		Zipcode:       firstNonEmpty(strings.TrimSpace(props.Postcode), components["postcode"]),
+		StreetName:    firstNonEmpty(strings.TrimSpace(props.Street), components["street"], components["road"]),
+		StreetNumber:  firstNonEmpty(strings.TrimSpace(props.HouseNumber), components["housenumber"], components["house_number"]),
+		Neighbourhood: strings.TrimSpace(props.District),
+		County:        firstNonEmpty(strings.TrimSpace(props.County), components["county"]),
+		Suburb:        suburb,
+	}
+
+	// Build FormattedAddress
+	if p.useCompact {
+		addr.FormattedAddress = FormatCompactAddress(*addr)
+	} else {
+		addr.FormattedAddress = p.formatOpenCage(components, countryCode)
+	}
+
+	return addr, nil
+}
+
+// formatOpenCage builds a FormattedAddress using OpenCage country templates.
+func (p *Photon) formatOpenCage(components map[string]string, countryCode string) string {
+	// Ensure country_code is set (uppercase)
+	components["country_code"] = countryCode
+
+	result := p.formatter.Format(components)
+	if result == "" {
+		// Fallback: build a simple comma-separated string
+		parts := filterNonEmpty(
+			strings.TrimSpace(components["road"]+" "+components["house_number"]),
+			components["postcode"]+" "+components["city"],
+			components["country"],
+		)
+		return strings.Join(parts, ", ")
+	}
+	return result
+}
+
+func photonComponents(props photonProperties) map[string]string {
+	components := map[string]string{
+		"type":        strings.TrimSpace(props.Type),
+		"countrycode": strings.TrimSpace(props.CountryCode),
+		"name":        strings.TrimSpace(props.Name),
+		"housenumber": strings.TrimSpace(props.HouseNumber),
+		"street":      strings.TrimSpace(props.Street),
+		"district":    strings.TrimSpace(props.District),
+		"city":        strings.TrimSpace(props.City),
+		"county":      strings.TrimSpace(props.County),
+		"state":       strings.TrimSpace(props.State),
+		"country":     strings.TrimSpace(props.Country),
+		"postcode":    strings.TrimSpace(props.Postcode),
+	}
+
+	for k, v := range components {
+		components[photonToOCKey(k)] = v
+	}
+
+	if propsType, name := components["type"], components["name"]; propsType != "" && name != "" && propsType != "house" {
+		components[propsType] = name
+		components[photonToOCKey(propsType)] = name
+	}
+
+	return components
+}
+
+// photonToOCKey maps Photon property names to OpenCage component names.
+func photonToOCKey(key string) string {
+	switch key {
+	case "housenumber":
+		return "house_number"
+	case "street":
+		return "road"
+	case "postcode":
+		return "postcode"
+	case "district":
+		return "city_district"
+	case "countrycode":
+		return "country_code"
+	default:
+		return key
+	}
+}
+
+// filterNonEmpty returns non-empty, non-whitespace strings from the arguments.
+func filterNonEmpty(ss ...string) []string {
+	var out []string
+	for _, s := range ss {
+		s = strings.TrimSpace(s)
+		if s != "" {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// Forward performs a forward geocode (address search) using Photon.
+func (p *Photon) Forward(query string) ([]ForwardResult, error) {
+	u, err := url.Parse(p.baseURL + "/api")
+	if err != nil {
+		return nil, fmt.Errorf("photon: parse URL: %w", err)
+	}
+	q := u.Query()
+	q.Set("q", query)
+	q.Set("limit", "5")
+	u.RawQuery = q.Encode()
+
+	resp, err := p.client.Get(u.String())
+	if err != nil {
+		return nil, fmt.Errorf("photon: request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 500 {
+		return nil, fmt.Errorf("photon: server error %d", resp.StatusCode)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("photon: HTTP %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("photon: read body: %w", err)
+	}
+
+	var result photonResponse
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("photon: unmarshal: %w", err)
+	}
+
+	out := make([]ForwardResult, 0, len(result.Features))
+	for _, f := range result.Features {
+		if len(f.Geometry.Coordinates) < 2 {
+			continue
+		}
+		components := photonComponents(f.Properties)
+		city := components["city"]
+		out = append(out, ForwardResult{
+			Latitude:  f.Geometry.Coordinates[1],
+			Longitude: f.Geometry.Coordinates[0],
+			City:      city,
+			Country:   components["country"],
+		})
+	}
+	return out, nil
+}

--- a/processor/internal/geocoding/photon.go
+++ b/processor/internal/geocoding/photon.go
@@ -15,23 +15,24 @@ import (
 // Photon implements Provider using the Photon geocoder API (komoot/photon).
 // Photon returns GeoJSON responses based on OpenStreetMap data.
 type Photon struct {
-	baseURL    string
-	client     *http.Client
-	formatter  *ocfmt.Formatter
-	useCompact bool // if true, use compact format instead of OpenCage templates
+	baseURL   string
+	client    *http.Client
+	formatter *ocfmt.Formatter
 }
 
-// NewPhoton creates a Photon provider. If useCompact is true, FormattedAddress
-// uses the compact "suburb: street, city" format instead of OpenCage templates.
-func NewPhoton(baseURL string, timeout time.Duration, useCompact bool) *Photon {
+// NewPhoton creates a Photon provider.
+// FormattedAddress is always populated via OpenCage country-specific
+// templates (ocfmt). Callers who want a different shape can drive it via
+// the existing address_format template with the per-field helpers
+// ({{{streetName}}}, {{{suburb}}}, {{{city}}}, etc.).
+func NewPhoton(baseURL string, timeout time.Duration) *Photon {
 	if timeout == 0 {
 		timeout = 10 * time.Second
 	}
 	return &Photon{
-		baseURL:    strings.TrimRight(baseURL, "/"),
-		client:     &http.Client{Timeout: timeout},
-		formatter:  ocfmt.Global(),
-		useCompact: useCompact,
+		baseURL:   strings.TrimRight(baseURL, "/"),
+		client:    &http.Client{Timeout: timeout},
+		formatter: ocfmt.Global(),
 	}
 }
 
@@ -81,7 +82,12 @@ func (p *Photon) Reverse(lat, lon float64) (*Address, error) {
 	if err != nil {
 		return nil, fmt.Errorf("photon: request failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		// Drain remaining body before close so HTTP/1.1 keep-alive can
+		// reuse the connection. Matches the pattern in nominatim/google.
+		io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+	}()
 
 	if resp.StatusCode >= 500 {
 		return nil, fmt.Errorf("photon: server error %d", resp.StatusCode)
@@ -119,7 +125,7 @@ func (p *Photon) Reverse(lat, lon float64) (*Address, error) {
 	countryCode := strings.ToUpper(strings.TrimSpace(props.CountryCode))
 	suburb := firstNonEmpty(components["suburb"], strings.TrimSpace(props.District))
 
-	streetName := photonStreetName(props, components, p.useCompact)
+	streetName := photonStreetName(props, components)
 
 	addr := &Address{
 		Latitude:      resultLat,
@@ -136,12 +142,8 @@ func (p *Photon) Reverse(lat, lon float64) (*Address, error) {
 		Suburb:        suburb,
 	}
 
-	// Build FormattedAddress
-	if p.useCompact {
-		addr.FormattedAddress = FormatCompactAddress(*addr)
-	} else {
-		addr.FormattedAddress = p.formatOpenCage(components, countryCode)
-	}
+	// Build FormattedAddress via OpenCage country-specific templates.
+	addr.FormattedAddress = p.formatOpenCage(components, countryCode)
 
 	return addr, nil
 }
@@ -191,12 +193,15 @@ func photonComponents(props photonProperties) map[string]string {
 	return components
 }
 
-func photonStreetName(props photonProperties, components map[string]string, useCompact bool) string {
+func photonStreetName(props photonProperties, components map[string]string) string {
 	streetName := firstNonEmpty(strings.TrimSpace(props.Street), components["street"], components["road"])
-	if !useCompact || streetName != "" {
+	if streetName != "" {
 		return streetName
 	}
 
+	// Photon returns "type":"other" for POIs and named features that aren't
+	// on a street. Surface Name as a sensible street-line fallback so
+	// templates like {{{streetName}}} don't render empty.
 	if strings.EqualFold(strings.TrimSpace(props.Type), "other") {
 		return strings.TrimSpace(props.Name)
 	}
@@ -249,7 +254,10 @@ func (p *Photon) Forward(query string) ([]ForwardResult, error) {
 	if err != nil {
 		return nil, fmt.Errorf("photon: request failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+	}()
 
 	if resp.StatusCode >= 500 {
 		return nil, fmt.Errorf("photon: server error %d", resp.StatusCode)

--- a/processor/internal/geocoding/photon.go
+++ b/processor/internal/geocoding/photon.go
@@ -74,7 +74,7 @@ func (p *Photon) Reverse(lat, lon float64) (*Address, error) {
 	q := u.Query()
 	q.Set("lat", fmt.Sprintf("%f", lat))
 	q.Set("lon", fmt.Sprintf("%f", lon))
-	q.Set("radius", "1")
+	q.Set("radius", "10")
 	u.RawQuery = q.Encode()
 
 	resp, err := p.client.Get(u.String())

--- a/processor/internal/geocoding/photon.go
+++ b/processor/internal/geocoding/photon.go
@@ -106,11 +106,11 @@ func (p *Photon) Reverse(lat, lon float64) (*Address, error) {
 	props := feature.Properties
 
 	// Extract coordinates from GeoJSON geometry (lon, lat order)
-	var resultLat, resultLon float64
-	if len(feature.Geometry.Coordinates) >= 2 {
-		resultLon = feature.Geometry.Coordinates[0]
-		resultLat = feature.Geometry.Coordinates[1]
+	if len(feature.Geometry.Coordinates) < 2 {
+		return nil, fmt.Errorf("photon: feature missing geometry coordinates")
 	}
+	resultLon := feature.Geometry.Coordinates[0]
+	resultLat := feature.Geometry.Coordinates[1]
 
 	components := photonComponents(props)
 

--- a/processor/internal/geocoding/photon_test.go
+++ b/processor/internal/geocoding/photon_test.go
@@ -125,7 +125,7 @@ func TestPhotonReverse(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	p := NewPhoton(srv.URL, 2*time.Second)
+	p := NewPhoton(srv.URL, 2*time.Second, true)
 	addr, err := p.Reverse(52.517, 13.389)
 	if err != nil {
 		t.Fatalf("Reverse: %v", err)
@@ -163,7 +163,7 @@ func TestPhotonReverseEmptyFeatures(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	p := NewPhoton(srv.URL, 2*time.Second)
+	p := NewPhoton(srv.URL, 2*time.Second, true)
 	if _, err := p.Reverse(0, 0); err == nil {
 		t.Fatal("expected error for empty features")
 	}
@@ -175,9 +175,51 @@ func TestPhotonReverseServerError(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	p := NewPhoton(srv.URL, 2*time.Second)
+	p := NewPhoton(srv.URL, 2*time.Second, true)
 	if _, err := p.Reverse(0, 0); err == nil {
 		t.Fatal("expected error for 500 response")
+	}
+}
+
+// TestPhotonReverseCountryExcluded verifies that includeCountry=false (the
+// default) strips the trailing country name from FormattedAddress while still
+// producing a country-idiomatic layout everywhere else. OpenCage's postformat
+// regex rules handle the dangling separator, so no manual cleanup needed.
+func TestPhotonReverseCountryExcluded(t *testing.T) {
+	const body = `{
+        "features": [{
+            "geometry": {"coordinates": [13.388860, 52.517037]},
+            "properties": {
+                "type": "house", "countrycode": "DE", "housenumber": "1",
+                "street": "Unter den Linden", "city": "Berlin",
+                "state": "Berlin", "country": "Germany", "postcode": "10117"
+            }
+        }]
+    }`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	p := NewPhoton(srv.URL, 2*time.Second, false)
+	addr, err := p.Reverse(52.517, 13.389)
+	if err != nil {
+		t.Fatalf("Reverse: %v", err)
+	}
+	if strings.Contains(addr.FormattedAddress, "Germany") {
+		t.Errorf("FormattedAddress should not contain country when includeCountry=false, got %q", addr.FormattedAddress)
+	}
+	// The rest of the country-idiomatic layout should still be present.
+	for _, want := range []string{"Unter den Linden", "10117", "Berlin"} {
+		if !strings.Contains(addr.FormattedAddress, want) {
+			t.Errorf("FormattedAddress %q missing %q", addr.FormattedAddress, want)
+		}
+	}
+	// Country component fields stay populated — templates that reference
+	// {{{country}}} still work; we only control FormattedAddress shape.
+	if addr.Country != "Germany" || addr.CountryCode != "DE" {
+		t.Errorf("component fields should stay populated, got Country=%q CountryCode=%q", addr.Country, addr.CountryCode)
 	}
 }
 
@@ -202,7 +244,7 @@ func TestPhotonForward(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	p := NewPhoton(srv.URL, 2*time.Second)
+	p := NewPhoton(srv.URL, 2*time.Second, true)
 	results, err := p.Forward("london")
 	if err != nil {
 		t.Fatalf("Forward: %v", err)

--- a/processor/internal/geocoding/photon_test.go
+++ b/processor/internal/geocoding/photon_test.go
@@ -1,0 +1,163 @@
+package geocoding
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestPhotonComponentsPromotesNameByType(t *testing.T) {
+	props := photonProperties{
+		Type:        "city",
+		Name:        "Berlin",
+		CountryCode: "de",
+		Country:     "Germany",
+	}
+
+	components := photonComponents(props)
+
+	if got := components["city"]; got != "Berlin" {
+		t.Fatalf("expected promoted city to be Berlin, got %q", got)
+	}
+	if got := components["country_code"]; got != "de" {
+		t.Fatalf("expected country_code to mirror countrycode, got %q", got)
+	}
+}
+
+func TestPhotonComponentsPromotesRoadFromNameType(t *testing.T) {
+	props := photonProperties{
+		Type: "street",
+		Name: "Unter den Linden",
+	}
+
+	components := photonComponents(props)
+
+	if got := components["street"]; got != "Unter den Linden" {
+		t.Fatalf("expected street from name/type promotion, got %q", got)
+	}
+	if got := components["road"]; got != "Unter den Linden" {
+		t.Fatalf("expected road alias from name/type promotion, got %q", got)
+	}
+}
+
+func TestPhotonComponentsDoesNotPromoteHouseFromNameType(t *testing.T) {
+	props := photonProperties{
+		Type: "house",
+		Name: "I-Punkt Skateland",
+	}
+
+	components := photonComponents(props)
+
+	if got := components["house"]; got != "" {
+		t.Fatalf("expected house promotion to be skipped, got %q", got)
+	}
+}
+
+func TestFormatCompactAddress(t *testing.T) {
+	tests := []struct {
+		name string
+		addr Address
+		want string
+	}{
+		{
+			name: "suburb street city",
+			addr: Address{Suburb: "Mitte", StreetName: "Friedrichstrasse", StreetNumber: "42", City: "Berlin"},
+			want: "Mitte: Friedrichstrasse 42, Berlin",
+		},
+		{
+			name: "city street when no suburb",
+			addr: Address{StreetName: "Main Street", StreetNumber: "1", City: "Springfield"},
+			want: "Springfield: Main Street 1",
+		},
+		{
+			name: "city only",
+			addr: Address{City: "Munich"},
+			want: "Munich:",
+		},
+		{
+			name: "formatted address fallback",
+			addr: Address{FormattedAddress: "Berlin Germany"},
+			want: "Berlin Germany",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FormatCompactAddress(tt.addr)
+			if got != tt.want {
+				t.Fatalf("FormatCompactAddress() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPhotonStreetName(t *testing.T) {
+	tests := []struct {
+		name       string
+		props      photonProperties
+		components map[string]string
+		compact    bool
+		want       string
+	}{
+		{
+			name:       "uses street when present",
+			props:      photonProperties{Street: "Main Street", Name: "POI Name", Type: "other"},
+			components: map[string]string{},
+			compact:    true,
+			want:       "Main Street",
+		},
+		{
+			name:       "uses name for compact other with no street",
+			props:      photonProperties{Type: "other", Name: "I-Punkt Skateland"},
+			components: map[string]string{},
+			compact:    true,
+			want:       "I-Punkt Skateland",
+		},
+		{
+			name:       "does not use name for non-compact",
+			props:      photonProperties{Type: "other", Name: "I-Punkt Skateland"},
+			components: map[string]string{},
+			compact:    false,
+			want:       "",
+		},
+		{
+			name:       "does not use name for non-other type",
+			props:      photonProperties{Type: "city", Name: "Berlin"},
+			components: map[string]string{},
+			compact:    true,
+			want:       "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := photonStreetName(tt.props, tt.components, tt.compact)
+			if got != tt.want {
+				t.Fatalf("photonStreetName() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPhotonTypeAliasMapping(t *testing.T) {
+	cases := map[string]string{
+		"housenumber": "house_number",
+		"street":      "road",
+		"district":    "city_district",
+		"countrycode": "country_code",
+		"city":        "city",
+	}
+
+	for in, want := range cases {
+		if got := photonToOCKey(in); got != want {
+			t.Fatalf("photonToOCKey(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestFilterNonEmpty(t *testing.T) {
+	got := filterNonEmpty("", "  a  ", " ", "b")
+	want := []string{"a", "b"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("filterNonEmpty() = %#v, want %#v", got, want)
+	}
+}

--- a/processor/internal/geocoding/photon_test.go
+++ b/processor/internal/geocoding/photon_test.go
@@ -1,8 +1,12 @@
 package geocoding
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"reflect"
+	"strings"
 	"testing"
+	"time"
 )
 
 func TestPhotonComponentsPromotesNameByType(t *testing.T) {
@@ -52,89 +56,162 @@ func TestPhotonComponentsDoesNotPromoteHouseFromNameType(t *testing.T) {
 	}
 }
 
-func TestFormatCompactAddress(t *testing.T) {
-	tests := []struct {
-		name string
-		addr Address
-		want string
-	}{
-		{
-			name: "suburb street city",
-			addr: Address{Suburb: "Mitte", StreetName: "Friedrichstrasse", StreetNumber: "42", City: "Berlin"},
-			want: "Mitte: Friedrichstrasse 42, Berlin",
-		},
-		{
-			name: "city street when no suburb",
-			addr: Address{StreetName: "Main Street", StreetNumber: "1", City: "Springfield"},
-			want: "Springfield: Main Street 1",
-		},
-		{
-			name: "city only",
-			addr: Address{City: "Munich"},
-			want: "Munich:",
-		},
-		{
-			name: "formatted address fallback",
-			addr: Address{FormattedAddress: "Berlin Germany"},
-			want: "Berlin Germany",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := FormatCompactAddress(tt.addr)
-			if got != tt.want {
-				t.Fatalf("FormatCompactAddress() = %q, want %q", got, tt.want)
-			}
-		})
-	}
-}
-
 func TestPhotonStreetName(t *testing.T) {
 	tests := []struct {
 		name       string
 		props      photonProperties
 		components map[string]string
-		compact    bool
 		want       string
 	}{
 		{
 			name:       "uses street when present",
 			props:      photonProperties{Street: "Main Street", Name: "POI Name", Type: "other"},
 			components: map[string]string{},
-			compact:    true,
 			want:       "Main Street",
 		},
 		{
-			name:       "uses name for compact other with no street",
+			name:       "falls back to name for type=other with no street",
 			props:      photonProperties{Type: "other", Name: "I-Punkt Skateland"},
 			components: map[string]string{},
-			compact:    true,
 			want:       "I-Punkt Skateland",
 		},
 		{
-			name:       "does not use name for non-compact",
-			props:      photonProperties{Type: "other", Name: "I-Punkt Skateland"},
-			components: map[string]string{},
-			compact:    false,
-			want:       "",
-		},
-		{
-			name:       "does not use name for non-other type",
+			name:       "does not surface name for non-other type",
 			props:      photonProperties{Type: "city", Name: "Berlin"},
 			components: map[string]string{},
-			compact:    true,
 			want:       "",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := photonStreetName(tt.props, tt.components, tt.compact)
+			got := photonStreetName(tt.props, tt.components)
 			if got != tt.want {
 				t.Fatalf("photonStreetName() = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+// TestPhotonReverse exercises the HTTP → parse → Address path with a stub
+// server returning a representative Photon GeoJSON response. Covers the
+// component mapping, OpenCage templating, and county propagation in one
+// shot so regressions in the Reverse pipeline surface here.
+func TestPhotonReverse(t *testing.T) {
+	const body = `{
+        "features": [{
+            "geometry": {"coordinates": [13.388860, 52.517037]},
+            "properties": {
+                "type": "house",
+                "countrycode": "DE",
+                "housenumber": "1",
+                "street": "Unter den Linden",
+                "city": "Berlin",
+                "district": "Mitte",
+                "state": "Berlin",
+                "country": "Germany",
+                "postcode": "10117",
+                "county": "Mitte"
+            }
+        }]
+    }`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasPrefix(r.URL.Path, "/reverse") {
+			t.Errorf("expected /reverse, got %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	p := NewPhoton(srv.URL, 2*time.Second)
+	addr, err := p.Reverse(52.517, 13.389)
+	if err != nil {
+		t.Fatalf("Reverse: %v", err)
+	}
+
+	if addr.CountryCode != "DE" {
+		t.Errorf("CountryCode = %q, want DE", addr.CountryCode)
+	}
+	if addr.City != "Berlin" {
+		t.Errorf("City = %q, want Berlin", addr.City)
+	}
+	if addr.StreetName != "Unter den Linden" {
+		t.Errorf("StreetName = %q, want Unter den Linden", addr.StreetName)
+	}
+	if addr.StreetNumber != "1" {
+		t.Errorf("StreetNumber = %q, want 1", addr.StreetNumber)
+	}
+	if addr.County != "Mitte" {
+		t.Errorf("County = %q, want Mitte", addr.County)
+	}
+	// OpenCage DE template yields something like "Unter den Linden 1, 10117 Berlin, Germany".
+	if addr.FormattedAddress == "" {
+		t.Error("FormattedAddress should not be empty")
+	}
+	for _, want := range []string{"Unter den Linden", "10117", "Berlin", "Germany"} {
+		if !strings.Contains(addr.FormattedAddress, want) {
+			t.Errorf("FormattedAddress %q missing %q", addr.FormattedAddress, want)
+		}
+	}
+}
+
+func TestPhotonReverseEmptyFeatures(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"features":[]}`))
+	}))
+	defer srv.Close()
+
+	p := NewPhoton(srv.URL, 2*time.Second)
+	if _, err := p.Reverse(0, 0); err == nil {
+		t.Fatal("expected error for empty features")
+	}
+}
+
+func TestPhotonReverseServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	p := NewPhoton(srv.URL, 2*time.Second)
+	if _, err := p.Reverse(0, 0); err == nil {
+		t.Fatal("expected error for 500 response")
+	}
+}
+
+func TestPhotonForward(t *testing.T) {
+	const body = `{
+        "features": [
+            {"geometry": {"coordinates": [-0.127758, 51.507351]},
+             "properties": {"name": "London", "country": "United Kingdom", "countrycode": "GB"}},
+            {"geometry": {"coordinates": [-0.13, 51.51]},
+             "properties": {"name": "Westminster", "city": "London", "country": "United Kingdom", "countrycode": "GB"}}
+        ]
+    }`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasPrefix(r.URL.Path, "/api") {
+			t.Errorf("expected /api, got %s", r.URL.Path)
+		}
+		if r.URL.Query().Get("q") != "london" {
+			t.Errorf("query %q, want london", r.URL.Query().Get("q"))
+		}
+		w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	p := NewPhoton(srv.URL, 2*time.Second)
+	results, err := p.Forward("london")
+	if err != nil {
+		t.Fatalf("Forward: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("got %d results, want 2", len(results))
+	}
+	if results[0].Latitude != 51.507351 || results[0].Longitude != -0.127758 {
+		t.Errorf("coords swapped: %v, %v", results[0].Latitude, results[0].Longitude)
 	}
 }
 


### PR DESCRIPTION
Takes over #47 (thanks @ccev) and lands it on `goodbye-node` instead of `main` so it doesn't need a second rebase once Goodbye Node merges. Addresses the review on that PR and extends the OpenCage treatment to Nominatim.

## What's in here

**From #47 (ccev's work, cherry-picked with author preserved):**
- Photon reverse-geocoding provider (`processor/internal/geocoding/photon.go`)
- OpenCage address formatting engine (`processor/internal/geocoding/ocfmt/`) with vendored `worldwide.yaml` (~4000 lines of country-specific templates)
- New `county` component field on the `Address` struct
- Performance / validation improvements from ccev's follow-up commits

**Review items applied (see comments on #47):**
1. Dropped `photon_address_format` config + `FormatCompactAddress` helper. FormattedAddress is now always populated via OpenCage; users drive any other shape via the standard `address_format` template.
2. `.gitignore` editor-specific entries reverted (already covered by the branch's `.idea/` / `*.iml` rules).
3. Whitespace-only reformat of `enrichment.Enricher` reverted; only the substantive `county` + `addGeoResult` additions kept.
4. Tests added: `ocfmt_test.go` (US / DE / missing fields / unknown country / YAML parse), expanded `photon_test.go` with `httptest`-backed Reverse + Forward + empty-features and 500 error paths.
5. Response-body drain added on Reverse/Forward error paths so HTTP/1.1 keep-alive works — matches the nominatim/google pattern.
6. `county` field kept.

**Additional: unify address handling across providers.**
- **Nominatim now routes through ocfmt** the same way Photon does, so FormattedAddress is country-idiomatic regardless of provider. Nominatim's raw `display_name` is preserved as a new `Address.DisplayName` field, accessible via `{{{displayName}}}` for operators who relied on the old shape.
- **`address_format` compiles through raymond** (our Handlebars fork — already in the binary for DTS). PoracleJS templates using `{{#if suburb}}{{suburb}}: {{/if}}…` start working again, and the `FormatCompactAddress` helper we dropped is trivially rebuildable in template form.

Compiled once at Geocoder construction; executed per address — no per-call parse cost. The legacy `{{{field}}}` templates continue to work unchanged (triple-brace is unescaped in both the old replacer and Handlebars).

## ⚠️ Default change — worth a second pair of eyes

The in-code default for `locale.address_format` was `"{{{streetName}}} {{streetNumber}}"`; this PR flips it to `""` (empty). Blank means "skip raymond entirely and use the OpenCage-formatted `FormattedAddress` directly."

- **Fresh installs / installs that never touched `address_format`:** `{{addr}}` now renders as the country-idiomatic full address (e.g. `"Unter den Linden 1, 10117 Berlin, Germany"`) instead of just the street line (`"Unter den Linden 1"`). That's a visible output change in every DTS template that uses `{{addr}}` / `{{{addr}}}`.
- **Installs that set `address_format` explicitly in their `config.toml`:** unaffected — their template wins.
- **Installs that deliberately relied on the old default without overriding:** behaviour changes. Restoring the previous output is one config line:
  ```toml
  [locale]
  address_format = "{{{streetName}}} {{streetNumber}}"
  ```

**Arguments for flipping the default:**
- The OpenCage string is almost always more useful than just the street line — it's what PoracleJS users typically hand-templated to approximate.
- With ocfmt wired in, the country-idiomatic default is genuinely good (tested across US, DE, FR, GB, JP).
- Keeps the zero-config "just works" story coherent: new operators don't have to learn the template syntax to get a sensible `{{addr}}`.

**Arguments against:**
- It's a behavioural break for existing installs who used the compiled-in default. Their alerts' `{{addr}}` text will change on upgrade without any config edit on their part.
- Most operators in practice have a custom `address_format` already (this is a commonly-edited line), so the blast radius may be small — but I don't have hard numbers on that.

**Alternatives to consider:**
1. **Keep the old default** (`"{{{streetName}}} {{streetNumber}}"`) to preserve upgrade semantics, and just document the empty-string option.
2. **Flip the default** (current PR behaviour) and add a CHANGELOG / release-note entry calling it out.
3. **Compromise:** keep the old default in-code for existing installs, add a comment in `config.example.toml` recommending blank for new ones.

I'm leaning 2 but happy to revert to 1 if the upgrade-break concern outweighs the better default. Flagging explicitly so it's a deliberate choice, not a drive-by.

## FormatCompactAddress equivalent

Example shipped in `config/config.example.toml`:

```toml
address_format = "{{#if suburb}}{{suburb}}{{else}}{{city}}{{/if}}:{{#if streetName}} {{streetName}}{{#if streetNumber}} {{streetNumber}}{{/if}}{{/if}}{{#if suburb}}, {{city}}{{/if}}"
```

Produces:
- `"Mitte: Friedrichstrasse 42, Berlin"` when a suburb is known
- `"Springfield: Main Street 1"` when only city is
- `"Munich:"` when only city is known and no street

Verified by `TestAddressTemplateCompactEquivalent` in `processor/internal/geocoding/address_test.go`.

## Closes
- #47 — this replaces it. Supersedes, doesn't discard: every ccev commit is preserved with original authorship.

🤖 Generated with [Claude Code](https://claude.ai/code)
