### PR TITLE
fallbacks: guard monsterChanged stats with {{#if encountered}}

### DIFF
--- a/DTS.md
+++ b/DTS.md
@@ -339,6 +339,15 @@ appropriate translated names (`original.fullName` for a German user is
 "Glumanda", for an English user "Charmander"). PVP rankings are not
 available under `original.*`.
 
+**Guard stat fields with `{{#if encountered}}`.** A species/form change
+fires `monsterChanged` as soon as the new species is *known*, which can
+be before it has been encountered (Golbat's wild webhook lands before
+the encounter webhook). In that window, `cp`, `level`, `atk/def/sta`,
+`iv`, `quickMoveName`, etc. are all zero/empty, and `iv` is `-1`. Wrap
+the stats portion of your template in `{{#if encountered}}…{{else}}…{{/if}}`
+so you don't render "−1% Foo cp:0 L:0 0/0/0" while waiting for the
+encounter. The shipped fallbacks do this.
+
 Only set when fired by a true change event — the dispatcher also leaves
 `{{original.X}}` empty when:
 - The encounter event reuses the regular `monster` template (CP 0 → >0).

--- a/fallbacks/dts.json
+++ b/fallbacks/dts.json
@@ -41,8 +41,8 @@
   "template": {
     "embed": {
       "color": "{{ivColor}}",
-      "title": "{{round iv}}% {{fullName}} cp:{{cp}} L:{{level}} {{atk}}/{{def}}/{{sta}} {{{boostWeatherEmoji}}}",
-      "description": "Originally seen as **{{original.fullName}}** (CP {{original.cp}}, IV {{toFixed original.iv 0}}%) — {{changeTypeText}}\nEnd: {{time}}, Time left: {{tthm}}m {{tths}}s \n {{#if weatherChange}}{{{weatherChange}}}\n{{/if}}{{{addr}}} \n quick: {{quickMoveName}}, charge: {{chargeMoveName}} \n{{#if pvpLittle}}**Little league:**\n{{#each pvpLittle}} - {{fullName}} #{{rank}} @{{cp}}CP (Lvl. {{levelWithCap}})\n{{/each}}{{/if}}{{#if pvpGreat}}**Great league:**\n{{#each pvpGreat}} - {{fullName}} #{{rank}} @{{cp}}CP (Lvl. {{levelWithCap}})\n{{/each}}{{/if}}{{#if pvpUltra}}**Ultra league:**\n{{#each pvpUltra}} - {{fullName}} #{{rank}} @{{cp}}CP (Lvl. {{levelWithCap}})\n{{/each}}{{/if}} Maps: [Google]({{{googleMapUrl}}}) | [Apple]({{{appleMapUrl}}})",
+      "title": "{{#if encountered}}{{round iv}}% {{fullName}} cp:{{cp}} L:{{level}} {{atk}}/{{def}}/{{sta}} {{{boostWeatherEmoji}}}{{else}}{{fullName}} (awaiting encounter){{/if}}",
+      "description": "Originally seen as **{{original.fullName}}** (CP {{original.cp}}, IV {{toFixed original.iv 0}}%) — {{changeTypeText}}\nEnd: {{time}}, Time left: {{tthm}}m {{tths}}s\n{{#if weatherChange}}{{{weatherChange}}}\n{{/if}}{{{addr}}}\n{{#if encountered}}quick: {{quickMoveName}}, charge: {{chargeMoveName}}\n{{#if pvpLittle}}**Little league:**\n{{#each pvpLittle}} - {{fullName}} #{{rank}} @{{cp}}CP (Lvl. {{levelWithCap}})\n{{/each}}{{/if}}{{#if pvpGreat}}**Great league:**\n{{#each pvpGreat}} - {{fullName}} #{{rank}} @{{cp}}CP (Lvl. {{levelWithCap}})\n{{/each}}{{/if}}{{#if pvpUltra}}**Ultra league:**\n{{#each pvpUltra}} - {{fullName}} #{{rank}} @{{cp}}CP (Lvl. {{levelWithCap}})\n{{/each}}{{/if}}{{/if}}Maps: [Google]({{{googleMapUrl}}}) | [Apple]({{{appleMapUrl}}})",
       "thumbnail": {
         "url": "{{{imgUrl}}}"
       },
@@ -59,7 +59,7 @@
   "default": true,
   "platform": "telegram",
   "template": {
-    "content": "Originally seen as **{{original.fullName}}** (CP {{original.cp}}, IV {{toFixed original.iv 0}}%) — {{changeTypeText}}\n{{round iv}}% {{fullName}} cp:{{cp}} L:{{level}} {{atk}}/{{def}}/{{sta}} {{boostWeatherEmoji}}\nEnd: {{time}}, Time left: {{tthm}}m {{tths}}s \n {{#if weatherChange}}{{weatherChange}}\n{{/if}} {{{addr}}} \n quick: {{quickMoveName}}, charge: {{chargeMoveName}} \n{{#if pvpLittle}}**Little league:**\n{{#each pvpLittle}} - {{fullName}} #{{rank}} @{{cp}}CP (Lvl. {{levelWithCap}})\n{{/each}}{{/if}}{{#if pvpGreat}}**Great league:**\n{{#each pvpGreat}} - {{fullName}} #{{rank}} @{{cp}}CP (Lvl. {{levelWithCap}})\n{{/each}}{{/if}}{{#if pvpUltra}}**Ultra league:**\n{{#each pvpUltra}} - {{fullName}} #{{rank}} @{{cp}}CP (Lvl. {{levelWithCap}})\n{{/each}}{{/if}} Maps: [Google]({{{googleMapUrl}}}) | [Apple]({{{appleMapUrl}}})",
+    "content": "Originally seen as **{{original.fullName}}** (CP {{original.cp}}, IV {{toFixed original.iv 0}}%) — {{changeTypeText}}\n{{#if encountered}}{{round iv}}% {{fullName}} cp:{{cp}} L:{{level}} {{atk}}/{{def}}/{{sta}} {{boostWeatherEmoji}}{{else}}{{fullName}} (awaiting encounter){{/if}}\nEnd: {{time}}, Time left: {{tthm}}m {{tths}}s\n{{#if weatherChange}}{{weatherChange}}\n{{/if}}{{{addr}}}\n{{#if encountered}}quick: {{quickMoveName}}, charge: {{chargeMoveName}}\n{{#if pvpLittle}}**Little league:**\n{{#each pvpLittle}} - {{fullName}} #{{rank}} @{{cp}}CP (Lvl. {{levelWithCap}})\n{{/each}}{{/if}}{{#if pvpGreat}}**Great league:**\n{{#each pvpGreat}} - {{fullName}} #{{rank}} @{{cp}}CP (Lvl. {{levelWithCap}})\n{{/each}}{{/if}}{{#if pvpUltra}}**Ultra league:**\n{{#each pvpUltra}} - {{fullName}} #{{rank}} @{{cp}}CP (Lvl. {{levelWithCap}})\n{{/each}}{{/if}}{{/if}}Maps: [Google]({{{googleMapUrl}}}) | [Apple]({{{appleMapUrl}}})",
     "sticker": "{{{stickerUrl}}}",
     "parse_mode": "Markdown",
     "location": true,


### PR DESCRIPTION
## Summary

User report: a Morelull→Deino species change at the start of community day rendered as \`-1% Deino cp:0 L:0 0/0/0 ... quick: , charge:\`. The new species was reported via Golbat's wild webhook (no encounter data yet), so stats/move/PVP fields were all zero/empty and \`iv=-1\`.

The dispatcher already exposes \`{{encountered}}\` as a bool — the fallback templates just weren't using it. Wrap the stats line + moves/PVP block in \`{{#if encountered}}\` on both Discord and Telegram fallbacks. Pre-encounter monsterChanged now renders as \`{{fullName}} (awaiting encounter)\` and the \"Originally seen as ...\" line stays so users still see the change context.

\`DTS.md\` updated to document the guard pattern for operator templates.

## Test plan

- [x] JSON validates.
- [x] Full Go test suite green.
- [ ] Manual: trigger a wild→encounter species change, confirm the \"awaiting encounter\" placeholder, then the regular stats line on the next webhook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)