### PR TITLE
weather: align clean alert TTH with shown pokemon, not cell-wide care

### DIFF
--- a/processor/cmd/processor/weather.go
+++ b/processor/cmd/processor/weather.go
@@ -182,18 +182,33 @@ func (ps *ProcessorService) consumeWeatherChanges() {
 				perLang = map[string]map[string]any{lang: langEnrichment}
 			}
 
-			// For clean weather alerts, TTH aligns with the longest TTH of any
-			// matched pokemon (CaresUntil). This is maintained by the weather
-			// care tracker independently of show_altered_pokemon, so clean
-			// weather alerts get a correct TTH even when the active-pokemon
-			// tracker is disabled. Users below the min-alert threshold were
-			// already dropped when matched was built.
+			// For clean weather alerts, align TTH with the longest-lived
+			// pokemon actually shown in the alert. CaresUntil is the max
+			// across every pokemon ever registered for this cell (extended,
+			// never reduced — see WeatherCareTracker.Register) and so can
+			// outlive the pokemon the alert mentions. Using it directly
+			// produced a real-world bug: pokemon A despawned and was
+			// clean-deleted, but the weather alert that mentioned A stayed
+			// behind until pokemon B's later despawn time. When the
+			// activePokemon tracker is off we have no per-pokemon data,
+			// so we fall back to CaresUntil as the best estimate.
 			userEnrichment := baseEnrichment
-			if user.Clean > 0 && user.CaresUntil > 0 {
-				// Copy base enrichment to avoid mutating shared map
-				userEnrichment = make(map[string]any, len(baseEnrichment)+1)
-				maps.Copy(userEnrichment, baseEnrichment)
-				userEnrichment["tth"] = geo.ComputeTTH(user.CaresUntil)
+			if user.Clean > 0 {
+				cleanUntil := weatherAlertCleanUntil(user)
+				if cleanUntil > 0 {
+					// Re-check the min-alert threshold with the
+					// alert-accurate TTH (the pre-filter at the top of
+					// the loop used CaresUntil, which can over-estimate
+					// when only short-lived active pokemon remain).
+					if remaining := cleanUntil - now; remaining < minAlert {
+						l.Debugf("Weather alert suppressed for %s (%s) — alert TTH %ds below alert_minimum_time %ds",
+							user.Name, user.ID, remaining, minAlert)
+						continue
+					}
+					userEnrichment = make(map[string]any, len(baseEnrichment)+1)
+					maps.Copy(userEnrichment, baseEnrichment)
+					userEnrichment["tth"] = geo.ComputeTTH(cleanUntil)
+				}
 			}
 
 			// Use per-user tile if available, otherwise base tile
@@ -214,4 +229,23 @@ func (ps *ProcessorService) consumeWeatherChanges() {
 			}
 		}
 	}
+}
+
+// weatherAlertCleanUntil returns the unix timestamp at which a clean
+// weather alert should auto-delete. Prefers max(ActivePokemons.DisappearTime)
+// — those are the pokemon the alert actually mentions, and aligning TTH
+// with them avoids orphan weather messages outliving the alerted pokemon.
+// Falls back to CaresUntil (the user's cell-wide care window) when the
+// active-pokemon tracker is off, since per-pokemon data isn't available.
+func weatherAlertCleanUntil(user webhook.MatchedUser) int64 {
+	if len(user.ActivePokemons) == 0 {
+		return user.CaresUntil
+	}
+	var maxDisappear int64
+	for _, ap := range user.ActivePokemons {
+		if ap.DisappearTime > maxDisappear {
+			maxDisappear = ap.DisappearTime
+		}
+	}
+	return maxDisappear
 }

--- a/processor/cmd/processor/weather_test.go
+++ b/processor/cmd/processor/weather_test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/pokemon/poracleng/processor/internal/webhook"
+)
+
+// weatherAlertCleanUntil must prefer max(ActivePokemons.DisappearTime)
+// so weather alerts auto-delete with the pokemon they mention, not
+// with the user's cell-wide care window (which is the max across every
+// pokemon ever registered and never shrinks). Falls back to CaresUntil
+// when no active-pokemon data is available (show_altered_pokemon off).
+func TestWeatherAlertCleanUntil(t *testing.T) {
+	cases := []struct {
+		name string
+		user webhook.MatchedUser
+		want int64
+	}{
+		{
+			name: "no active pokemon → falls back to CaresUntil",
+			user: webhook.MatchedUser{CaresUntil: 1700000000},
+			want: 1700000000,
+		},
+		{
+			name: "single active pokemon → uses its DisappearTime",
+			user: webhook.MatchedUser{
+				CaresUntil:     2000000000, // longer-lived pokemon registered earlier, already despawned
+				ActivePokemons: []webhook.ActivePokemonEntry{{DisappearTime: 1700000000}},
+			},
+			want: 1700000000,
+		},
+		{
+			name: "multiple active pokemon → max(DisappearTime)",
+			user: webhook.MatchedUser{
+				CaresUntil: 3000000000, // stale, ignored when ActivePokemons present
+				ActivePokemons: []webhook.ActivePokemonEntry{
+					{DisappearTime: 1700000000},
+					{DisappearTime: 1700001800}, // 30min later
+					{DisappearTime: 1700000900},
+				},
+			},
+			want: 1700001800,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := weatherAlertCleanUntil(c.user)
+			if got != c.want {
+				t.Errorf("got %d, want %d", got, c.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## User report

A weather change alert outlived the pokemon it mentioned. The pokemon's clean-delete fired on its despawn; the weather message stayed behind and was cleaned later.

## Cause

\`WeatherCareTracker.Register\` extends \`CaresUntil\` to the max \`DisappearTime\` across every pokemon ever registered for the user's S2 cell, and never reduces it. The dispatcher used \`CaresUntil\` directly for the alert's TTH, so the weather message's TTL tracked the longest-lived pokemon **ever in the cell** — even if that pokemon had since despawned and the alert mentioned only short-lived ones.

Scenario:
- 14:00 — Pokemon A despawns 14:30, Pokemon B despawns 14:45. Both match user, same cell. \`CaresUntil = 14:45\`.
- ~14:15 — Pokemon B becomes inactive.
- 14:20 — Weather changes. Affected list: just A. Alert tracked with TTL = 14:45 − 14:20 = 25 min, cleans at **14:45**.
- 14:30 — Pokemon A alert cleans.
- 14:45 — Weather alert finally cleans. 15 min of orphan message.

## Fix

- When \`ActivePokemons\` is non-empty (\`show_altered_pokemon\` on), derive TTH from \`max(ActivePokemons.DisappearTime)\` — the pokemon the alert actually shows.
- Falls back to \`CaresUntil\` when \`ActivePokemons\` is empty (no per-pokemon data available).
- Re-checks \`alert_minimum_time\` against the alert-accurate TTH so users who pass the \`CaresUntil\`-based pre-filter (which can over-estimate) are still dropped if their actually-shown pokemon yield a TTL below the threshold.
- Logic extracted as \`weatherAlertCleanUntil\` for testability.

## Tests

- \`TestWeatherAlertCleanUntil\` covers all three branches: no active pokemon → CaresUntil; single active → its DisappearTime; multiple active → max(DisappearTime).
- Full suite + race detector clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)