### PR TITLE
pokemon: inherit Clean on monsterChanged reply

### DIFF
--- a/processor/cmd/processor/pokemon.go
+++ b/processor/cmd/processor/pokemon.go
@@ -204,14 +204,10 @@ func (ps *ProcessorService) ProcessPokemon(raw json.RawMessage) error {
 				if _, ok := matchedIDs[targetID]; ok {
 					continue
 				}
-				// Inherit Clean from the prior alert so the
-				// monsterChanged reply auto-deletes alongside the
-				// original on TTL — without this, the original
-				// disappears at expiry but the "your pokemon
-				// changed" reply persists.
 				prior := tracker.LookupReplyMessage(pokemon.EncounterID, targetID)
 				if prior == nil {
-					continue // raced with eviction
+					// Prior already TTL-evicted; original is gone, nothing to reply to.
+					continue
 				}
 				if u := ps.rebuildMatchedUserForChange(targetID, prior.Clean); u != nil {
 					priorOnlyUsers = append(priorOnlyUsers, *u)

--- a/processor/cmd/processor/pokemon.go
+++ b/processor/cmd/processor/pokemon.go
@@ -199,11 +199,21 @@ func (ps *ProcessorService) ProcessPokemon(raw json.RawMessage) error {
 			for _, u := range matched {
 				matchedIDs[u.ID] = struct{}{}
 			}
-			for _, targetID := range ps.dispatcher.MessageTracker().LookupReplyTargets(pokemon.EncounterID) {
+			tracker := ps.dispatcher.MessageTracker()
+			for _, targetID := range tracker.LookupReplyTargets(pokemon.EncounterID) {
 				if _, ok := matchedIDs[targetID]; ok {
 					continue
 				}
-				if u := ps.rebuildMatchedUserForChange(targetID); u != nil {
+				// Inherit Clean from the prior alert so the
+				// monsterChanged reply auto-deletes alongside the
+				// original on TTL — without this, the original
+				// disappears at expiry but the "your pokemon
+				// changed" reply persists.
+				prior := tracker.LookupReplyMessage(pokemon.EncounterID, targetID)
+				if prior == nil {
+					continue // raced with eviction
+				}
+				if u := ps.rebuildMatchedUserForChange(targetID, prior.Clean); u != nil {
 					priorOnlyUsers = append(priorOnlyUsers, *u)
 				}
 			}
@@ -432,11 +442,12 @@ func (ps *ProcessorService) perLangWithChangeFields(perLang map[string]map[strin
 
 // rebuildMatchedUserForChange synthesises a MatchedUser for a target
 // that had a prior alert for this encounter but no longer matches.
-// Rule-specific fields (Template, Clean, Ping, Distance) stay at
-// zero values — the T1 tracking rule isn't known here and may have
-// been deleted or edited since. Returns nil for unknown or disabled
-// humans; their reply-index entry expires on its own.
-func (ps *ProcessorService) rebuildMatchedUserForChange(targetID string) *webhook.MatchedUser {
+// Clean is inherited from the prior tracked message so the
+// monsterChanged reply follows the same auto-delete behaviour as
+// the original. Template / Ping / Distance stay at zero values —
+// the T1 tracking rule isn't known here. Returns nil for unknown
+// or disabled humans; their reply-index entry expires on its own.
+func (ps *ProcessorService) rebuildMatchedUserForChange(targetID string, clean int) *webhook.MatchedUser {
 	if ps.humans == nil {
 		return nil
 	}
@@ -452,6 +463,7 @@ func (ps *ProcessorService) rebuildMatchedUserForChange(targetID string) *webhoo
 		Type:     human.Type,
 		Name:     human.Name,
 		Language: effectiveLanguage(webhook.MatchedUser{Language: human.Language}, ps.cfg.General.Locale),
+		Clean:    clean,
 	}
 }
 

--- a/processor/cmd/processor/pokemon_change_test.go
+++ b/processor/cmd/processor/pokemon_change_test.go
@@ -126,7 +126,9 @@ func TestDispatchPokemonAlert_PriorOnlyNoLongerMatches(t *testing.T) {
 	ps, ch, _ := minimalProcessor(t)
 
 	encounterID := "enc-bad-news"
-	priorOnly := webhook.MatchedUser{ID: "user-bad-news", Type: "discord:user"}
+	// Clean=1 simulates inheritance from the T1 message so the
+	// monsterChanged reply auto-deletes alongside the original.
+	priorOnly := webhook.MatchedUser{ID: "user-bad-news", Type: "discord:user", Clean: 1}
 
 	change := &tracker.EncounterChange{
 		EncounterID: encounterID,
@@ -165,6 +167,9 @@ func TestDispatchPokemonAlert_PriorOnlyNoLongerMatches(t *testing.T) {
 	}
 	if len(j.MatchedUsers) != 1 || j.MatchedUsers[0].ID != "user-bad-news" {
 		t.Errorf("MatchedUsers should be [user-bad-news], got %v", j.MatchedUsers)
+	}
+	if j.MatchedUsers[0].Clean != 1 {
+		t.Errorf("Clean must propagate from priorOnly fixture into the RenderJob's MatchedUser (else monsterChanged outlives the original): got %d, want 1", j.MatchedUsers[0].Clean)
 	}
 	// Template-facing fields: the collapsed bucket + localised label.
 	// minimalProcessor has no Translations bundle, so T() returns the

--- a/processor/cmd/processor/pokemon_change_test.go
+++ b/processor/cmd/processor/pokemon_change_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/pokemon/poracleng/processor/internal/delivery"
 	"github.com/pokemon/poracleng/processor/internal/enrichment"
 	"github.com/pokemon/poracleng/processor/internal/staticmap"
+	"github.com/pokemon/poracleng/processor/internal/store"
 	"github.com/pokemon/poracleng/processor/internal/tracker"
 	"github.com/pokemon/poracleng/processor/internal/webhook"
 )
@@ -251,6 +252,41 @@ func TestDispatchPokemonAlert_WeatherBoost_StatsBucket(t *testing.T) {
 	}
 	if got := j.PerLangEnrichment[lang]["changeTypeText"]; got != "change_type_text_stats" {
 		t.Errorf("PerLangEnrichment[%s][changeTypeText] = %v, want fallback key", lang, got)
+	}
+}
+
+// rebuildMatchedUserForChange must stamp the prior message's Clean
+// onto the synthesised MatchedUser so the monsterChanged reply
+// inherits the same TTL clean-delete behaviour as the original.
+// Defaulting Clean to zero was the bug that left orphan reply
+// messages in the channel after the original auto-deleted.
+func TestRebuildMatchedUserForChange_InheritsClean(t *testing.T) {
+	ps, _, _ := minimalProcessor(t)
+	humans := store.NewMockHumanStore()
+	humans.AddHuman(&store.Human{
+		ID:       "user-1",
+		Type:     "discord:user",
+		Name:     "Tester",
+		Enabled:  true,
+		Language: "en",
+	})
+	ps.humans = humans
+
+	got := ps.rebuildMatchedUserForChange("user-1", 1)
+	if got == nil {
+		t.Fatalf("rebuildMatchedUserForChange returned nil for a registered enabled human")
+	}
+	if got.Clean != 1 {
+		t.Errorf("Clean = %d, want 1 (inherited from prior tracked message)", got.Clean)
+	}
+	if got.ID != "user-1" || got.Type != "discord:user" || got.Name != "Tester" {
+		t.Errorf("identity fields wrong: %+v", *got)
+	}
+
+	// Disabled humans drop out so their reply-index entry expires naturally.
+	humans.AddHuman(&store.Human{ID: "user-2", Enabled: false})
+	if got := ps.rebuildMatchedUserForChange("user-2", 1); got != nil {
+		t.Errorf("disabled human should produce nil MatchedUser, got %+v", *got)
 	}
 }
 

--- a/processor/internal/delivery/tracker.go
+++ b/processor/internal/delivery/tracker.go
@@ -151,20 +151,34 @@ func (mt *MessageTracker) LookupReplyTargets(replyKey string) []string {
 // reverse-index map then cache. Returns "" if the cache entry has
 // expired between the two reads (treated as "no prior").
 func (mt *MessageTracker) LookupReply(replyKey, target string) string {
-	if replyKey == "" {
+	msg := mt.LookupReplyMessage(replyKey, target)
+	if msg == nil {
 		return ""
+	}
+	return msg.SentID
+}
+
+// LookupReplyMessage returns the full TrackedMessage for the latest
+// message under this (replyKey, target) pair, or nil if none. Used
+// by change-event dispatch to inherit rule-level fields (Clean,
+// Type) from the prior alert when reconstructing a recipient.
+// Same race semantics as LookupReply: nil if the cache entry
+// expires between the index read and the cache read.
+func (mt *MessageTracker) LookupReplyMessage(replyKey, target string) *TrackedMessage {
+	if replyKey == "" {
+		return nil
 	}
 	mt.repliesMu.RLock()
 	editKey, ok := mt.replies[replyKey][target]
 	mt.repliesMu.RUnlock()
 	if !ok {
-		return ""
+		return nil
 	}
 	item := mt.cache.Get(editKey)
 	if item == nil {
-		return ""
+		return nil
 	}
-	return item.Value().SentID
+	return item.Value()
 }
 
 // LookupEdit returns the tracked message for the given edit key, or nil if not found/expired.

--- a/processor/internal/delivery/tracker_test.go
+++ b/processor/internal/delivery/tracker_test.go
@@ -260,6 +260,41 @@ func TestLookupReplyReturnsLatest(t *testing.T) {
 	}
 }
 
+// LookupReplyMessage must return the full prior TrackedMessage so
+// change-event dispatch can inherit rule-level fields (Clean, Type)
+// when reconstructing prior-only recipients. Without this, the
+// monsterChanged reply doesn't auto-delete alongside the original.
+func TestLookupReplyMessage_ReturnsFullPrior(t *testing.T) {
+	mt, _ := newTestTracker(t)
+
+	mt.Track("edit-clean", &TrackedMessage{
+		SentID: "msg-clean", Target: "userA", Type: "discord:user",
+		Clean: 1, ReplyKey: "enc-x",
+	}, time.Hour)
+
+	got := mt.LookupReplyMessage("enc-x", "userA")
+	if got == nil {
+		t.Fatalf("LookupReplyMessage returned nil for a live entry")
+	}
+	if got.SentID != "msg-clean" {
+		t.Errorf("SentID = %q, want msg-clean", got.SentID)
+	}
+	if got.Clean != 1 {
+		t.Errorf("Clean = %d, want 1 (inherited by monsterChanged dispatch)", got.Clean)
+	}
+	if got.Type != "discord:user" {
+		t.Errorf("Type = %q, want discord:user", got.Type)
+	}
+
+	// Misses return nil.
+	if got := mt.LookupReplyMessage("enc-x", "userB"); got != nil {
+		t.Errorf("LookupReplyMessage cross-target = %+v, want nil", got)
+	}
+	if got := mt.LookupReplyMessage("", "userA"); got != nil {
+		t.Errorf("LookupReplyMessage empty key = %+v, want nil", got)
+	}
+}
+
 func TestLookupReplyTargets_EnumeratesAllAndEvicts(t *testing.T) {
 	mt, _ := newTestTracker(t)
 


### PR DESCRIPTION
## Summary

Bug: when a tracked pokemon's species or weather boost changed, the original \`monster\` (Clean=1) was auto-deleted on TTL but the \`monsterChanged\` reply persisted forever — leaving an orphan \"originally seen as …\" message in the channel after the original disappeared.

Cause: \`rebuildMatchedUserForChange\` left \`Clean: 0\` with the reasoning that \"the T1 tracking rule isn't known here\". But Clean is stored on the prior \`TrackedMessage\` itself, which the reply index already points at — no need to know the rule, just inherit.

## Changes

- \`MessageTracker.LookupReplyMessage(replyKey, target)\` returns the full prior \`TrackedMessage\`. \`LookupReply\` becomes a thin wrapper.
- \`ProcessPokemon\`'s priorOnly loop reads \`prior.Clean\` per target and passes it to \`rebuildMatchedUserForChange(targetID, clean int)\`, which stamps it on the synthesised \`MatchedUser\`.
- Template / Ping / Distance still default to zero — per-rule and not stored on \`TrackedMessage\`.

## Test plan

- [x] \`TestLookupReplyMessage_ReturnsFullPrior\` — new method returns full struct, nil on miss.
- [x] \`TestDispatchPokemonAlert_PriorOnlyNoLongerMatches\` — Clean=1 on the priorOnly fixture survives into the RenderJob's MatchedUser.
- [x] Full suite green, race detector clean on \`cmd/processor\` + \`internal/delivery\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)