### PR TITLE
db/invasions: rewrite legacy 'metal' grunt_type to 'steel' on load

### DIFF
--- a/processor/internal/db/invasions.go
+++ b/processor/internal/db/invasions.go
@@ -1,6 +1,10 @@
 package db
 
-import "github.com/jmoiron/sqlx"
+import (
+	"strings"
+
+	"github.com/jmoiron/sqlx"
+)
 
 // InvasionTracking represents a row from the invasion table.
 type InvasionTracking struct {
@@ -15,6 +19,14 @@ type InvasionTracking struct {
 }
 
 // LoadInvasions loads all invasion trackings from the database.
+//
+// In-memory normalisation: rows with grunt_type='metal' (legacy
+// PoracleJS spelling, still emitted by some third-party CRUD tools)
+// are translated to 'steel' so they match the webhook-side classifier
+// in gamedata.TypeNameFromTemplate (which returns 'steel' for the
+// METAL template). The DB row is left untouched — only the in-memory
+// snapshot used by the matcher is rewritten. Drop this once the
+// known offending third-party tools have caught up.
 func LoadInvasions(db *sqlx.DB) ([]*InvasionTracking, error) {
 	var invasions []InvasionTracking
 	err := db.Select(&invasions,
@@ -27,7 +39,18 @@ func LoadInvasions(db *sqlx.DB) ([]*InvasionTracking, error) {
 
 	result := make([]*InvasionTracking, len(invasions))
 	for i := range invasions {
+		invasions[i].GruntType = normaliseInvasionGruntType(invasions[i].GruntType)
 		result[i] = &invasions[i]
 	}
 	return result, nil
+}
+
+// normaliseInvasionGruntType rewrites legacy/third-party grunt_type
+// values to the canonical name the webhook-side classifier produces.
+// Returns the input unchanged when nothing needs rewriting.
+func normaliseInvasionGruntType(s string) string {
+	if strings.EqualFold(s, "metal") {
+		return "steel"
+	}
+	return s
 }

--- a/processor/internal/db/invasions_test.go
+++ b/processor/internal/db/invasions_test.go
@@ -1,0 +1,27 @@
+package db
+
+import "testing"
+
+// normaliseInvasionGruntType maps legacy/third-party 'metal' to the
+// canonical 'steel' that the webhook classifier produces. Anything
+// else passes through unchanged.
+func TestNormaliseInvasionGruntType(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"metal", "steel"},
+		{"Metal", "steel"}, // case-insensitive — third-party tools vary
+		{"METAL", "steel"},
+		{"steel", "steel"},  // canonical → unchanged
+		{"fire", "fire"},    // typed grunt unchanged
+		{"giovanni", "giovanni"},
+		{"everything", "everything"},
+		{"boss", "boss"},
+		{"", ""},
+	}
+	for _, c := range cases {
+		if got := normaliseInvasionGruntType(c.in); got != c.want {
+			t.Errorf("normaliseInvasionGruntType(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## Context

Some operators have invasion tracking rows with \`grunt_type='metal'\` — legacy PoracleJS spelling, still emitted by some third-party CRUD tools. The webhook-side classifier (\`gamedata.TypeNameFromTemplate\` in PR #106) now canonicalises METAL → \`steel\`, so those legacy rows stopped matching against live invasions.

## Fix

Patch \`LoadInvasions\` to rewrite \`metal\` → \`steel\` in-memory while loading the matcher state. DB row left untouched; only the in-process snapshot the matcher reads is normalised. Drop the helper once the known offending third-party tools have caught up.

\`normaliseInvasionGruntType\` extracted for testability. Case-insensitive (third-party tools vary), pass-through for everything else.

## Test plan

- [x] \`go build ./...\` / \`go vet ./...\` clean.
- [x] \`TestNormaliseInvasionGruntType\` covers case-insensitive metal → steel + pass-through for typed/boss/everything/empty.
- [x] Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)