### PR TITLE
pokemon: fire monsterChanged on ChangeEncountered for prior-only users

### DIFF
--- a/DTS.md
+++ b/DTS.md
@@ -360,12 +360,11 @@ fired the alert. Use these in templates to switch wording or styling:
 | `changeType` | Fires for | Meaning |
 |---|---|---|
 | `species` | `ChangeSpecies`, `ChangeForm`, `ChangeGender` | Identity change. Most commonly community-day re-classifications, or the known "A/B pokemon" server bug where Golbat reports a different species ID for the same encounter. |
-| `stats` | `ChangeWeatherBoost` | Same pokemon, weather boost shifted. Post-boost IVs and CP differ from the originally-alerted state. This is the most common cause in practice. |
+| `stats` | `ChangeWeatherBoost`, `ChangeEncountered` | Same pokemon, different effective stats. Weather-boost shifts the CP/level post-encounter; ChangeEncountered fires when the encounter scan reveals IV/CP/level values that reject the user's tracking filter (closing the loop on the optimistic `monsterNoIv` they got at the wild scan). |
 
-The `ChangeEncountered` dimension (CP 0 → >0, "IVs just arrived") does **not**
-fire `monsterChanged`. Users who were tracking IV-insensitive ("any pokemon of
-species X") get a regular `monster` reply to their `monsterNoIv` alert; users
-whose IV filter excluded the post-encounter stats get no follow-up at all.
+Users who still match at T2 (no stat filter, or filter still passes)
+receive a regular `monster` reply via the matched path — `monsterChanged`
+only fires for recipients whose filter excluded the new state.
 
 PoracleNG ships a default `monsterChanged` template per platform in
 `fallbacks/dts.json`; admins override via `config/dts.json` or

--- a/processor/cmd/processor/pokemon.go
+++ b/processor/cmd/processor/pokemon.go
@@ -350,12 +350,13 @@ func (ps *ProcessorService) dispatchPokemonAlert(in pokemonDispatchInput) {
 		}
 	}
 
-	// Bucket 2: prior-only users → `monsterChanged`, grouped by language.
-	// ChangeEncountered (CP 0 → >0) is filtered out — IV reveal isn't a
-	// change worth notifying about for users whose filter excluded the
-	// new state; the matched-still-matches path already covers users
-	// whose rule was IV-insensitive.
-	if len(in.priorOnlyUsers) > 0 && in.change != nil && in.change.Type != tracker.ChangeEncountered {
+	// Bucket 2: prior-only users → `monsterChanged`, grouped by
+	// language. ChangeEncountered fires too: the prior was a
+	// monsterNoIv "this might be one you care about" alert and we
+	// owe the user a follow-up when the IV/CP/level/etc. reveal
+	// rejects their filter, otherwise the optimistic T1 alert is
+	// left dangling.
+	if len(in.priorOnlyUsers) > 0 && in.change != nil {
 		bucket := changeTypeBucket(in.change.Type)
 
 		var perLangOriginal map[string]map[string]any
@@ -395,14 +396,14 @@ func (ps *ProcessorService) dispatchPokemonAlert(in pokemonDispatchInput) {
 
 // changeTypeBucket collapses the 5-value tracker.ChangeType enum into
 // the two template-facing values:
-//   - "stats" for weather-boost-driven CP/IV shifts (same pokemon,
-//     different effective stats).
-//   - "species" for everything else (species, form, gender — all
-//     identity changes; gender alone effectively never fires).
-//
-// ChangeEncountered is filtered upstream and never reaches here.
+//   - "stats" for ChangeWeatherBoost (post-encounter CP shift) and
+//     ChangeEncountered (IV/CP reveal that rejected the user's filter).
+//     Both are "same pokemon, different effective stats".
+//   - "species" for ChangeSpecies/Form/Gender — identity changes
+//     (gender alone effectively never fires).
 func changeTypeBucket(t tracker.ChangeType) string {
-	if t == tracker.ChangeWeatherBoost {
+	switch t {
+	case tracker.ChangeWeatherBoost, tracker.ChangeEncountered:
 		return "stats"
 	}
 	return "species"

--- a/processor/cmd/processor/pokemon_change_test.go
+++ b/processor/cmd/processor/pokemon_change_test.go
@@ -184,14 +184,16 @@ func TestDispatchPokemonAlert_PriorOnlyNoLongerMatches(t *testing.T) {
 	}
 }
 
-// ChangeEncountered (CP 0 → >0) must NOT fire monsterChanged for
-// prior-only users: their filter excluded the new state, sending a
-// "stats revealed" follow-up would contradict their tracking rule.
-func TestDispatchPokemonAlert_EncounteredChange_PriorOnly_NoJob(t *testing.T) {
+// ChangeEncountered (CP 0 → >0) fires monsterChanged for prior-only
+// users: their T1 alert was a monsterNoIv "this might be one you
+// care about", and the encounter-reveal rejecting their filter is
+// exactly the follow-up they need to know about. Maps to the
+// "stats" changeType bucket.
+func TestDispatchPokemonAlert_EncounteredChange_PriorOnly_FiresStats(t *testing.T) {
 	ps, ch, _ := minimalProcessor(t)
 
 	encounterID := "enc-iv-reveal"
-	priorOnly := webhook.MatchedUser{ID: "user-iv-strict", Type: "discord:user"}
+	priorOnly := webhook.MatchedUser{ID: "user-iv-strict", Type: "discord:user", Clean: 1}
 
 	change := &tracker.EncounterChange{
 		EncounterID: encounterID,
@@ -209,8 +211,22 @@ func TestDispatchPokemonAlert_EncounteredChange_PriorOnly_NoJob(t *testing.T) {
 	})
 
 	jobs := drainRenderJobs(ch)
-	if len(jobs) != 0 {
-		t.Fatalf("expected 0 RenderJobs (ChangeEncountered skips monsterChanged), got %d: %v", len(jobs), jobs)
+	if len(jobs) != 1 {
+		t.Fatalf("expected 1 monsterChanged RenderJob for ChangeEncountered priorOnly, got %d", len(jobs))
+	}
+	j := jobs[0]
+	if !j.IsChange {
+		t.Errorf("must use monsterChanged template (IsChange=true)")
+	}
+	if j.ReplyKey != encounterID {
+		t.Errorf("ReplyKey must thread under the monsterNoIv original: got %q", j.ReplyKey)
+	}
+	if j.MatchedUsers[0].Clean != 1 {
+		t.Errorf("Clean must propagate so the reply auto-deletes with the original: got %d", j.MatchedUsers[0].Clean)
+	}
+	lang := effectiveLanguage(priorOnly, ps.cfg.General.Locale)
+	if got := j.PerLangEnrichment[lang]["changeType"]; got != "stats" {
+		t.Errorf("changeType = %v, want \"stats\" (IV reveal is a stats event)", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

Users with an IV/CP/level filter on their tracking rule saw `monsterNoIv` on the wild webhook (matcher skips encounter-only filters when CP is unknown). When the encounter webhook arrived with revealed stats below their filter, they landed in priorOnly with \`change.Type=ChangeEncountered\` — and the dispatcher silently dropped the bucket. The optimistic T1 alert was left dangling with no follow-up.

## Cause

Earlier I added \`in.change.Type != tracker.ChangeEncountered\` to bucket 2 in \`dispatchPokemonAlert\` on the reasoning that users who still match at T2 get a regular \`monster\` reply via the matched path. That's true for catch-all rules (e.g. \`!track pikachu\`), but for IV/CP-filtered users whose reveal fails the filter, dropping the bucket entirely means they never hear what the IVs actually were.

## Fix

- Drop the \`ChangeEncountered\` skip in bucket 2.
- \`changeTypeBucket\` now maps \`ChangeEncountered\` to \`"stats"\` alongside \`ChangeWeatherBoost\` — same pokemon, different effective stats.
- Replaced \`TestDispatchPokemonAlert_EncounteredChange_PriorOnly_NoJob\` with \`_FiresStats\` (1 RenderJob, IsChange=true, ReplyKey set, Clean inherited, \`changeType="stats"\`).
- Updated DTS.md.

## Test plan

- [x] \`go build ./...\` clean.
- [x] \`go vet ./...\` clean.
- [x] Full test suite green.
- [ ] Manual verify: \`!track pikachu iv90\`, wait for a sub-90% IV Pikachu encounter, confirm \`monsterChanged\` reply now arrives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)