### PR TITLE
Fix !track when only min is provided

### DIFF
--- a/processor/internal/bot/commands/track.go
+++ b/processor/internal/bot/commands/track.go
@@ -431,8 +431,11 @@ func (c *TrackCommand) parseFilters(ctx *bot.CommandContext, parsed *bot.ParsedA
 	// Size
 	if r, ok := parsed.Ranges["size"]; ok {
 		f.size = r.Min
+		// Set maxSize to Min, if no Max is provided
 		if r.HasMax {
 			f.maxSize = r.Max
+		} else {
+			f.maxSize = r.Min
 		}
 	}
 	if v, ok := parsed.Singles["maxsize"]; ok {


### PR DESCRIPTION
Very basic fix, where maxSize is set to Min, if no range is provided in !track
Also follows the docs already: https://jfberry.github.io/PoracleNG-docs/userguide/pokemon/#track-by-size

Previous behaviour
  - size1 → size=1, maxSize=5 → size: XXS-XXL
  - size3 → size=3, maxSize=5 → size: M-XXL
  - size1-3 → size=1, maxSize=3 → size: XXS-M (explicit range, unchanged)

New behaviour
  - size1 → size=1, maxSize=1 → size: XXS (exact match)
  - size3 → size=3, maxSize=3 → size: M (exact match)
  - size1-3 → size=1, maxSize=3 → size: XXS-M (explicit range, unchanged)