### PR TITLE
migrate-from-poracle: don't snake-case inside dts_dictionary

### DIFF
--- a/scripts/migrate-from-poracle.js
+++ b/scripts/migrate-from-poracle.js
@@ -53,13 +53,27 @@ function camelToSnake(str) {
 		.toLowerCase()
 }
 
+// Keys whose value is a user-defined free-form map (template variables,
+// custom locale strings, etc.) and must NOT have its inner keys
+// snake-cased. The TOML schema renames the key itself (camelCase →
+// snake_case) but the contents are pass-through. Match on the
+// snake-cased form because that's what convertKeysToSnake produces.
+const PASSTHROUGH_KEYS = new Set([
+	'dts_dictionary', // {{templateVar}} → user-defined identifier
+])
+
 function convertKeysToSnake(obj) {
 	if (obj === null || obj === undefined) return obj
 	if (Array.isArray(obj)) return obj.map(convertKeysToSnake)
 	if (typeof obj !== 'object') return obj
 	const result = {}
 	for (const [key, value] of Object.entries(obj)) {
-		result[camelToSnake(key)] = convertKeysToSnake(value)
+		const snakeKey = camelToSnake(key)
+		if (PASSTHROUGH_KEYS.has(snakeKey)) {
+			result[snakeKey] = value
+			continue
+		}
+		result[snakeKey] = convertKeysToSnake(value)
 	}
 	return result
 }


### PR DESCRIPTION
## User report

A PoracleJS \`local.json\` with

\`\`\`json
\"dtsDictionary\": {
  \"scannerUrl\": \"https://www.mwbmap.net\",
  \"scannerIconUrl\": \"https://i.imgur.com/dM8AmjW.png\",
  \"discordInviteUrl\": \"https://discord.gg/xfSGVCjkG4\",
  \"map\": \"bpm\"
}
\`\`\`

migrated to

\`\`\`toml
[general.dts_dictionary]
scanner_url = \"https://www.mwbmap.net\"
scanner_icon_url = \"https://i.imgur.com/dM8AmjW.png\"
discord_invite_url = \"https://discord.gg/xfSGVCjkG4\"
map = \"bpm\"
\`\`\`

— so any DTS template referencing \`{{scannerUrl}}\` stopped resolving. \`LayeredView\`'s dtsDict lookup at \`internal/dts/layered_view.go:170\` is a verbatim case-sensitive map lookup; renaming the user's template variable names destroys the binding.

## Cause

\`convertKeysToSnake\` (line 56) recurses unconditionally. Since \`general\` flows through the generic \`simpleSections\` loop (line 344), the user-defined dictionary values get snake-cased too.

## Fix

Introduce a \`PASSTHROUGH_KEYS\` set in \`convertKeysToSnake\`. When a snake-cased key is in the set, the value is copied as-is (no recursion). Currently the only entry is \`dts_dictionary\`; add more if other free-form maps surface.

The map-level key itself is still renamed (\`dtsDictionary\` → \`dts_dictionary\`) so the Go TOML schema picks it up.

## Operator-side recovery

Per the discussion: this is migrator-only. Operators with already-migrated configs need to hand-fix their \`config.toml\` — rename the snake_cased keys inside \`[general.dts_dictionary]\` back to camelCase to match what their templates reference.

## Test plan

- [x] Manual reproduction: built a standalone harness with the fixed \`convertKeysToSnake\` and the user's input → output matches expectation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)