### PR TITLE
staticmap: trim trailing slash from tileserver URL on config load

### DIFF
--- a/processor/internal/staticmap/staticmap.go
+++ b/processor/internal/staticmap/staticmap.go
@@ -267,6 +267,12 @@ func New(config Config) *Resolver {
 	if config.InternalURL == "" {
 		config.InternalURL = config.ProviderURL
 	}
+	// Operators commonly paste tileserver URLs with a trailing slash;
+	// downstream concat sites all do fmt.Sprintf("%s/%s/..."), so a
+	// trailing slash here yields a `host//path` request that
+	// tileservers reject with 404.
+	config.ProviderURL = strings.TrimRight(config.ProviderURL, "/")
+	config.InternalURL = strings.TrimRight(config.InternalURL, "/")
 
 	r := &Resolver{
 		config: config,

--- a/processor/internal/staticmap/staticmap_test.go
+++ b/processor/internal/staticmap/staticmap_test.go
@@ -206,6 +206,35 @@ func TestGetConfigForTileTypeStaticMapType(t *testing.T) {
 	}
 }
 
+// Trailing slashes on the configured tileserver URL must be trimmed
+// at New() so downstream `host + "/" + path` concats don't yield
+// `host//path` (which tileservers reject with 404). Operator-paste
+// mistake; regression guard.
+func TestTileserverURLTrailingSlashTrimmed(t *testing.T) {
+	cases := []struct {
+		name        string
+		providerURL string
+	}{
+		{"trailing slash", "http://vpsip:9000/"},
+		{"no trailing slash", "http://vpsip:9000"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			r := New(Config{
+				Provider:    "tileservercache",
+				ProviderURL: c.providerURL,
+			})
+			url := r.GetTileURL("monster", map[string]any{"latitude": 51.28, "longitude": 1.08}, "staticMap")
+			if strings.Contains(url, "//staticmap") {
+				t.Errorf("tile URL contains double slash before staticmap: %q", url)
+			}
+			if !strings.Contains(url, "/staticmap/poracle-monster") {
+				t.Errorf("tile URL missing expected path: %q", url)
+			}
+		})
+	}
+}
+
 // Provider="rampardos" must route through the same tileservercache
 // pipeline (identical wire format). GetStaticMapURLAsync's gate is
 // the load-bearing one — non-tileservercache providers bypass async


### PR DESCRIPTION
## Summary

User report: a trailing slash on \`static_provider_url\` produced a double-slash in the request path, which the tileserver rejected with 404:

\`\`\`
pregenerate http://vpsip:9000//staticmap/poracle-monster?pregenerate=true&ttl=86400 got status 404: 404 page not found
\`\`\`

Every downstream concat site uses \`fmt.Sprintf(\"%s/%s/...\", ProviderURL, mapPath, ...)\`, so a trailing slash on the configured URL yields \`host//path\`. Fix: \`TrimRight\` both \`ProviderURL\` and \`InternalURL\` in \`New()\` so every downstream concat gets a clean host.

\`TestTileserverURLTrailingSlashTrimmed\` pins the trim with a slash-suffixed \`ProviderURL\` and asserts no \`//staticmap\` appears in the resulting URL.

## Test plan

- [x] \`go build ./...\` / \`go vet ./...\` clean.
- [x] Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)