### PR TITLE
matching/gym: drop unused GymData.OldInBattle field

### DIFF
--- a/processor/cmd/processor/gym.go
+++ b/processor/cmd/processor/gym.go
@@ -67,11 +67,9 @@ func (ps *ProcessorService) ProcessGym(raw json.RawMessage) error {
 		oldTeamID := -1
 		oldSlotsAvailable := -1
 		oldLastOwnerID := -1
-		var oldInBattle bool
 		if oldState != nil {
 			oldTeamID = oldState.TeamID
 			oldSlotsAvailable = oldState.SlotsAvailable
-			oldInBattle = oldState.InBattle
 			oldLastOwnerID = oldState.LastOwnerID
 		}
 
@@ -87,7 +85,6 @@ func (ps *ProcessorService) ProcessGym(raw json.RawMessage) error {
 			SlotsAvailable:    gym.SlotsAvailable,
 			OldSlotsAvailable: oldSlotsAvailable,
 			InBattle:          inBattle,
-			OldInBattle:       oldInBattle,
 			Latitude:          gym.Latitude,
 			Longitude:         gym.Longitude,
 		}

--- a/processor/internal/matching/gym.go
+++ b/processor/internal/matching/gym.go
@@ -18,7 +18,6 @@ type GymData struct {
 	SlotsAvailable    int
 	OldSlotsAvailable int
 	InBattle          bool
-	OldInBattle       bool
 	Latitude          float64
 	Longitude         float64
 }

--- a/processor/internal/matching/gym_test.go
+++ b/processor/internal/matching/gym_test.go
@@ -118,7 +118,6 @@ func TestGymNoTeamChangeWithoutSlotOrBattle(t *testing.T) {
 		SlotsAvailable:    3,
 		OldSlotsAvailable: 3,
 		InBattle:          false,
-		OldInBattle:       false,
 		Latitude:          51.0, Longitude: 0.0,
 	}
 
@@ -166,12 +165,11 @@ func TestGymBattleChange(t *testing.T) {
 	matcher := &GymMatcher{}
 
 	data := &GymData{
-		GymID:       "gym1",
-		TeamID:      2,
-		OldTeamID:   2,
-		InBattle:    true,
-		OldInBattle: false, // battle started
-		Latitude:    51.0, Longitude: 0.0,
+		GymID:     "gym1",
+		TeamID:    2,
+		OldTeamID: 2,
+		InBattle:  true,
+		Latitude:  51.0, Longitude: 0.0,
 	}
 
 	matched, _ := matcher.Match(data, st)
@@ -192,12 +190,11 @@ func TestGymBattleActiveMatchesAfterPriorBattleState(t *testing.T) {
 	matcher := &GymMatcher{}
 
 	data := &GymData{
-		GymID:       "gym1",
-		TeamID:      2,
-		OldTeamID:   2,
-		InBattle:    true,
-		OldInBattle: true,
-		Latitude:    51.0, Longitude: 0.0,
+		GymID:     "gym1",
+		TeamID:    2,
+		OldTeamID: 2,
+		InBattle:  true,
+		Latitude:  51.0, Longitude: 0.0,
 	}
 
 	matched, _ := matcher.Match(data, st)


### PR DESCRIPTION
Followup to PR #117. That PR dropped the matcher's \`!data.OldInBattle\` gate for parity with PoracleJS (which only checks \`data.inBattle\`), which left \`GymData.OldInBattle\` as dead state — still set in \`ProcessGym\`, never read anywhere.

Remove the field, the corresponding dispatcher local (\`oldInBattle\`), and the test initialisations that referenced it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)