### PR TITLE
migrate-from-poracle: map server.host → processor.host

### DIFF
--- a/scripts/migrate-from-poracle.js
+++ b/scripts/migrate-from-poracle.js
@@ -258,6 +258,9 @@ function buildUnifiedConfig(defaults, local) {
 		port: oldPort,
 	}
 
+	if (serverOverrides.host) {
+		unified.processor.host = serverOverrides.host
+	}
 	// Preserve api_secret from server overrides
 	if (serverOverrides.apiSecret) {
 		unified.processor.api_secret = serverOverrides.apiSecret


### PR DESCRIPTION
User reported \`server.host\` was silently dropped during migration. The networking block in \`buildUnifiedConfig\` only handled \`port\`, \`apiSecret\`, \`ipWhitelist\`, \`ipBlacklist\`. Operators who had locked PoracleJS's API to a specific bind address lost that binding after migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)