### PR TITLE
grunts: patch missing type for METAL grunt (29) → Steel

### DIFF
--- a/processor/internal/enrichment/testdata/expected.json
+++ b/processor/internal/enrichment/testdata/expected.json
@@ -7385,7 +7385,7 @@
           "nameEng": "Aggron"
         }
       ],
-      "typeId": 0,
+      "typeId": 9,
       "categoryId": 2
     }
   },
@@ -9210,7 +9210,7 @@
           "nameEng": "Aggron"
         }
       ],
-      "typeId": 0,
+      "typeId": 9,
       "categoryId": 2
     }
   },
@@ -9544,7 +9544,7 @@
           "nameEng": "Aggron"
         }
       ],
-      "typeId": 0,
+      "typeId": 9,
       "categoryId": 2
     }
   },
@@ -10660,7 +10660,7 @@
           "nameEng": "Aggron"
         }
       ],
-      "typeId": 0,
+      "typeId": 9,
       "categoryId": 2
     }
   },

--- a/processor/internal/gamedata/grunts.go
+++ b/processor/internal/gamedata/grunts.go
@@ -118,6 +118,22 @@ func categoryFromTemplate(template string) int {
 	}
 }
 
+// inferGruntTypeID returns the upstream type ID when set, otherwise
+// patches known gaps in WatWowMap's classic.json. As of the report,
+// grunt 29 (CHARACTER_METAL_GRUNT_MALE) ships with `"type": {}` —
+// the type ID is missing but the template makes the intent clear
+// (Metal grunt = Steel type). Add new template→ID rows here if more
+// upstream gaps appear.
+func inferGruntTypeID(template string, upstreamID int) int {
+	if upstreamID != 0 {
+		return upstreamID
+	}
+	if strings.Contains(template, "METAL") {
+		return 9 // Steel
+	}
+	return 0
+}
+
 // LoadGrunts parses the classic.json invasions format.
 func LoadGrunts(path string) (map[int]*Grunt, error) {
 	data, err := os.ReadFile(path)
@@ -142,7 +158,7 @@ func LoadGrunts(path string) (map[int]*Grunt, error) {
 			Template:   g.Character.Template,
 			Gender:     g.Character.Gender,
 			Boss:       g.Character.Boss,
-			TypeID:     g.Character.Type.ID,
+			TypeID:     inferGruntTypeID(g.Character.Template, g.Character.Type.ID),
 			Active:     g.Active,
 			Rewards:    g.Lineup.Rewards,
 			CategoryID: categoryFromTemplate(g.Character.Template),

--- a/processor/internal/gamedata/grunts_test.go
+++ b/processor/internal/gamedata/grunts_test.go
@@ -41,6 +41,32 @@ func TestTypeNameFromTemplate(t *testing.T) {
 	}
 }
 
+// WatWowMap's classic.json ships grunt 29 (CHARACTER_METAL_GRUNT_MALE)
+// with an empty "type": {} block, so the parsed TypeID is 0. The
+// game intends Steel (type ID 9). Patch must fill the gap without
+// overwriting a genuine upstream value.
+func TestInferGruntTypeID(t *testing.T) {
+	cases := []struct {
+		name       string
+		template   string
+		upstreamID int
+		want       int
+	}{
+		{"metal grunt with missing type → steel (9)", "CHARACTER_METAL_GRUNT_MALE", 0, 9},
+		{"metal grunt with upstream type → respected", "CHARACTER_METAL_GRUNT_MALE", 5, 5},
+		{"typed grunt with upstream type → unchanged", "CHARACTER_FIRE_GRUNT_FEMALE", 10, 10},
+		{"untyped boss → 0", "CHARACTER_GIOVANNI", 0, 0},
+		{"untyped grunt → 0", "CHARACTER_GRUNT_MALE", 0, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := inferGruntTypeID(tc.template, tc.upstreamID); got != tc.want {
+				t.Errorf("inferGruntTypeID(%q, %d) = %d, want %d", tc.template, tc.upstreamID, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestCategoryFromTemplate(t *testing.T) {
 	cases := []struct {
 		template string


### PR DESCRIPTION
## User report

WatWowMap's classic.json ships grunt 29 (\`CHARACTER_METAL_GRUNT_MALE\`) with an empty \`\"type\": {}\` block:

\`\`\`json
\"29\": {
  \"active\": true,
  \"character\": {
    \"template\": \"CHARACTER_METAL_GRUNT_MALE\",
    \"gender\": 1,
    \"boss\": false,
    \"type\": {}
  },
\`\`\`

So the parsed TypeID is 0, but the template's intent (Metal grunt = Steel type, ID 9) is unambiguous.

## Fix

\`inferGruntTypeID(template, upstreamID)\` called from \`LoadGrunts\`. Upstream-supplied ID wins; otherwise template inference fills known gaps. Currently only METAL → 9 (Steel); easy to extend when more upstream omissions appear.

## Tests

- \`TestInferGruntTypeID\` covers five branches: METAL missing/present, typed grunt unchanged, untyped boss, untyped grunt.
- Updated four \`internal/enrichment/testdata/expected.json\` grunt-29 fixture entries from \`typeId: 0\` to \`typeId: 9\` — the JS that generated those fixtures shared the same upstream bug, so the equivalence test had been pinning the broken value.

## Test plan

- [x] \`go build ./...\` / \`go vet ./...\` clean.
- [x] Full test suite green (including invasion equivalence test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)