### PR TITLE
ci: build linux/arm64 on native GitHub arm runners (drop QEMU)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,9 +10,30 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
+# Per-platform jobs run natively on matching GitHub-hosted runners:
+# amd64 on ubuntu-latest, arm64 on ubuntu-24.04-arm (free for public
+# repos as of early 2025). The two digests are then stitched into a
+# single multi-arch manifest by the merge job, so consumers see one
+# image with two platforms exactly as before.
+#
+# Replaces the previous setup-qemu-action + single-job build, where the
+# arm64 leg ran the Go compiler under QEMU emulation (~5-10x slower).
+# Build cache is scoped per platform so arch-specific layers don't
+# invalidate the cross-platform sibling on every push.
+
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            arch: amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            arch: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
       packages: write
@@ -21,8 +42,54 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          push: true
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true
+          cache-from: type=gha,scope=${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.arch }}
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          echo "${{ steps.build.outputs.digest }}" > /tmp/digests/${{ matrix.arch }}
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.arch }}
+          path: /tmp/digests/*
+          retention-days: 1
+          if-no-files-found: error
+
+  merge:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -46,13 +113,14 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=sha,prefix=
 
-      - name: Build and push
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      - name: Create multi-arch manifest
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' $(cat *))
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -128,9 +128,12 @@ jobs:
       - name: Create multi-arch manifest
         working-directory: /tmp/digests
         run: |
+          # Per-arch digest files already contain the full "sha256:<hex>"
+          # form (that's what build-push-action's `digest` output emits),
+          # so don't prepend "sha256:" again.
           docker buildx imagetools create \
             $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.REGISTRY }}/${{ steps.img.outputs.name }}@sha256:%s ' $(cat *))
+            $(printf '${{ env.REGISTRY }}/${{ steps.img.outputs.name }}@%s ' $(cat *))
 
       - name: Inspect image
         run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -42,6 +42,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      # github.repository preserves the original repo case (e.g.
+      # jfberry/PoracleNG) but Docker registry refs must be all
+      # lowercase. metadata-action handles this for tags, but the
+      # build-push-action `outputs:` field needs a pre-lowered value.
+      - name: Resolve lowercase image name
+        id: img
+        run: echo "name=$(echo '${{ env.IMAGE_NAME }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
@@ -59,7 +67,7 @@ jobs:
           context: .
           platforms: ${{ matrix.platform }}
           push: true
-          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ steps.img.outputs.name }},push-by-digest=true,name-canonical=true
           cache-from: type=gha,scope=${{ matrix.arch }}
           cache-to: type=gha,mode=max,scope=${{ matrix.arch }}
 
@@ -91,6 +99,10 @@ jobs:
           pattern: digests-*
           merge-multiple: true
 
+      - name: Resolve lowercase image name
+        id: img
+        run: echo "name=$(echo '${{ env.IMAGE_NAME }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
@@ -105,7 +117,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v6
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ steps.img.outputs.name }}
           tags: |
             type=ref,event=branch
             type=raw,value=latest,enable={{is_default_branch}}
@@ -118,9 +130,9 @@ jobs:
         run: |
           docker buildx imagetools create \
             $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' $(cat *))
+            $(printf '${{ env.REGISTRY }}/${{ steps.img.outputs.name }}@sha256:%s ' $(cat *))
 
       - name: Inspect image
         run: |
           docker buildx imagetools inspect \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}
+            ${{ env.REGISTRY }}/${{ steps.img.outputs.name }}:${{ steps.meta.outputs.version }}


### PR DESCRIPTION
## Why

The current `docker.yml` builds `linux/amd64` natively and `linux/arm64` under QEMU emulation on the same `ubuntu-latest` runner. Go compilation under QEMU runs roughly **5-10× slower** than native, so the arm64 leg dominates total wall time on every push.

GitHub now offers **free arm64 runners** (`ubuntu-24.04-arm`) for public repositories (GA early 2025). Switching the arm64 leg to a native runner removes the emulation cost entirely.

## What changes

- **Per-platform matrix**: two parallel build jobs — `linux/amd64` on `ubuntu-latest`, `linux/arm64` on `ubuntu-24.04-arm`. Each pushes a digest-only image to GHCR with no tags.
- **Merge job** stitches the two digests into a single multi-arch manifest using the same tag set the previous workflow produced (branch / `latest`-on-default / semver / sha-prefix). Consumers see identical pulls — no change to image coordinates.
- **`docker/setup-qemu-action` removed**: native builds don't need binfmt registration.
- **Per-arch cache scopes** (`scope=amd64` / `scope=arm64`): arch-specific layers no longer cross-invalidate the cache on every push.

## Expected impact

Typical wall time on a Go-only build of this size:

| | Before (QEMU) | After (native split) |
|---|---|---|
| amd64 leg | ~1-2 min (native) | ~1-2 min (native, unchanged) |
| arm64 leg | ~5-8 min (QEMU) | ~1-2 min (native) |
| Merge job | n/a | ~20-30 sec |
| **Total wall time** | ~5-8 min | ~2-3 min |

## Tradeoffs

- **Three jobs** instead of one in the Actions UI. The build jobs run in parallel so total wall time still drops sharply.
- **Cache layout** scopes per arch. First runs after this lands will see cold caches on both legs; subsequent runs benefit normally.
- **Free for this repo** (public). For private repos, arm runners bill at 2× the amd64 minute rate, but that's not in play here.

## Verification

Push this branch and watch the Actions tab. Expected pattern:

1. `build (linux/amd64)` and `build (linux/arm64)` start in parallel
2. Both finish in roughly the same wall time (1-2 min each), no QEMU step in either log
3. `merge` runs once both succeed and prints the final multi-arch manifest from `docker buildx imagetools inspect`

Pulling the resulting image on either arch should produce a byte-identical image to what the previous workflow produced — only the build path changed, not the artefact.

## Out of scope (separate work)

- Cross-compiling the Go binary from amd64 to arm64 (`GOOS=linux GOARCH=$TARGETARCH`) would let the arm64 build run on amd64 hardware too. Worth doing in addition for projects with mixed runner availability, but the native-runner change here is simpler and faster.
- Switching to BuildKit cache mounts (`RUN --mount=type=cache,target=/root/.cache/go-build`) for tighter Go-build-cache reuse across runs. Independent optimisation.
