### PR TITLE
Default weather.enable_inference to true

### DIFF
--- a/processor/internal/api/config_schema.go
+++ b/processor/internal/api/config_schema.go
@@ -268,7 +268,7 @@ var configSchema = []ConfigSection{
 		Name:  "weather",
 		Title: "Weather",
 		Fields: []ConfigFieldDef{
-			{Name: "enable_inference", Type: "bool", Default: false, Description: "Infer weather conditions from pokemon boost patterns"},
+			{Name: "enable_inference", Type: "bool", Default: true, Description: "Infer weather conditions from pokemon boost patterns"},
 			{Name: "change_alert", Type: "bool", Default: false, Description: "Enable weather change alert notifications"},
 			{Name: "show_altered_pokemon", Type: "bool", Default: false, Description: "Track weather-changed pokemon to show in DTS weather alerts"},
 			{Name: "show_altered_pokemon_max_count", Type: "int", Default: 10, Description: "Maximum number of changed pokemon per weather alert", DependsOn: &ConfigDependency{Field: "show_altered_pokemon", Value: true}},

--- a/processor/internal/config/config.go
+++ b/processor/internal/config/config.go
@@ -698,6 +698,7 @@ func Load(baseDir string) (*Config, error) {
 			// need a specific shape override in config.toml.
 		},
 		Weather: WeatherConfig{
+			EnableInference:            true,
 			ShowAlteredPokemonMaxCount: 10,
 			AccuWeatherDayQuota:        500,
 			ForecastRefreshInterval:    8,


### PR DESCRIPTION
## Summary

- Flip the code default for `[weather] enable_inference` from `false` to `true` in `WeatherConfig` (`processor/internal/config/config.go`).
- Flip the matching default in the config-editor schema (`processor/internal/api/config_schema.go`) so the web UI shows the same default.

Weather inference fills in a pokemon's weather cell from the in-game boost when Golbat omits weather data — useful enough that it should be on out of the box. The example config already shows the commented line as `#enable_inference = true`, so this just makes code/schema match the documented value.

Operators who want it off can still set `enable_inference = false` in their `config.toml`.

## Test plan

- [ ] `go build ./...` in `processor/` succeeds
- [ ] `go test ./internal/config/... ./internal/api/...` green (verified locally)
- [ ] Fresh install with no `[weather] enable_inference` line: confirm processor logs / behaviour show inference active
- [ ] Existing install with explicit `enable_inference = false`: confirm that override still disables inference

🤖 Generated with [Claude Code](https://claude.com/claude-code)