### PR TITLE
tracker: preserve encountered state on wild re-scans + ChangeStats

### DIFF
--- a/DTS.md
+++ b/DTS.md
@@ -359,13 +359,15 @@ fired the alert. Use these in templates to switch wording or styling:
 
 | `changeType` | Fires for | Meaning |
 |---|---|---|
-| `species` | `ChangeSpecies`, `ChangeForm`, `ChangeGender` | Identity change. Most commonly community-day re-classifications, or the known "A/B pokemon" server bug where Golbat reports a different species ID for the same encounter. |
-| `stats` | `ChangeWeatherBoost` | Same pokemon, weather boost shifted. Post-boost IVs and CP differ from the originally-alerted state. This is the most common cause in practice. |
+| `species` | `ChangeSpecies`, `ChangeForm`, `ChangeGender` | Identity change. Community-day re-classifications, or the "A/B pokemon" anomaly where Golbat reports a different species ID for the same encounter. |
+| `stats` | `ChangeWeatherBoost`, `ChangeStats` | Same pokemon, different effective stats. Weather-boost shifts the CP/level post-encounter; `ChangeStats` fires when Golbat re-reports the same encounter with different raw IVs (atk/def/sta) — the scanner anomaly where successive webhooks for the same encounter ID carry different IV values. |
 
 The `ChangeEncountered` dimension (CP 0 → >0, "IVs just arrived") does **not**
-fire `monsterChanged`. Users who were tracking IV-insensitive ("any pokemon of
-species X") get a regular `monster` reply to their `monsterNoIv` alert; users
-whose IV filter excluded the post-encounter stats get no follow-up at all.
+fire `monsterChanged`. Users tracking IV-insensitively (`!track pikachu`, no
+filter) get a regular `monster` reply via the matched path. Users with strict
+IV filters never matched the wild webhook in the first place (the matcher
+rejects rules with `min_iv > -1` when CP=0), so there is no prior message
+to follow up.
 
 PoracleNG ships a default `monsterChanged` template per platform in
 `fallbacks/dts.json`; admins override via `config/dts.json` or

--- a/processor/cmd/processor/pokemon.go
+++ b/processor/cmd/processor/pokemon.go
@@ -393,16 +393,18 @@ func (ps *ProcessorService) dispatchPokemonAlert(in pokemonDispatchInput) {
 	}
 }
 
-// changeTypeBucket collapses the 5-value tracker.ChangeType enum into
-// the two template-facing values:
-//   - "stats" for weather-boost-driven CP/IV shifts (same pokemon,
-//     different effective stats).
-//   - "species" for everything else (species, form, gender — all
-//     identity changes; gender alone effectively never fires).
+// changeTypeBucket collapses the tracker.ChangeType enum into the
+// two template-facing values:
+//   - "stats" for ChangeWeatherBoost (post-encounter CP shift) and
+//     ChangeStats (raw IV re-report from scanner). Both are "same
+//     pokemon, different effective stats" from the user's view.
+//   - "species" for ChangeSpecies/Form/Gender — identity changes
+//     (gender alone effectively never fires).
 //
 // ChangeEncountered is filtered upstream and never reaches here.
 func changeTypeBucket(t tracker.ChangeType) string {
-	if t == tracker.ChangeWeatherBoost {
+	switch t {
+	case tracker.ChangeWeatherBoost, tracker.ChangeStats:
 		return "stats"
 	}
 	return "species"

--- a/processor/cmd/processor/pokemon_change_test.go
+++ b/processor/cmd/processor/pokemon_change_test.go
@@ -255,6 +255,51 @@ func TestDispatchPokemonAlert_WeatherBoost_StatsBucket(t *testing.T) {
 	}
 }
 
+// ChangeStats (raw IV drift between two encountered webhooks)
+// fires monsterChanged via the "stats" bucket — same pokemon,
+// scanner re-reported different IVs (A/B anomaly), user's filter
+// now rejects.
+func TestDispatchPokemonAlert_StatsDrift_StatsBucket(t *testing.T) {
+	ps, ch, _ := minimalProcessor(t)
+
+	encounterID := "enc-iv-drift"
+	priorOnly := webhook.MatchedUser{ID: "user-iv-strict", Type: "discord:user", Clean: 1}
+
+	change := &tracker.EncounterChange{
+		EncounterID: encounterID,
+		Type:        tracker.ChangeStats,
+		Old:         tracker.EncounterState{PokemonID: 25, CP: 1200, Weather: 1, ATK: 15, DEF: 15, STA: 15}, // 100% IV
+		New:         tracker.EncounterState{PokemonID: 25, CP: 1200, Weather: 1, ATK: 11, DEF: 11, STA: 11}, // 73% IV
+	}
+
+	ps.dispatchPokemonAlert(pokemonDispatchInput{
+		encounterID:    encounterID,
+		change:         change,
+		matched:        nil,
+		priorOnlyUsers: []webhook.MatchedUser{priorOnly},
+		isEncountered:  true,
+	})
+
+	jobs := drainRenderJobs(ch)
+	if len(jobs) != 1 {
+		t.Fatalf("expected 1 monsterChanged RenderJob for ChangeStats priorOnly, got %d", len(jobs))
+	}
+	j := jobs[0]
+	if !j.IsChange {
+		t.Errorf("ChangeStats must use monsterChanged (IsChange=true)")
+	}
+	if j.ReplyKey != encounterID {
+		t.Errorf("ReplyKey must thread under the prior message: got %q", j.ReplyKey)
+	}
+	if j.MatchedUsers[0].Clean != 1 {
+		t.Errorf("Clean must propagate: got %d, want 1", j.MatchedUsers[0].Clean)
+	}
+	lang := effectiveLanguage(priorOnly, ps.cfg.General.Locale)
+	if got := j.PerLangEnrichment[lang]["changeType"]; got != "stats" {
+		t.Errorf("changeType = %v, want \"stats\" (raw IV drift is a stats event)", got)
+	}
+}
+
 // rebuildMatchedUserForChange must stamp the prior message's Clean
 // onto the synthesised MatchedUser so the monsterChanged reply
 // inherits the same TTL clean-delete behaviour as the original.

--- a/processor/internal/tracker/encounter.go
+++ b/processor/internal/tracker/encounter.go
@@ -120,6 +120,17 @@ func (et *EncounterTracker) Track(encounterID string, newState EncounterState, p
 		return false, change
 	}
 
+	// Wild re-scan of an already-encountered pokemon: don't downgrade.
+	// Golbat re-emits wild webhooks (CP=0, zeroed IVs) after the
+	// initial encounter, often after weather shifts. Overwriting the
+	// encountered snapshot with that zero data makes the next encounter
+	// webhook look like a fresh CP 0→>0 transition (ChangeEncountered),
+	// hiding the real stats/weather diff and dropping prior recipients
+	// silently.
+	if old.CP > 0 && newState.CP == 0 {
+		return false, nil
+	}
+
 	// Refresh state for accurate next-change comparison. The webhook
 	// struct is NOT refreshed: it must stick from the most recent
 	// change (or first sighting) so {{original.X}} renders against

--- a/processor/internal/tracker/encounter.go
+++ b/processor/internal/tracker/encounter.go
@@ -83,10 +83,12 @@ func (et *EncounterTracker) Track(encounterID string, newState EncounterState, p
 
 	old := prev.state
 
-	// Detect change type. Priority order: species > form > gender > encountered > weather_boost.
+	// Detect change type. Priority order: species > form > gender > encountered > weather_boost > stats.
 	// Gender change only fires when both old and new are non-zero (initial gender resolution doesn't count).
 	// Weather-boost shift only fires post-encounter (both CPs > 0) AND when the CP actually moved.
-	// Raw IV (atk/def/sta) drift is ignored — physical IVs don't change post-encounter.
+	// Stats drift (raw atk/def/sta differing between two encountered webhooks) fires when
+	// Golbat re-reports the same encounter with different IVs — happens with the A/B
+	// scanner anomaly. Physical IVs don't change in-game, but scanner reports can.
 	var changeType ChangeType
 	switch {
 	case old.PokemonID != newState.PokemonID:
@@ -99,6 +101,8 @@ func (et *EncounterTracker) Track(encounterID string, newState EncounterState, p
 		changeType = ChangeEncountered
 	case old.Weather != newState.Weather && old.CP > 0 && newState.CP > 0 && old.CP != newState.CP:
 		changeType = ChangeWeatherBoost
+	case old.CP > 0 && newState.CP > 0 && (old.ATK != newState.ATK || old.DEF != newState.DEF || old.STA != newState.STA):
+		changeType = ChangeStats
 	}
 
 	if changeType != ChangeNone {

--- a/processor/internal/tracker/encounter_change.go
+++ b/processor/internal/tracker/encounter_change.go
@@ -10,6 +10,7 @@ const (
 	ChangeGender
 	ChangeEncountered  // non-IV sighting filled in with CP/IVs
 	ChangeWeatherBoost // post-encounter weather change that moved CP
+	ChangeStats        // raw IV (atk/def/sta) drift between two encountered webhooks
 )
 
 func (c ChangeType) String() string {
@@ -24,6 +25,8 @@ func (c ChangeType) String() string {
 		return "encountered"
 	case ChangeWeatherBoost:
 		return "weather_boost"
+	case ChangeStats:
+		return "stats"
 	}
 	return "none"
 }

--- a/processor/internal/tracker/encounter_test.go
+++ b/processor/internal/tracker/encounter_test.go
@@ -123,12 +123,41 @@ func TestTrackDetectsGenderChange(t *testing.T) {
 	}
 }
 
-func TestTrackIVNoiseIgnored(t *testing.T) {
+// Raw IV drift between two encountered webhooks fires ChangeStats.
+// Golbat re-reports the same encounter with different IVs under the
+// A/B scanner anomaly — the user's filter may reject the new reading,
+// so prior recipients need a monsterChanged follow-up.
+func TestTrackDetectsStatsDrift(t *testing.T) {
 	et := NewEncounterTracker()
-	et.Track("enc-3", EncounterState{PokemonID: 25, CP: 1000, ATK: 10}, nil)
-	_, change := et.Track("enc-3", EncounterState{PokemonID: 25, CP: 1000, ATK: 11}, nil)
+	et.Track("enc-3", EncounterState{PokemonID: 25, CP: 1000, ATK: 15, DEF: 15, STA: 15}, nil)
+	_, change := et.Track("enc-3", EncounterState{PokemonID: 25, CP: 1000, ATK: 10, DEF: 10, STA: 10}, nil)
+	if change == nil || change.Type != ChangeStats {
+		t.Fatalf("expected ChangeStats for raw IV drift, got %+v", change)
+	}
+	if change.Old.ATK != 15 || change.New.ATK != 10 {
+		t.Errorf("ATK delta not propagated: old=%d new=%d", change.Old.ATK, change.New.ATK)
+	}
+}
+
+// Stats drift on a pre-encounter sighting (CP=0 → CP>0) is the
+// "encountered" transition, not stats drift. ChangeEncountered wins.
+func TestTrackStatsDriftIgnoredOnEncounterTransition(t *testing.T) {
+	et := NewEncounterTracker()
+	et.Track("enc-3b", EncounterState{PokemonID: 25, CP: 0, ATK: 0, DEF: 0, STA: 0}, nil)
+	_, change := et.Track("enc-3b", EncounterState{PokemonID: 25, CP: 1000, ATK: 15, DEF: 15, STA: 15}, nil)
+	if change == nil || change.Type != ChangeEncountered {
+		t.Fatalf("expected ChangeEncountered (not ChangeStats), got %+v", change)
+	}
+}
+
+// No diff in monitored fields → no change.
+func TestTrackNoChangeOnIdenticalState(t *testing.T) {
+	et := NewEncounterTracker()
+	state := EncounterState{PokemonID: 25, CP: 1000, ATK: 15, DEF: 15, STA: 15, Weather: 1}
+	et.Track("enc-3c", state, nil)
+	_, change := et.Track("enc-3c", state, nil)
 	if change != nil {
-		t.Fatalf("post-encounter IV change should not fire, got %+v", change)
+		t.Fatalf("identical-state re-Track should not fire, got %+v", change)
 	}
 }
 

--- a/processor/internal/tracker/encounter_test.go
+++ b/processor/internal/tracker/encounter_test.go
@@ -161,6 +161,52 @@ func TestTrackNoChangeOnIdenticalState(t *testing.T) {
 	}
 }
 
+// Wild re-scan after a weather shift must not downgrade the
+// encountered state. Real webhook sequence from production:
+//
+//   W1 wild      CP=0    weather=0  → first sighting
+//   W2 encounter CP=153  weather=0  IVs=15/15/15  → ChangeEncountered
+//   W3 wild      CP=0    weather=4  → must NOT overwrite state
+//   W4 encounter CP=280  weather=4  IVs=13/13/12  → must fire
+//                                                   ChangeWeatherBoost
+//                                                   against W2's stats
+//
+// Without the wild-rescan guard, W3 zeroed prev.state.CP and W4 then
+// triggered a second ChangeEncountered, which the dispatcher skips
+// for prior-only users — silently dropping the follow-up alert.
+func TestTrackWildRescanDoesNotDowngradeEncounteredState(t *testing.T) {
+	et := NewEncounterTracker()
+
+	w1 := EncounterState{PokemonID: 23, Form: 697, Gender: 2, CP: 0, Weather: 0}
+	w2 := EncounterState{PokemonID: 23, Form: 697, Gender: 2, CP: 153, Weather: 0, ATK: 15, DEF: 15, STA: 15}
+	w3 := EncounterState{PokemonID: 23, Form: 697, Gender: 2, CP: 0, Weather: 4}
+	w4 := EncounterState{PokemonID: 23, Form: 697, Gender: 2, CP: 280, Weather: 4, ATK: 13, DEF: 13, STA: 12}
+
+	et.Track("enc-prod", w1, nil)
+
+	_, change2 := et.Track("enc-prod", w2, nil)
+	if change2 == nil || change2.Type != ChangeEncountered {
+		t.Fatalf("W2 should fire ChangeEncountered, got %+v", change2)
+	}
+
+	_, change3 := et.Track("enc-prod", w3, nil)
+	if change3 != nil {
+		t.Fatalf("W3 (wild re-scan) should not fire a change, got %+v", change3)
+	}
+
+	_, change4 := et.Track("enc-prod", w4, nil)
+	if change4 == nil {
+		t.Fatalf("W4 must fire a change against W2's preserved state, got nil")
+	}
+	if change4.Type != ChangeWeatherBoost {
+		t.Errorf("W4 change type: got %v, want ChangeWeatherBoost", change4.Type)
+	}
+	// And the diff must reflect W2's stats, not W3's zeroed state.
+	if change4.Old.CP != 153 || change4.Old.ATK != 15 {
+		t.Errorf("W4 change.Old must reflect W2's encountered state, got CP=%d ATK=%d (W3 would have CP=0 ATK=0)", change4.Old.CP, change4.Old.ATK)
+	}
+}
+
 func TestTrackDetectsWeatherBoost(t *testing.T) {
 	et := NewEncounterTracker()
 	et.Track("enc-4", EncounterState{PokemonID: 25, CP: 1000, Weather: 1}, nil)


### PR DESCRIPTION
## Real-world bug from production webhook stream

Same encounter ID, four webhooks:

| W | Time | Type | CP | IV | Weather |
|---|---|---|---|---|---|
| 1 | 10:59:14 | wild | 0 | — | 0 |
| 2 | 10:59:14 | encounter | 153 | 100% (15/15/15) | 0 |
| 3 | 11:02:52 | wild | 0 | — | **4** |
| 4 | 11:11:56 | encounter | 280 | 84% (13/13/12) | 4 |

User with `iv95` filter matched W2 → \`monster\` sent + tracked. W4 should have produced a `monsterChanged` reply (filter rejects 84%, weather changed since W2). It didn't.

## Causes

**1. Wild re-scan downgraded encountered state.** When W3 (wild, CP=0) lands after W2 (encounter, CP=153), the change switch correctly returns `ChangeNone` — but then `prev.state = newState` overwrites W2's rich snapshot with W3's zeroed wild data. By W4, the tracker's "prior" looks like CP=0 again, so W4 fires a **second** `ChangeEncountered` (CP 0→280). The dispatcher's `ChangeEncountered` skip drops the priorOnly user silently.

**2. (Separate, smaller gap) Raw IV drift between two encounter webhooks wasn't a tracked change dimension.** The original comment said *"physical IVs don't change post-encounter"* — true in-game, but Golbat's A/B scanner anomaly re-reports different IVs for the same encounter ID. Without weather/CP also differing, the tracker missed it.

## Fixes

**Wild re-scan guard** (`internal/tracker/encounter.go`):

```go
if old.CP > 0 && newState.CP == 0 {
    return false, nil  // don't downgrade encountered state
}
```

W3 now leaves the tracker state intact. W4 compares against W2 → weather differs + both CPs > 0 + CP differs → `ChangeWeatherBoost` fires. PriorOnly user routes to bucket 2 → `monsterChanged` sent.

**ChangeStats addition** (closes the IV-only-drift gap):

- New `tracker.ChangeStats` enum value, fires when both webhooks are encountered (CP>0) and ATK/DEF/STA differ.
- Last in the priority chain so species/form/gender/encountered/weather_boost still win when they apply.
- Maps to the existing `"stats"` template bucket alongside `ChangeWeatherBoost` — no template changes.

## Tests

- `TestTrackWildRescanDoesNotDowngradeEncounteredState` — walks the exact W1-W4 sequence above, asserts W3 silent and W4 fires `ChangeWeatherBoost` with `.Old` reflecting W2's stats (not W3's zeroed downgrade).
- `TestTrackDetectsStatsDrift` — pure IV drift, no weather/CP change → fires `ChangeStats`.
- `TestTrackStatsDriftIgnoredOnEncounterTransition` — encounter transition still wins.
- `TestTrackNoChangeOnIdenticalState` — regression guard.
- `TestDispatchPokemonAlert_StatsDrift_StatsBucket` — dispatcher emits monsterChanged with `changeType="stats"`.

## Closes / supersedes

Supersedes the closed #95.

🤖 Generated with [Claude Code](https://claude.com/claude-code)