### PR TITLE
dts/helpers: register `is` as an alias for `eq`

### DIFF
--- a/DTS.md
+++ b/DTS.md
@@ -870,7 +870,7 @@ Templates can use built-in Handlebars block helpers plus custom helpers register
 - `{{#each array}}` — iteration (`{{this}}` for current item, `{{@index}}` for index, `{{isFirst}}`/`{{isLast}}` as context properties)
 - `{{#forEach array}}` — like each, with `{{@total}}` data variable
 
-**Comparison:** `{{#eq a b}}`, `{{#ne a b}}`, `{{#isnt a b}}`, `{{#gt a b}}`, `{{#lt a b}}`, `{{#gte a b}}`, `{{#lte a b}}`, `{{#and a b ...}}` (variadic), `{{#or a b ...}}` (variadic), `{{#neither a b ...}}` (variadic, inverse of or), `{{#oneOf value a b c ...}}` (value equals any of a/b/c — use this instead of `{{#or value a b}}` which is "any arg truthy"), `{{#not a}}`, `{{#contains collection value}}`, `{{#compare a "op" b}}`
+**Comparison:** `{{#eq a b}}`, `{{#is a b}}` (alias for `eq`), `{{#ne a b}}`, `{{#isnt a b}}` (alias for `ne`), `{{#gt a b}}`, `{{#lt a b}}`, `{{#gte a b}}`, `{{#lte a b}}`, `{{#and a b ...}}` (variadic), `{{#or a b ...}}` (variadic), `{{#neither a b ...}}` (variadic, inverse of or), `{{#oneOf value a b c ...}}` (value equals any of a/b/c — use this instead of `{{#or value a b}}` which is "any arg truthy"), `{{#not a}}`, `{{#contains collection value}}`, `{{#compare a "op" b}}`
 
 All comparison helpers work both as block helpers (`{{#eq a b}}X{{else}}Y{{/eq}}`) and as subexpressions (`{{#if (eq a b)}}`).
 

--- a/processor/internal/dts/helpers.go
+++ b/processor/internal/dts/helpers.go
@@ -174,6 +174,11 @@ func registerComparisonHelpers() {
 		return boolResult(looseEqual(a, b), options)
 	})
 
+	// is — alias for eq (mirrors `isnt` as the alias for `ne`).
+	raymond.RegisterHelper("is", func(a, b any, options *raymond.Options) any {
+		return boolResult(looseEqual(a, b), options)
+	})
+
 	// ne — true if a != b (loose comparison, see eq).
 	raymond.RegisterHelper("ne", func(a, b any, options *raymond.Options) any {
 		return boolResult(!looseEqual(a, b), options)

--- a/processor/internal/dts/helpers_test.go
+++ b/processor/internal/dts/helpers_test.go
@@ -53,6 +53,26 @@ func TestEq(t *testing.T) {
 	}
 }
 
+func TestIs(t *testing.T) {
+	ctx := map[string]any{"a": "foo", "b": "foo", "c": "bar"}
+
+	// Block mode
+	got := render(t, `{{#is a b}}same{{else}}different{{/is}}`, ctx)
+	if got != "same" {
+		t.Errorf("is block match: got %q, want %q", got, "same")
+	}
+	got = render(t, `{{#is a c}}same{{else}}different{{/is}}`, ctx)
+	if got != "different" {
+		t.Errorf("is block mismatch: got %q, want %q", got, "different")
+	}
+
+	// Subexpression mode
+	got = render(t, `{{#if (is a b)}}same{{else}}different{{/if}}`, ctx)
+	if got != "same" {
+		t.Errorf("is subexpr match: got %q, want %q", got, "same")
+	}
+}
+
 func TestIsnt(t *testing.T) {
 	ctx := map[string]any{"a": "foo", "b": "bar"}
 


### PR DESCRIPTION
Mirrors the existing \`isnt\` alias for \`ne\`. Operators porting templates from PoracleJS sometimes use \`{{#is a b}}…{{/is}}\` and expected it to work alongside \`isnt\`.

- Adds the helper alongside \`eq\` in \`internal/dts/helpers.go\`.
- \`TestIs\` covers block + subexpression modes.
- DTS.md helper index notes both aliases (\`is\` for \`eq\`, \`isnt\` for \`ne\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)