### PR TITLE
lure: set RenderJob.EditKey so the edit flag works for revised expirations

### DIFF
--- a/processor/cmd/processor/lure.go
+++ b/processor/cmd/processor/lure.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -93,6 +94,16 @@ func (ps *ProcessorService) ProcessLure(raw json.RawMessage) error {
 				MatchedAreas:      matchedAreas,
 				TileGate:          ps.newTileGate(tilePending),
 				LogReference:      lure.PokestopID,
+				// Edit key for users with the edit flag (Clean bit 2):
+				// a revised lure expiration on the same (pokestop,
+				// lure_id) re-uses the prior message instead of
+				// sending a fresh one. Stops can host only one lure
+				// at a time, so this is safe even across non-overlapping
+				// lures of the same type — the message tracker entry
+				// for the prior lure has TTL aligned with its expiry
+				// and will have evicted before a new same-type lure
+				// can plausibly arrive.
+				EditKey: fmt.Sprintf("lure:%s:%d", lure.PokestopID, lure.LureID),
 			}
 		} else {
 			l.Debugf("%s at %s [%.3f,%.3f] and 0 humans cared",

--- a/processor/cmd/processor/lure.go
+++ b/processor/cmd/processor/lure.go
@@ -94,15 +94,9 @@ func (ps *ProcessorService) ProcessLure(raw json.RawMessage) error {
 				MatchedAreas:      matchedAreas,
 				TileGate:          ps.newTileGate(tilePending),
 				LogReference:      lure.PokestopID,
-				// Edit key for users with the edit flag (Clean bit 2):
-				// a revised lure expiration on the same (pokestop,
-				// lure_id) re-uses the prior message instead of
-				// sending a fresh one. Stops can host only one lure
-				// at a time, so this is safe even across non-overlapping
-				// lures of the same type — the message tracker entry
-				// for the prior lure has TTL aligned with its expiry
-				// and will have evicted before a new same-type lure
-				// can plausibly arrive.
+				// Edit key for users with Clean bit 2: a revised lure
+				// expiration on the same (pokestop, lure_id) edits
+				// the prior message in place.
 				EditKey: fmt.Sprintf("lure:%s:%d", lure.PokestopID, lure.LureID),
 			}
 		} else {

--- a/processor/cmd/processor/lure_test.go
+++ b/processor/cmd/processor/lure_test.go
@@ -6,16 +6,11 @@ import (
 	"testing"
 )
 
-// TestProcessLure_SetsEditKey is a source-level guard: lure
-// RenderJobs must carry EditKey = "lure:<pokestop>:<lure_id>" so
-// users with the edit flag (Clean bit 2) get the revised-expiration
-// update edited in place instead of receiving a duplicate alert.
-// Without this, Golbat's mid-lure expiration revisions show up as
-// back-to-back "Lure at X" messages — exactly the screenshot the
-// user reported. Source-grep on purpose: ProcessLure needs a fully
-// constructed ProcessorService (matcher, enricher, render channel)
-// which is impractical to assemble here. The per-user gating
-// (only-set-for-edit-flag) is exercised at the renderer layer.
+// TestProcessLure_SetsEditKey: lure RenderJobs must carry
+// EditKey = "lure:<pokestop>:<lure_id>" so users with the edit
+// flag get revised-expiration updates edited in place. Source-grep
+// on purpose: ProcessLure needs a fully-wired ProcessorService to
+// drive end-to-end. Per-user gating is covered by renderer tests.
 func TestProcessLure_SetsEditKey(t *testing.T) {
 	src, err := os.ReadFile("lure.go")
 	if err != nil {

--- a/processor/cmd/processor/lure_test.go
+++ b/processor/cmd/processor/lure_test.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestProcessLure_SetsEditKey is a source-level guard: lure
+// RenderJobs must carry EditKey = "lure:<pokestop>:<lure_id>" so
+// users with the edit flag (Clean bit 2) get the revised-expiration
+// update edited in place instead of receiving a duplicate alert.
+// Without this, Golbat's mid-lure expiration revisions show up as
+// back-to-back "Lure at X" messages — exactly the screenshot the
+// user reported. Source-grep on purpose: ProcessLure needs a fully
+// constructed ProcessorService (matcher, enricher, render channel)
+// which is impractical to assemble here. The per-user gating
+// (only-set-for-edit-flag) is exercised at the renderer layer.
+func TestProcessLure_SetsEditKey(t *testing.T) {
+	src, err := os.ReadFile("lure.go")
+	if err != nil {
+		t.Fatalf("read lure.go: %v", err)
+	}
+	normalized := strings.Join(strings.Fields(string(src)), " ")
+	want := `EditKey: fmt.Sprintf("lure:%s:%d", lure.PokestopID, lure.LureID)`
+	if !strings.Contains(normalized, want) {
+		t.Fatalf("lure.go must set RenderJob.EditKey to %q — without it, the edit flag on a user's lure rule has no effect and revised-expiration lures arrive as duplicates", want)
+	}
+}

--- a/processor/internal/bot/commands/lure.go
+++ b/processor/internal/bot/commands/lure.go
@@ -20,6 +20,7 @@ var lureParams = []bot.ParamDef{
 	{Type: bot.ParamKeyword, Key: "arg.remove"},
 	{Type: bot.ParamKeyword, Key: "arg.everything"},
 	{Type: bot.ParamKeyword, Key: "arg.clean"},
+	{Type: bot.ParamKeyword, Key: "arg.edit"},
 	{Type: bot.ParamLureType},
 }
 

--- a/processor/internal/bot/commands/lure_test.go
+++ b/processor/internal/bot/commands/lure_test.go
@@ -79,6 +79,24 @@ func TestLure_Glacial(t *testing.T) {
 	assert.NotEqual(t, 0, rows[0].LureID, "glacial should have a specific lure ID")
 }
 
+// `!lure <type> edit` must set Clean bit 2 (db.IsEdit). Without
+// arg.edit in lureParams the matcher would warn "unrecognized" and
+// the edit flag would never propagate, defeating the EditKey wiring
+// in cmd/processor/lure.go.
+func TestLure_EditFlag(t *testing.T) {
+	ctx := lureCtx(t)
+	replies := runLure(t, ctx, "glacial edit")
+
+	require.NotEmpty(t, replies)
+	assert.Equal(t, "✅", replies[0].React, "reply: %s", replies[0].Text)
+
+	rows, _ := ctx.Tracking.Lures.SelectByIDProfile("user1", 1)
+	require.Len(t, rows, 1)
+	if rows[0].Clean&2 == 0 {
+		t.Errorf("Clean bit 2 (edit) not set: got %d", rows[0].Clean)
+	}
+}
+
 func TestLure_Duplicate(t *testing.T) {
 	ctx := lureCtx(t)
 	replies1 := runLure(t, ctx, "everything")


### PR DESCRIPTION
## Summary

User report: Golbat occasionally emits a second webhook for the same lure with a revised expiration time. Users tracking with the edit flag (\`!lure <type> edit\`) were getting two separate \"Lure at X\" messages — the second a duplicate of the first with a different \"Time left:\".

## Cause

\`lure.go\`'s RenderJob didn't carry an \`EditKey\`. The renderer's per-user editKey computation gates on \`db.IsEdit(user.Clean)\` AND requires a non-empty \`editKeyBase\` from the caller. Without the base, the per-user editKey stays empty and the queue's edit-lookup path is skipped — every webhook ships as a fresh send.

## Fix

Set \`EditKey = \"lure:<pokestop_id>:<lure_id>\"\` on the lure RenderJob. Mirrors the raid pattern (\`raid:<gymID>:<end>\`). Users without the edit flag are unaffected — per-user gating still produces an empty editKey for them.

## Edge case considered

A same-type lure placed at the same stop much later (after the prior message has been clean-evicted) gets a fresh send rather than reviving a stale message. The cache TTL aligns with the lure's expiration so this is handled naturally.

## Tests

\`TestProcessLure_SetsEditKey\` source-grep guard pinning the key shape. \`ProcessLure\` needs a fully-wired ProcessorService to drive end-to-end (impractical in a unit test); per-user gating is covered by existing renderer tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)