### PR TITLE
[codex] Fix gym battle cooldown deduplication

### DIFF
--- a/processor/cmd/processor/gym.go
+++ b/processor/cmd/processor/gym.go
@@ -55,17 +55,14 @@ func (ps *ProcessorService) ProcessGym(raw json.RawMessage) error {
 		// Resolve in-battle
 		inBattle := bool(gym.IsInBattle) || bool(gym.InBattle)
 
-		// Battle cooldown: during battles, Golbat sends frequent updates.
-		// GymInBattleCooldown reports the pre-existing cooldown state, then
-		// starts/refreshes it for in-battle webhooks. This keeps the first
-		// under-attack update eligible and suppresses repeated same-state ones.
-		battleCooldown := ps.duplicates.GymInBattleCooldown(gymID, inBattle)
-
 		// Update gym state and get old state.
 		// On first sight (oldState == nil), use -1 for old values to signal
 		// "unknown previous state" — this triggers team-change alerts matching
 		// the original behavior where old_team_id=-1 means "team changed".
-		oldState := ps.gymState.Update(gymID, teamID, gym.SlotsAvailable, inBattle)
+		//
+		// Battle cooldown is decided inside the same tracker transition so
+		// concurrent first in-battle updates for a cold gym cannot both alert.
+		oldState, battleCooldown := ps.gymState.UpdateWithBattleCooldown(gymID, teamID, gym.SlotsAvailable, inBattle, time.Now())
 
 		oldTeamID := -1
 		oldSlotsAvailable := -1

--- a/processor/cmd/processor/gym.go
+++ b/processor/cmd/processor/gym.go
@@ -56,7 +56,9 @@ func (ps *ProcessorService) ProcessGym(raw json.RawMessage) error {
 		inBattle := bool(gym.IsInBattle) || bool(gym.InBattle)
 
 		// Battle cooldown: during battles, Golbat sends frequent updates.
-		// Skip if same team + same slots and within 5-min battle cooldown.
+		// GymInBattleCooldown reports the pre-existing cooldown state, then
+		// starts/refreshes it for in-battle webhooks. This keeps the first
+		// under-attack update eligible and suppresses repeated same-state ones.
 		battleCooldown := ps.duplicates.GymInBattleCooldown(gymID, inBattle)
 
 		// Update gym state and get old state.

--- a/processor/internal/matching/gym.go
+++ b/processor/internal/matching/gym.go
@@ -36,7 +36,6 @@ type GymMatcher struct {
 func (m *GymMatcher) matchGyms(data *GymData, rules []*db.GymTracking) []trackingUserData {
 	teamChanged := data.OldTeamID != data.TeamID
 	slotsChanged := data.OldSlotsAvailable != data.SlotsAvailable
-	battleChanged := data.InBattle && !data.OldInBattle
 
 	var out []trackingUserData
 	for _, g := range rules {
@@ -52,7 +51,7 @@ func (m *GymMatcher) matchGyms(data *GymData, rules []*db.GymTracking) []trackin
 			if slotsChanged && g.SlotChanges {
 				wantsThis = true
 			}
-			if battleChanged && g.BattleChanges {
+			if data.InBattle && g.BattleChanges {
 				wantsThis = true
 			}
 			if !wantsThis {

--- a/processor/internal/matching/gym_test.go
+++ b/processor/internal/matching/gym_test.go
@@ -180,6 +180,32 @@ func TestGymBattleChange(t *testing.T) {
 	}
 }
 
+func TestGymBattleActiveMatchesAfterPriorBattleState(t *testing.T) {
+	human := makeHuman("user1")
+	gym := &db.GymTracking{
+		ID: "user1", ProfileNo: 1, Team: 2,
+		BattleChanges: true,
+		Distance:      0, Template: "1",
+	}
+
+	st := makeGymTestState([]*db.GymTracking{gym}, map[string]*db.Human{"user1": human})
+	matcher := &GymMatcher{}
+
+	data := &GymData{
+		GymID:       "gym1",
+		TeamID:      2,
+		OldTeamID:   2,
+		InBattle:    true,
+		OldInBattle: true,
+		Latitude:    51.0, Longitude: 0.0,
+	}
+
+	matched, _ := matcher.Match(data, st)
+	if len(matched) != 1 {
+		t.Errorf("Expected 1 match for active battle, got %d", len(matched))
+	}
+}
+
 func TestGymSpecificGym(t *testing.T) {
 	human := makeHuman("user1")
 	gymID := "gym1"

--- a/processor/internal/tracker/duplicate.go
+++ b/processor/internal/tracker/duplicate.go
@@ -2,7 +2,6 @@ package tracker
 
 import (
 	"fmt"
-	"sync"
 	"time"
 
 	"github.com/jellydator/ttlcache/v3"
@@ -10,10 +9,8 @@ import (
 
 // DuplicateCache provides deduplication for webhooks.
 type DuplicateCache struct {
-	cache       *ttlcache.Cache[string, bool]
-	raidCache   *ttlcache.Cache[string, *RaidCacheResult]
-	gymBattle   *ttlcache.Cache[string, bool] // battle cooldown (5 min TTL)
-	gymBattleMu sync.Mutex
+	cache     *ttlcache.Cache[string, bool]
+	raidCache *ttlcache.Cache[string, *RaidCacheResult]
 }
 
 // NewDuplicateCache creates a new duplicate detection cache.
@@ -26,21 +23,15 @@ func NewDuplicateCache() *DuplicateCache {
 		ttlcache.WithTTL[string, *RaidCacheResult](90*time.Minute),
 		ttlcache.WithDisableTouchOnHit[string, *RaidCacheResult](),
 	)
-	gymBattle := ttlcache.New[string, bool](
-		ttlcache.WithTTL[string, bool](5*time.Minute),
-		ttlcache.WithDisableTouchOnHit[string, bool](),
-	)
 	go cache.Start()
 	go raidCache.Start()
-	go gymBattle.Start()
-	return &DuplicateCache{cache: cache, raidCache: raidCache, gymBattle: gymBattle}
+	return &DuplicateCache{cache: cache, raidCache: raidCache}
 }
 
 // Close stops all cache eviction goroutines.
 func (dc *DuplicateCache) Close() {
 	dc.cache.Stop()
 	dc.raidCache.Stop()
-	dc.gymBattle.Stop()
 }
 
 // CheckPokemon returns true if this pokemon was already seen (duplicate).
@@ -223,18 +214,4 @@ func (dc *DuplicateCache) CheckNest(nestID int64, pokemonID int, resetTime int64
 	}
 	dc.cache.Set(key, true, time.Duration(remaining)*time.Second)
 	return false
-}
-
-// GymInBattleCooldown checks if a gym was already within the 5-minute battle
-// cooldown before this webhook. If inBattle is true, starts/refreshes the
-// cooldown after reading the previous state.
-func (dc *DuplicateCache) GymInBattleCooldown(gymID string, inBattle bool) bool {
-	dc.gymBattleMu.Lock()
-	defer dc.gymBattleMu.Unlock()
-
-	active := dc.gymBattle.Get(gymID) != nil
-	if inBattle {
-		dc.gymBattle.Set(gymID, true, 5*time.Minute)
-	}
-	return active
 }

--- a/processor/internal/tracker/duplicate.go
+++ b/processor/internal/tracker/duplicate.go
@@ -2,6 +2,7 @@ package tracker
 
 import (
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/jellydator/ttlcache/v3"
@@ -9,9 +10,10 @@ import (
 
 // DuplicateCache provides deduplication for webhooks.
 type DuplicateCache struct {
-	cache     *ttlcache.Cache[string, bool]
-	raidCache *ttlcache.Cache[string, *RaidCacheResult]
-	gymBattle *ttlcache.Cache[string, bool] // battle cooldown (5 min TTL)
+	cache       *ttlcache.Cache[string, bool]
+	raidCache   *ttlcache.Cache[string, *RaidCacheResult]
+	gymBattle   *ttlcache.Cache[string, bool] // battle cooldown (5 min TTL)
+	gymBattleMu sync.Mutex
 }
 
 // NewDuplicateCache creates a new duplicate detection cache.
@@ -227,6 +229,9 @@ func (dc *DuplicateCache) CheckNest(nestID int64, pokemonID int, resetTime int64
 // cooldown before this webhook. If inBattle is true, starts/refreshes the
 // cooldown after reading the previous state.
 func (dc *DuplicateCache) GymInBattleCooldown(gymID string, inBattle bool) bool {
+	dc.gymBattleMu.Lock()
+	defer dc.gymBattleMu.Unlock()
+
 	active := dc.gymBattle.Get(gymID) != nil
 	if inBattle {
 		dc.gymBattle.Set(gymID, true, 5*time.Minute)

--- a/processor/internal/tracker/duplicate.go
+++ b/processor/internal/tracker/duplicate.go
@@ -223,12 +223,13 @@ func (dc *DuplicateCache) CheckNest(nestID int64, pokemonID int, resetTime int64
 	return false
 }
 
-// GymInBattleCooldown checks if a gym is within the 5-minute battle cooldown.
-// If inBattle is true, starts/refreshes the cooldown.
-// Returns true if the gym is still in the cooldown period.
+// GymInBattleCooldown checks if a gym was already within the 5-minute battle
+// cooldown before this webhook. If inBattle is true, starts/refreshes the
+// cooldown after reading the previous state.
 func (dc *DuplicateCache) GymInBattleCooldown(gymID string, inBattle bool) bool {
+	active := dc.gymBattle.Get(gymID) != nil
 	if inBattle {
 		dc.gymBattle.Set(gymID, true, 5*time.Minute)
 	}
-	return dc.gymBattle.Get(gymID) != nil
+	return active
 }

--- a/processor/internal/tracker/duplicate_test.go
+++ b/processor/internal/tracker/duplicate_test.go
@@ -160,14 +160,19 @@ func TestGymBattleCooldown(t *testing.T) {
 		t.Error("Expected no cooldown when not in battle and no prior entry")
 	}
 
-	// Start battle — sets cooldown, returns true
-	if !dc.GymInBattleCooldown("gym1", true) {
-		t.Error("Expected cooldown to be active after battle starts")
+	// First battle update starts cooldown but is not itself suppressed.
+	if dc.GymInBattleCooldown("gym1", true) {
+		t.Error("Expected first battle update to be outside cooldown")
 	}
 
 	// Check again without battle — still in cooldown
 	if !dc.GymInBattleCooldown("gym1", false) {
 		t.Error("Expected cooldown to persist")
+	}
+
+	// Another battle update during cooldown is suppressed and refreshes it.
+	if !dc.GymInBattleCooldown("gym1", true) {
+		t.Error("Expected repeated battle update to be inside cooldown")
 	}
 
 	// Different gym — no cooldown

--- a/processor/internal/tracker/duplicate_test.go
+++ b/processor/internal/tracker/duplicate_test.go
@@ -1,6 +1,8 @@
 package tracker
 
 import (
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -178,6 +180,34 @@ func TestGymBattleCooldown(t *testing.T) {
 	// Different gym — no cooldown
 	if dc.GymInBattleCooldown("gym2", false) {
 		t.Error("Expected different gym to have no cooldown")
+	}
+}
+
+func TestGymBattleCooldownConcurrentFirstUpdate(t *testing.T) {
+	dc := NewDuplicateCache()
+	defer dc.Close()
+
+	const workers = 64
+	var wg sync.WaitGroup
+	var first int64
+	start := make(chan struct{})
+
+	wg.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func() {
+			defer wg.Done()
+			<-start
+			if !dc.GymInBattleCooldown("gym-concurrent", true) {
+				atomic.AddInt64(&first, 1)
+			}
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+
+	if first != 1 {
+		t.Errorf("Expected exactly one first battle update, got %d", first)
 	}
 }
 

--- a/processor/internal/tracker/duplicate_test.go
+++ b/processor/internal/tracker/duplicate_test.go
@@ -1,8 +1,6 @@
 package tracker
 
 import (
-	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -150,64 +148,6 @@ func TestRaidRSVPNilToSome(t *testing.T) {
 	}
 	if isFirst {
 		t.Error("Expected nil→some to not be first notification")
-	}
-}
-
-func TestGymBattleCooldown(t *testing.T) {
-	dc := NewDuplicateCache()
-	defer dc.Close()
-
-	// No cooldown initially
-	if dc.GymInBattleCooldown("gym1", false) {
-		t.Error("Expected no cooldown when not in battle and no prior entry")
-	}
-
-	// First battle update starts cooldown but is not itself suppressed.
-	if dc.GymInBattleCooldown("gym1", true) {
-		t.Error("Expected first battle update to be outside cooldown")
-	}
-
-	// Check again without battle — still in cooldown
-	if !dc.GymInBattleCooldown("gym1", false) {
-		t.Error("Expected cooldown to persist")
-	}
-
-	// Another battle update during cooldown is suppressed and refreshes it.
-	if !dc.GymInBattleCooldown("gym1", true) {
-		t.Error("Expected repeated battle update to be inside cooldown")
-	}
-
-	// Different gym — no cooldown
-	if dc.GymInBattleCooldown("gym2", false) {
-		t.Error("Expected different gym to have no cooldown")
-	}
-}
-
-func TestGymBattleCooldownConcurrentFirstUpdate(t *testing.T) {
-	dc := NewDuplicateCache()
-	defer dc.Close()
-
-	const workers = 64
-	var wg sync.WaitGroup
-	var first int64
-	start := make(chan struct{})
-
-	wg.Add(workers)
-	for i := 0; i < workers; i++ {
-		go func() {
-			defer wg.Done()
-			<-start
-			if !dc.GymInBattleCooldown("gym-concurrent", true) {
-				atomic.AddInt64(&first, 1)
-			}
-		}()
-	}
-
-	close(start)
-	wg.Wait()
-
-	if first != 1 {
-		t.Errorf("Expected exactly one first battle update, got %d", first)
 	}
 }
 

--- a/processor/internal/tracker/gymstate.go
+++ b/processor/internal/tracker/gymstate.go
@@ -12,11 +12,12 @@ import (
 
 // GymState holds cached gym state for change detection.
 type GymState struct {
-	TeamID         int       `json:"team_id"`
-	SlotsAvailable int       `json:"slots_available"`
-	InBattle       bool      `json:"in_battle"`
-	LastOwnerID    int       `json:"last_owner_id"`
-	LastSeen       time.Time `json:"last_seen"`
+	TeamID              int       `json:"team_id"`
+	SlotsAvailable      int       `json:"slots_available"`
+	InBattle            bool      `json:"in_battle"`
+	LastOwnerID         int       `json:"last_owner_id"`
+	LastSeen            time.Time `json:"last_seen"`
+	BattleCooldownUntil time.Time `json:"-"`
 }
 
 // GymStateTracker tracks gym state for detecting team/slot/battle changes.
@@ -52,6 +53,27 @@ func (gst *GymStateTracker) Update(gymID string, teamID, slotsAvailable int, inB
 	gst.mu.Lock()
 	defer gst.mu.Unlock()
 
+	return gst.updateLocked(gymID, teamID, slotsAvailable, inBattle, time.Now())
+}
+
+// UpdateWithBattleCooldown stores current gym state and returns the old state
+// plus whether the gym was already inside the battle cooldown before this
+// webhook. The cooldown decision and state transition are made under the same
+// lock so concurrent first in-battle updates cannot both escape suppression.
+func (gst *GymStateTracker) UpdateWithBattleCooldown(gymID string, teamID, slotsAvailable int, inBattle bool, now time.Time) (*GymState, bool) {
+	gst.mu.Lock()
+	defer gst.mu.Unlock()
+
+	old := gst.gyms[gymID]
+	battleCooldown := old != nil && old.BattleCooldownUntil.After(now)
+	oldCopy := gst.updateLocked(gymID, teamID, slotsAvailable, inBattle, now)
+	if inBattle {
+		gst.gyms[gymID].BattleCooldownUntil = now.Add(5 * time.Minute)
+	}
+	return oldCopy, battleCooldown
+}
+
+func (gst *GymStateTracker) updateLocked(gymID string, teamID, slotsAvailable int, inBattle bool, now time.Time) *GymState {
 	old := gst.gyms[gymID]
 	var oldCopy *GymState
 
@@ -72,14 +94,14 @@ func (gst *GymStateTracker) Update(gymID string, teamID, slotsAvailable int, inB
 		old.SlotsAvailable = slotsAvailable
 		old.InBattle = inBattle
 		old.LastOwnerID = newLastOwner
-		old.LastSeen = time.Now()
+		old.LastSeen = now
 	} else {
 		gst.gyms[gymID] = &GymState{
 			TeamID:         teamID,
 			SlotsAvailable: slotsAvailable,
 			InBattle:       inBattle,
 			LastOwnerID:    newLastOwner,
-			LastSeen:       time.Now(),
+			LastSeen:       now,
 		}
 	}
 	return oldCopy

--- a/processor/internal/tracker/gymstate_test.go
+++ b/processor/internal/tracker/gymstate_test.go
@@ -1,7 +1,10 @@
 package tracker
 
 import (
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 )
 
 // TestGymStateLastOwnerEvolution mirrors PoracleJS app.js behaviour for the
@@ -86,5 +89,77 @@ func TestGymStateLastOwnerFirstSightUncontested(t *testing.T) {
 	cur = gst.gyms["gym2"]
 	if cur.LastOwnerID != 1 {
 		t.Errorf("Uncontested → Mystic cache lastOwnerID=%d, want 1", cur.LastOwnerID)
+	}
+}
+
+func TestGymStateBattleCooldown(t *testing.T) {
+	gst := NewGymStateTracker("")
+	now := time.Unix(1_700_000_000, 0)
+
+	old, cooldown := gst.UpdateWithBattleCooldown("gym1", 2, 3, true, now)
+	if old != nil {
+		t.Errorf("first battle update should have no old state, got %+v", old)
+	}
+	if cooldown {
+		t.Error("first battle update should be outside cooldown")
+	}
+
+	old, cooldown = gst.UpdateWithBattleCooldown("gym1", 2, 3, false, now.Add(time.Second))
+	if old == nil {
+		t.Fatal("second update should have old state")
+	}
+	if !cooldown {
+		t.Error("cooldown should persist after first battle update")
+	}
+
+	_, cooldown = gst.UpdateWithBattleCooldown("gym1", 2, 3, true, now.Add(2*time.Second))
+	if !cooldown {
+		t.Error("repeated battle update should be inside cooldown")
+	}
+
+	_, cooldown = gst.UpdateWithBattleCooldown("gym2", 2, 3, false, now.Add(3*time.Second))
+	if cooldown {
+		t.Error("different gym should not share cooldown")
+	}
+
+	_, cooldown = gst.UpdateWithBattleCooldown("gym1", 2, 3, false, now.Add(6*time.Minute))
+	if cooldown {
+		t.Error("cooldown should expire")
+	}
+}
+
+func TestGymStateBattleCooldownConcurrentColdGym(t *testing.T) {
+	gst := NewGymStateTracker("")
+	now := time.Unix(1_700_000_000, 0)
+
+	const workers = 64
+	var wg sync.WaitGroup
+	var first int64
+	var suppressedWithOldState int64
+	start := make(chan struct{})
+
+	wg.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func() {
+			defer wg.Done()
+			<-start
+			old, cooldown := gst.UpdateWithBattleCooldown("gym-concurrent", 2, 3, true, now)
+			if !cooldown {
+				atomic.AddInt64(&first, 1)
+			}
+			if cooldown && old != nil {
+				atomic.AddInt64(&suppressedWithOldState, 1)
+			}
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+
+	if first != 1 {
+		t.Errorf("Expected exactly one first battle update, got %d", first)
+	}
+	if suppressedWithOldState != workers-1 {
+		t.Errorf("Expected %d suppressed updates with old state, got %d", workers-1, suppressedWithOldState)
 	}
 }


### PR DESCRIPTION
## Summary
- preserve the first gym under-attack alert while suppressing repeated same-state battle webhooks
- move battle cooldown state into the gym-state transition so old state and cooldown are decided under one lock
- align battle-change matching with PoracleJS behavior and cover cold-gym concurrency with targeted tests

## Root Cause
NG started and checked the gym battle cooldown outside the gym-state transition. Under concurrency, duplicate first in-battle webhooks for a cold gym could observe inconsistent cooldown and old-state ordering, allowing duplicate battle alerts.

## Validation
- go test ./internal/tracker ./internal/matching
- go test ./cmd/processor -run '^$'
- go test -race ./internal/tracker
- git diff --check