### PR TITLE
track: rarity:N (no range) means exactly N — parity with size

### DIFF
--- a/processor/internal/bot/commands/track.go
+++ b/processor/internal/bot/commands/track.go
@@ -420,8 +420,13 @@ func (c *TrackCommand) parseFilters(ctx *bot.CommandContext, parsed *bot.ParsedA
 	// Rarity
 	if r, ok := parsed.Ranges["rarity"]; ok {
 		f.rarity = r.Min
+		// Set maxRarity to Min if no Max is provided — mirrors the
+		// PoracleJS `?? ?? ?? 6` chain so `rarity:rare` means
+		// exactly Rare rather than "Rare or above".
 		if r.HasMax {
 			f.maxRarity = r.Max
+		} else {
+			f.maxRarity = r.Min
 		}
 	}
 	if v, ok := parsed.Singles["maxrarity"]; ok {

--- a/processor/internal/bot/commands/track_test.go
+++ b/processor/internal/bot/commands/track_test.go
@@ -390,3 +390,63 @@ func TestTrack_WarningNoLocation(t *testing.T) {
 	require.NotEmpty(t, replies)
 	assert.Contains(t, replies[0].Text, "location")
 }
+
+// --- Size and rarity bounds ---
+//
+// PoracleJS treats `size:N` and `rarity:N` (no range, no maxsize/maxrarity)
+// as an exact match — the chain in src/lib/poracleMessage/commands/track.js
+// is `max ?? maxsize ?? min ?? 5` and the symmetric one for rarity.
+// Match that here so a single-value filter doesn't silently include
+// everything above it.
+
+func TestTrack_SizeMinOnly_BoundsToMin(t *testing.T) {
+	ctx := trackCtx(t)
+	replies := runTrack(t, ctx, "25 size3")
+
+	require.NotEmpty(t, replies)
+	assert.Equal(t, "✅", replies[0].React, "reply: %s", replies[0].Text)
+
+	rows, _ := ctx.Tracking.Monsters.SelectByIDProfile("user1", 1)
+	require.Len(t, rows, 1)
+	assert.Equal(t, 3, rows[0].Size, "min size should be 3 (M)")
+	assert.Equal(t, 3, rows[0].MaxSize, "max size should also be 3 (M) — exact match, not size>=3")
+}
+
+func TestTrack_SizeRange_PreservesMax(t *testing.T) {
+	ctx := trackCtx(t)
+	replies := runTrack(t, ctx, "25 size1-3")
+
+	require.NotEmpty(t, replies)
+	assert.Equal(t, "✅", replies[0].React, "reply: %s", replies[0].Text)
+
+	rows, _ := ctx.Tracking.Monsters.SelectByIDProfile("user1", 1)
+	require.Len(t, rows, 1)
+	assert.Equal(t, 1, rows[0].Size)
+	assert.Equal(t, 3, rows[0].MaxSize, "explicit range max must be preserved")
+}
+
+func TestTrack_RarityMinOnly_BoundsToMin(t *testing.T) {
+	ctx := trackCtx(t)
+	replies := runTrack(t, ctx, "25 rarity3")
+
+	require.NotEmpty(t, replies)
+	assert.Equal(t, "✅", replies[0].React, "reply: %s", replies[0].Text)
+
+	rows, _ := ctx.Tracking.Monsters.SelectByIDProfile("user1", 1)
+	require.Len(t, rows, 1)
+	assert.Equal(t, 3, rows[0].Rarity, "min rarity should be 3")
+	assert.Equal(t, 3, rows[0].MaxRarity, "max rarity should also be 3 — exact match, not rarity>=3")
+}
+
+func TestTrack_RarityRange_PreservesMax(t *testing.T) {
+	ctx := trackCtx(t)
+	replies := runTrack(t, ctx, "25 rarity1-3")
+
+	require.NotEmpty(t, replies)
+	assert.Equal(t, "✅", replies[0].React, "reply: %s", replies[0].Text)
+
+	rows, _ := ctx.Tracking.Monsters.SelectByIDProfile("user1", 1)
+	require.Len(t, rows, 1)
+	assert.Equal(t, 1, rows[0].Rarity)
+	assert.Equal(t, 3, rows[0].MaxRarity, "explicit range max must be preserved")
+}


### PR DESCRIPTION
Mirrors merged PR #115 for the rarity filter. PoracleJS's \`track.js\` uses the same \`max ?? maxrarity ?? min ?? 6\` chain for rarity as it does for size, so a bare \`rarity:3\` was supposed to mean \"exactly that rarity tier\" — not \"tier 3 or above\". The Go path left \`f.maxRarity\` at default 6 when only Min was given, over-broadening the alert.

One-line fix in \`parseFilters\`: when the Range has no Max, set maxRarity to Min.

## Tests

- \`TestTrack_RarityMinOnly_BoundsToMin\` pins the new behaviour.
- \`TestTrack_RarityRange_PreservesMax\` guards against accidentally clobbering an explicit range.
- Parallel size tests added at the same time so merged PR #115 has a regression guard.
- Verified the rarity test fails without the fix (errors out at \`max rarity should also be 3 — got 6\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)