### PR TITLE
scanner: constructors return Scanner interface to fix typed-nil panic

### DIFF
--- a/processor/internal/scanner/golbat.go
+++ b/processor/internal/scanner/golbat.go
@@ -19,7 +19,13 @@ type GolbatScanner struct {
 }
 
 // NewGolbat creates a new GolbatScanner with the given DSN.
-func NewGolbat(dsn string) (*GolbatScanner, error) {
+//
+// Returns the Scanner interface (not *GolbatScanner) so the error
+// path `return nil, err` yields a true nil interface for the caller.
+// Returning the concrete type would assign a typed-nil into the
+// caller's interface variable, which compares != nil and panics on
+// the first method call (nil receiver derefs s.db).
+func NewGolbat(dsn string) (Scanner, error) {
 	db, err := sqlx.Open("mysql", dsn)
 	if err != nil {
 		return nil, fmt.Errorf("scanner: open golbat db: %w", err)

--- a/processor/internal/scanner/rdm.go
+++ b/processor/internal/scanner/rdm.go
@@ -16,8 +16,10 @@ type RDMScanner struct {
 	db *sqlx.DB
 }
 
-// NewRDM creates a new RDMScanner with the given DSN.
-func NewRDM(dsn string) (*RDMScanner, error) {
+// NewRDM creates a new RDMScanner with the given DSN. Returns the
+// Scanner interface (not *RDMScanner) — see NewGolbat's doc-comment
+// for why.
+func NewRDM(dsn string) (Scanner, error) {
 	db, err := sqlx.Open("mysql", dsn)
 	if err != nil {
 		return nil, fmt.Errorf("scanner: open rdm db: %w", err)

--- a/processor/internal/scanner/scanner_test.go
+++ b/processor/internal/scanner/scanner_test.go
@@ -1,0 +1,36 @@
+package scanner
+
+import "testing"
+
+// NewGolbat and NewRDM must return the Scanner INTERFACE (not a
+// concrete pointer) so the error path produces a true nil interface
+// for callers. Returning a concrete *GolbatScanner / *RDMScanner
+// would assign a typed-nil into the caller's Scanner variable, which
+// compares != nil but panics on the first method call (nil receiver
+// derefs s.db). The dial-failure traceback was
+//
+//   scanner.(*GolbatScanner).GetStopData(0x0, ...)
+//     scanner/golbat.go:50 +0x14a
+//
+// — the 0x0 receiver is the smoking gun. This test guards against a
+// future signature regression that would re-introduce the panic.
+func TestConstructors_ErrorReturnsNilInterface(t *testing.T) {
+	cases := []struct {
+		name string
+		fn   func() (Scanner, error)
+	}{
+		{"NewGolbat", func() (Scanner, error) { return NewGolbat("invalid-dsn") }},
+		{"NewRDM", func() (Scanner, error) { return NewRDM("invalid-dsn") }},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			s, err := c.fn()
+			if err == nil {
+				t.Fatalf("%s with invalid DSN should error", c.name)
+			}
+			if s != nil {
+				t.Errorf("%s on error must return a true nil interface (got typed-nil %T = %v) — downstream `== nil` gates will fail and methods will panic", c.name, s, s)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## User report

\`\`\`
scanner.(*GolbatScanner).GetStopData(0x0, ...)
  scanner/golbat.go:50 +0x14a
\`\`\`

A user with a misconfigured scanner DB hit a nil-pointer deref the moment the static-map code tried to query nearby stops. The receiver (\`0x0\`) is the smoking gun.

## Cause

\`NewGolbat\` and \`NewRDM\` returned the concrete pointer type (\`*GolbatScanner\` / \`*RDMScanner\`). On connect failure they returned \`(nil, err)\`. The caller in \`main.go\` assigned that into a \`scanner.Scanner\` interface variable — classic Go gotcha: a typed-nil concrete value placed into an interface becomes a **non-nil interface holding a nil pointer**. Every \`scannerInstance == nil\` gate downstream returned false, and the first method call deref'd \`s.db\` → panic.

## Fix

Change both constructors to return the \`Scanner\` interface. The \`return nil, err\` paths now yield a true nil interface; the typed-nil pitfall is impossible at the call site. Doc-comments on both constructors explain why the interface return type matters.

Only one call site existed (\`main.go\`); no other callers of the concrete types, so the signature change is safe.

## Test

\`TestConstructors_ErrorReturnsNilInterface\` calls each constructor with a deliberately broken DSN and asserts \`s == nil\` on the returned interface. Guards against a future signature regression.

## Test plan

- [x] \`go build ./...\` / \`go vet ./...\` clean.
- [x] New test fails without the fix (typed-nil), passes with it.
- [x] Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)