### PR TITLE
staticmap: accept "rampardos" as alias for tileservercache provider

### DIFF
--- a/processor/internal/api/config_schema.go
+++ b/processor/internal/api/config_schema.go
@@ -326,6 +326,7 @@ var configSchema = []ConfigSection{
 			{Name: "static_provider", Type: "select", Default: "none", Description: "Static map tile provider for generating map images in alerts", Options: []ConfigSelectOption{
 				{Value: "none", Label: "None", Description: "Disable static map tiles"},
 				{Value: "tileservercache", Label: "TileserverCache", Description: "SwiftTileserverCache (recommended, self-hosted)"},
+					{Value: "rampardos", Label: "Rampardos", Description: "Rampardos — improved tileserver written by Unown (recommended)"},
 				{Value: "google", Label: "Google", Description: "Google Static Maps API"},
 				{Value: "osm", Label: "OSM", Description: "OpenStreetMap tile rendering"},
 				{Value: "mapbox", Label: "Mapbox", Description: "Mapbox Static Images API"},

--- a/processor/internal/staticmap/staticmap.go
+++ b/processor/internal/staticmap/staticmap.go
@@ -46,9 +46,21 @@ func boolVal(b *bool) bool {
 	return *b
 }
 
+// isTileserverCacheProvider returns true for any provider name that
+// follows the SwiftTileserverCache POST-body protocol. "rampardos" is
+// a drop-in alternative implementation with identical wire format.
+// Add new aliases here as they ship.
+func isTileserverCacheProvider(p string) bool {
+	switch p {
+	case "tileservercache", "rampardos":
+		return true
+	}
+	return false
+}
+
 // Config holds all static map configuration.
 type Config struct {
-	Provider    string // "none", "tileservercache", "google", "osm", "mapbox"
+	Provider    string // "none", "tileservercache", "rampardos", "google", "osm", "mapbox"
 	ProviderURL string // tileserver URL (public — this is what appears in rendered message URLs for Discord/Telegram to fetch)
 	// InternalURL is the URL the processor uses for its own tileserver HTTP
 	// (render POST, pregenerate POST, upload-images pre-fetch). Empty =
@@ -484,9 +496,15 @@ func (r *Resolver) GetStaticMapURL(maptype string, data map[string]any, keys, pr
 
 	var result string
 
-	switch provider {
-	case "tileservercache":
+	if isTileserverCacheProvider(provider) {
 		result = r.tileserverCache(maptype, data, lat, lon, keys, pregenKeys)
+		if result == "" && r.config.FallbackURL != "" {
+			return r.config.FallbackURL
+		}
+		return result
+	}
+
+	switch provider {
 	case "google":
 		key := r.randomKey()
 		result = fmt.Sprintf(
@@ -523,7 +541,7 @@ func (r *Resolver) GetStaticMapURL(maptype string, data map[string]any, keys, pr
 func (r *Resolver) GetStaticMapURLAsync(maptype string, data map[string]any, keys, pregenKeys []string, target map[string]any) (string, *TilePending) {
 	provider := strings.ToLower(r.config.Provider)
 
-	if provider != "tileservercache" {
+	if !isTileserverCacheProvider(provider) {
 		// Non-tileservercache: instant URL, no async
 		return r.GetStaticMapURL(maptype, data, keys, pregenKeys), nil
 	}

--- a/processor/internal/staticmap/staticmap_test.go
+++ b/processor/internal/staticmap/staticmap_test.go
@@ -206,6 +206,34 @@ func TestGetConfigForTileTypeStaticMapType(t *testing.T) {
 	}
 }
 
+// Provider="rampardos" must route through the same tileservercache
+// pipeline (identical wire format). GetStaticMapURLAsync's gate is
+// the load-bearing one — non-tileservercache providers bypass async
+// pregeneration, so a typo there would silently strip rampardos of
+// pregen support. This test pins both providers to the same async
+// path so any future divergence requires a deliberate test update.
+func TestRampardosProviderAliasesTileserverCache(t *testing.T) {
+	for _, provider := range []string{"tileservercache", "rampardos"} {
+		t.Run(provider, func(t *testing.T) {
+			r := New(Config{
+				Provider:    provider,
+				ProviderURL: "https://tiles.example.com",
+				TileserverSettings: map[string]TileTypeConfig{
+					"default": {Type: "staticMap", Pregenerate: boolPtr(true)},
+				},
+			})
+			target := map[string]any{}
+			url, pending := r.GetStaticMapURLAsync("monster", map[string]any{"latitude": 51.28, "longitude": 1.08}, nil, nil, target)
+			if pending == nil {
+				t.Fatalf("provider %q: expected pregen pending, got nil (provider was treated as instant)", provider)
+			}
+			if url != "" {
+				t.Errorf("provider %q: pregen path returns URL after async resolution, sync return should be empty: got %q", provider, url)
+			}
+		})
+	}
+}
+
 func TestGetTileURL(t *testing.T) {
 	r := New(Config{
 		Provider:    "tileservercache",


### PR DESCRIPTION
## Summary

Adds \`rampardos\` as a valid \`static_provider\` value. Routes through the existing tileservercache plumbing (identical POST-body wire format) — no functional behavior changes for tileservercache users; rampardos users now get pregen + async tile resolution out of the box.

## Changes

- \`isTileserverCacheProvider(p string)\` helper centralises the alias list.
- \`GetStaticMapURL\`'s switch + \`GetStaticMapURLAsync\`'s async gate both route through the predicate.
- Config schema gains a \"Rampardos — improved tileserver written by Unown (recommended)\" option.
- \`TestRampardosProviderAliasesTileserverCache\` pins both providers to the async pregen path so future divergence requires a deliberate test update.

## Test plan

- [x] \`go build ./...\` / \`go vet ./...\` clean.
- [x] Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)