### PR TITLE
geocoding: per-language reverse geocode results via localized cache keys

### DIFF
--- a/API.md
+++ b/API.md
@@ -1430,7 +1430,7 @@ All invasion grunt types.
 
 ## Geocoding
 
-Reverse geocoding for alert templates is locale-aware. The processor performs a base lookup as a fallback, then performs per-language lookups for the matched users' effective languages and stores those address fields in the per-language DTS layer. Existing DTS fields such as `{{addr}}`, `{{city}}`, `{{streetName}}`, and `{{formattedAddress}}` automatically resolve to the user's localized geocoder result when the provider supports it.
+Reverse geocoding for alert templates is locale-aware. The processor performs a base reverse-geocode lookup that populates the default-locale address fields, then performs per-language lookups for matched user languages that shadow those fields in the per-language DTS layer. Existing DTS fields such as `{{addr}}`, `{{city}}`, `{{streetName}}`, and `{{formattedAddress}}` automatically resolve to the user's localized geocoder result when the provider supports it.
 
 Supported reverse-geocode language parameters:
 

--- a/API.md
+++ b/API.md
@@ -1430,6 +1430,18 @@ All invasion grunt types.
 
 ## Geocoding
 
+Reverse geocoding for alert templates is locale-aware. The processor performs a base lookup as a fallback, then performs per-language lookups for the matched users' effective languages and stores those address fields in the per-language DTS layer. Existing DTS fields such as `{{addr}}`, `{{city}}`, `{{streetName}}`, and `{{formattedAddress}}` automatically resolve to the user's localized geocoder result when the provider supports it.
+
+Supported reverse-geocode language parameters:
+
+| Provider | Parameter |
+|----------|-----------|
+| Nominatim | `accept-language` |
+| Photon | `lang` |
+| Google | `language` |
+
+Reverse geocode cache keys include the language code for localized lookups, so cached German and English address results do not overwrite each other.
+
 ### GET /api/geocode/forward?q={query}
 
 Forward geocode a location name to coordinates.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,7 +186,8 @@ Enrichment is computed in three layers:
 - **Map URLs**: Google Maps, Apple Maps, Waze, RDM, ReactMap, RocketMad
 - **Icons**: Pokemon/raid/gym/weather icon URLs via uicons (with scheduled index refresh)
 - **Static map**: Tileserver tile URL (pregenerate or query params), with scanner DB stop lookups
-- **Geocoding**: Reverse geocode address via nominatim/photon/google with pogreb on-disk + ttlcache in-memory cache. Alert rendering adds per-language reverse geocoding for each matched user language (`accept-language` for Nominatim, `lang` for Photon, `language` for Google), and localized cache keys include the language code so address fields (`addr`, `city`, `streetName`, etc.) resolve in the user's locale when the provider supports it.
+- **Geocoding**: Reverse geocode address via nominatim/photon/google with pogreb on-disk + ttlcache in-memory cache.
+- **Localized addresses**: Per-language enrichment adds reverse geocoding for each matched user language (`accept-language` for Nominatim, `lang` for Photon, `language` for Google). Localized cache keys include the language code so address fields (`addr`, `city`, `streetName`, etc.) resolve in the user's locale when the provider supports it.
 
 **Per-language enrichment** (computed once per distinct language among matched users):
 - Translated pokemon/form/move/type/weather/team/generation names using pogo-translations identifier keys (`poke_1`, `move_14`, `form_46`, etc.)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,7 +186,7 @@ Enrichment is computed in three layers:
 - **Map URLs**: Google Maps, Apple Maps, Waze, RDM, ReactMap, RocketMad
 - **Icons**: Pokemon/raid/gym/weather icon URLs via uicons (with scheduled index refresh)
 - **Static map**: Tileserver tile URL (pregenerate or query params), with scanner DB stop lookups
-- **Geocoding**: Reverse geocode address via nominatim/google with pogreb on-disk + ttlcache in-memory cache
+- **Geocoding**: Reverse geocode address via nominatim/photon/google with pogreb on-disk + ttlcache in-memory cache. Alert rendering adds per-language reverse geocoding for each matched user language (`accept-language` for Nominatim, `lang` for Photon, `language` for Google), and localized cache keys include the language code so address fields (`addr`, `city`, `streetName`, etc.) resolve in the user's locale when the provider supports it.
 
 **Per-language enrichment** (computed once per distinct language among matched users):
 - Translated pokemon/form/move/type/weather/team/generation names using pogo-translations identifier keys (`poke_1`, `move_14`, `form_46`, etc.)

--- a/processor/cmd/processor/enrich.go
+++ b/processor/cmd/processor/enrich.go
@@ -226,7 +226,7 @@ func (ps *ProcessorService) enrichInvasion(raw json.RawMessage, language string)
 
 	var perLang map[string]any
 	if ps.enricher.GameData != nil && ps.enricher.Translations != nil {
-		perLang = ps.enricher.InvasionTranslate(base, gruntTypeID, inv.Lineup, inv.ShowcaseRankings, language)
+		perLang = ps.enricher.InvasionTranslate(base, inv.Latitude, inv.Longitude, gruntTypeID, inv.Lineup, inv.ShowcaseRankings, language)
 	}
 
 	return &enrichResult{
@@ -248,7 +248,7 @@ func (ps *ProcessorService) enrichLure(raw json.RawMessage, language string) (*e
 
 	var perLang map[string]any
 	if ps.enricher.GameData != nil && ps.enricher.Translations != nil {
-		perLang = ps.enricher.LureTranslate(base, lure.LureID, language)
+		perLang = ps.enricher.LureTranslate(base, &lure, language)
 	}
 
 	return &enrichResult{
@@ -270,7 +270,7 @@ func (ps *ProcessorService) enrichNest(raw json.RawMessage, language string) (*e
 
 	var perLang map[string]any
 	if ps.enricher.GameData != nil && ps.enricher.Translations != nil {
-		perLang = ps.enricher.NestTranslate(base, nest.PokemonID, nest.Form, language)
+		perLang = ps.enricher.NestTranslate(base, &nest, language)
 	}
 
 	return &enrichResult{
@@ -303,7 +303,7 @@ func (ps *ProcessorService) enrichGym(raw json.RawMessage, language string) (*en
 	var perLang map[string]any
 	if ps.enricher.GameData != nil && ps.enricher.Translations != nil {
 		// Editor preview has no team-change context, so suppress previousControl* fields.
-		perLang = ps.enricher.GymTranslate(base, teamID, -1, -1, language)
+		perLang = ps.enricher.GymTranslate(base, gym.Latitude, gym.Longitude, teamID, -1, -1, language)
 	}
 
 	return &enrichResult{
@@ -322,10 +322,12 @@ func (ps *ProcessorService) enrichFort(raw json.RawMessage, language string) (*e
 	}
 
 	base, tilePending := ps.enricher.FortUpdate(fort.Latitude(), fort.Longitude(), fort.FortID(), &fort, enrichment.TileModeURL)
+	perLang := ps.enricher.FortUpdateTranslate(fort.Latitude(), fort.Longitude(), language)
 
 	return &enrichResult{
 		templateType:  "fort-update",
 		base:          base,
+		perLang:       perLang,
 		webhookFields: parseWebhookFields(raw),
 		tilePending:   tilePending,
 	}, nil

--- a/processor/cmd/processor/fort.go
+++ b/processor/cmd/processor/fort.go
@@ -79,20 +79,29 @@ func (ps *ProcessorService) ProcessFortUpdate(raw json.RawMessage) error {
 			mode := ps.tileMode("fort-update", matched)
 			enrichmentData, tilePending := ps.enricher.FortUpdate(lat, lon, fortID, &fort, mode)
 
+			var perLang map[string]map[string]any
+			if ps.enricher.Geocoder != nil {
+				perLang = make(map[string]map[string]any)
+				for _, lang := range distinctLanguages(matched, ps.cfg.General.Locale) {
+					perLang[lang] = ps.enricher.FortUpdateTranslate(lat, lon, lang)
+				}
+			}
+
 			if ps.renderCh == nil {
 				return
 			}
 			webhookFields := parseWebhookFields(raw)
 
 			ps.renderCh <- RenderJob{
-				AlertType:     "fort-update",
-				TemplateType:  "fort-update",
-				Enrichment:    enrichmentData,
-				WebhookFields: webhookFields,
-				MatchedUsers:  matched,
-				MatchedAreas:  matchedAreas,
-				TileGate:      ps.newTileGate(tilePending),
-				LogReference:  fortID,
+				AlertType:         "fort-update",
+				TemplateType:      "fort-update",
+				Enrichment:        enrichmentData,
+				PerLangEnrichment: perLang,
+				WebhookFields:     webhookFields,
+				MatchedUsers:      matched,
+				MatchedAreas:      matchedAreas,
+				TileGate:          ps.newTileGate(tilePending),
+				LogReference:      fortID,
 			}
 		} else {
 			l.Debugf("Fort update %s (%s, %s) and 0 humans cared",

--- a/processor/cmd/processor/gym.go
+++ b/processor/cmd/processor/gym.go
@@ -112,7 +112,7 @@ func (ps *ProcessorService) ProcessGym(raw json.RawMessage) error {
 			if ps.enricher.GameData != nil && ps.enricher.Translations != nil {
 				perLang = make(map[string]map[string]any)
 				for _, lang := range distinctLanguages(matched, ps.cfg.General.Locale) {
-					perLang[lang] = ps.enricher.GymTranslate(enrichmentData, teamID, oldTeamID, oldLastOwnerID, lang)
+					perLang[lang] = ps.enricher.GymTranslate(enrichmentData, gym.Latitude, gym.Longitude, teamID, oldTeamID, oldLastOwnerID, lang)
 				}
 			}
 

--- a/processor/cmd/processor/invasion.go
+++ b/processor/cmd/processor/invasion.go
@@ -120,7 +120,7 @@ func (ps *ProcessorService) ProcessInvasion(raw json.RawMessage) error {
 			if ps.enricher.GameData != nil && ps.enricher.Translations != nil {
 				perLang = make(map[string]map[string]any)
 				for _, lang := range distinctLanguages(matched, ps.cfg.General.Locale) {
-					perLang[lang] = ps.enricher.InvasionTranslate(baseEnrichment, gruntTypeID, inv.Lineup, inv.ShowcaseRankings, lang)
+					perLang[lang] = ps.enricher.InvasionTranslate(baseEnrichment, inv.Latitude, inv.Longitude, gruntTypeID, inv.Lineup, inv.ShowcaseRankings, lang)
 				}
 			}
 

--- a/processor/cmd/processor/lure.go
+++ b/processor/cmd/processor/lure.go
@@ -78,7 +78,7 @@ func (ps *ProcessorService) ProcessLure(raw json.RawMessage) error {
 			if ps.enricher.GameData != nil && ps.enricher.Translations != nil {
 				perLang = make(map[string]map[string]any)
 				for _, lang := range distinctLanguages(matched, ps.cfg.General.Locale) {
-					perLang[lang] = ps.enricher.LureTranslate(enrichmentData, lure.LureID, lang)
+					perLang[lang] = ps.enricher.LureTranslate(enrichmentData, &lure, lang)
 				}
 			}
 

--- a/processor/cmd/processor/nest.go
+++ b/processor/cmd/processor/nest.go
@@ -80,7 +80,7 @@ func (ps *ProcessorService) ProcessNest(raw json.RawMessage) error {
 			if ps.enricher.GameData != nil && ps.enricher.Translations != nil {
 				perLang = make(map[string]map[string]any)
 				for _, lang := range distinctLanguages(matched, ps.cfg.General.Locale) {
-					perLang[lang] = ps.enricher.NestTranslate(enrichmentData, nest.PokemonID, nest.Form, lang)
+					perLang[lang] = ps.enricher.NestTranslate(enrichmentData, &nest, lang)
 				}
 			}
 

--- a/processor/cmd/processor/render.go
+++ b/processor/cmd/processor/render.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"maps"
 	"strconv"
 	"time"
 
@@ -135,7 +134,6 @@ func (ps *ProcessorService) processRenderJob(job RenderJob) {
 		metrics.RenderTotal.WithLabelValues("error").Inc()
 		return
 	}
-	ps.addLocalizedGeocoding(&job)
 
 	if job.IsPokemon {
 		if job.IsChange {
@@ -211,42 +209,6 @@ func (ps *ProcessorService) processRenderJob(job RenderJob) {
 	}
 
 	metrics.RenderTotal.WithLabelValues("ok").Inc()
-}
-
-func (ps *ProcessorService) addLocalizedGeocoding(job *RenderJob) {
-	if ps.enricher == nil || ps.enricher.Geocoder == nil || len(job.MatchedUsers) == 0 {
-		return
-	}
-	defaultLocale := ""
-	if ps.cfg != nil {
-		defaultLocale = ps.cfg.General.Locale
-	}
-	if job.PerLangEnrichment != nil {
-		cloned := make(map[string]map[string]any, len(job.PerLangEnrichment))
-		for lang, fields := range job.PerLangEnrichment {
-			if fields == nil {
-				continue
-			}
-			clonedFields := make(map[string]any, len(fields))
-			maps.Copy(clonedFields, fields)
-			cloned[lang] = clonedFields
-		}
-		job.PerLangEnrichment = cloned
-	}
-	for _, lang := range distinctLanguages(job.MatchedUsers, defaultLocale) {
-		fields := ps.enricher.LocalizedGeoFields(job.Enrichment, lang)
-		if len(fields) == 0 {
-			continue
-		}
-		if job.PerLangEnrichment == nil {
-			job.PerLangEnrichment = make(map[string]map[string]any)
-		}
-		if job.PerLangEnrichment[lang] == nil {
-			job.PerLangEnrichment[lang] = fields
-			continue
-		}
-		maps.Copy(job.PerLangEnrichment[lang], fields)
-	}
 }
 
 // resolveTilePending performs the synchronous tile wait that processRenderJob

--- a/processor/cmd/processor/render.go
+++ b/processor/cmd/processor/render.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"maps"
 	"strconv"
 	"time"
 
@@ -77,10 +78,10 @@ type RenderJob struct {
 	MatchedUsers      []webhook.MatchedUser
 	MatchedAreas      []webhook.MatchedArea
 	TileGate          *tileGate
-	IsEncountered    bool // pokemon only
-	IsPokemon        bool // true = RenderPokemon, false = RenderAlert
-	LogReference     string
-	EditKey          string
+	IsEncountered     bool // pokemon only
+	IsPokemon         bool // true = RenderPokemon, false = RenderAlert
+	LogReference      string
+	EditKey           string
 	// ReplyKey indexes the sent message for reply chaining. Copied verbatim
 	// onto every constructed delivery.Job. For pokemon, this is the encounter
 	// ID so subsequent change events can find prior messages via the
@@ -134,6 +135,7 @@ func (ps *ProcessorService) processRenderJob(job RenderJob) {
 		metrics.RenderTotal.WithLabelValues("error").Inc()
 		return
 	}
+	ps.addLocalizedGeocoding(&job)
 
 	if job.IsPokemon {
 		if job.IsChange {
@@ -209,6 +211,42 @@ func (ps *ProcessorService) processRenderJob(job RenderJob) {
 	}
 
 	metrics.RenderTotal.WithLabelValues("ok").Inc()
+}
+
+func (ps *ProcessorService) addLocalizedGeocoding(job *RenderJob) {
+	if ps.enricher == nil || ps.enricher.Geocoder == nil || len(job.MatchedUsers) == 0 {
+		return
+	}
+	defaultLocale := ""
+	if ps.cfg != nil {
+		defaultLocale = ps.cfg.General.Locale
+	}
+	if job.PerLangEnrichment != nil {
+		cloned := make(map[string]map[string]any, len(job.PerLangEnrichment))
+		for lang, fields := range job.PerLangEnrichment {
+			if fields == nil {
+				continue
+			}
+			clonedFields := make(map[string]any, len(fields))
+			maps.Copy(clonedFields, fields)
+			cloned[lang] = clonedFields
+		}
+		job.PerLangEnrichment = cloned
+	}
+	for _, lang := range distinctLanguages(job.MatchedUsers, defaultLocale) {
+		fields := ps.enricher.LocalizedGeoFields(job.Enrichment, lang)
+		if len(fields) == 0 {
+			continue
+		}
+		if job.PerLangEnrichment == nil {
+			job.PerLangEnrichment = make(map[string]map[string]any)
+		}
+		if job.PerLangEnrichment[lang] == nil {
+			job.PerLangEnrichment[lang] = fields
+			continue
+		}
+		maps.Copy(job.PerLangEnrichment[lang], fields)
+	}
 }
 
 // resolveTilePending performs the synchronous tile wait that processRenderJob

--- a/processor/cmd/processor/test.go
+++ b/processor/cmd/processor/test.go
@@ -185,7 +185,7 @@ func (ps *ProcessorService) processTestInvasion(raw json.RawMessage, target webh
 	var perLang map[string]map[string]any
 	if ps.enricher.GameData != nil && ps.enricher.Translations != nil {
 		perLang = map[string]map[string]any{
-			target.Language: ps.enricher.InvasionTranslate(enrichmentData, gruntTypeID, inv.Lineup, inv.ShowcaseRankings, target.Language),
+			target.Language: ps.enricher.InvasionTranslate(enrichmentData, inv.Latitude, inv.Longitude, gruntTypeID, inv.Lineup, inv.ShowcaseRankings, target.Language),
 		}
 	}
 
@@ -267,7 +267,7 @@ func (ps *ProcessorService) processTestGym(raw json.RawMessage, target webhook.M
 	if ps.enricher.GameData != nil && ps.enricher.Translations != nil {
 		perLang = map[string]map[string]any{
 			// Test path has no team-change context, so suppress previousControl* fields.
-			target.Language: ps.enricher.GymTranslate(enrichmentData, teamID, -1, -1, target.Language),
+			target.Language: ps.enricher.GymTranslate(enrichmentData, gym.Latitude, gym.Longitude, teamID, -1, -1, target.Language),
 		}
 	}
 
@@ -301,7 +301,7 @@ func (ps *ProcessorService) processTestNest(raw json.RawMessage, target webhook.
 	var perLang map[string]map[string]any
 	if ps.enricher.GameData != nil && ps.enricher.Translations != nil {
 		perLang = map[string]map[string]any{
-			target.Language: ps.enricher.NestTranslate(enrichmentData, nest.PokemonID, nest.Form, target.Language),
+			target.Language: ps.enricher.NestTranslate(enrichmentData, &nest, target.Language),
 		}
 	}
 
@@ -330,20 +330,24 @@ func (ps *ProcessorService) processTestFort(raw json.RawMessage, target webhook.
 	}
 
 	enrichmentData, tilePending := ps.enricher.FortUpdate(fort.Latitude(), fort.Longitude(), fort.FortID(), &fort, enrichment.TileModeURL)
+	perLang := map[string]map[string]any{
+		target.Language: ps.enricher.FortUpdateTranslate(fort.Latitude(), fort.Longitude(), target.Language),
+	}
 
 	if ps.renderCh == nil {
 		return fmt.Errorf("render queue not available")
 	}
 	webhookFields := parseWebhookFields(raw)
 	ps.renderCh <- RenderJob{
-		AlertType:     "fort-update",
-		TemplateType:  "fort-update",
-		Enrichment:    enrichmentData,
-		WebhookFields: webhookFields,
-		MatchedUsers:  []webhook.MatchedUser{target},
-		MatchedAreas:  []webhook.MatchedArea{},
-		TileGate:      ps.newTileGate(tilePending),
-		LogReference:  "test",
+		AlertType:         "fort-update",
+		TemplateType:      "fort-update",
+		Enrichment:        enrichmentData,
+		PerLangEnrichment: perLang,
+		WebhookFields:     webhookFields,
+		MatchedUsers:      []webhook.MatchedUser{target},
+		MatchedAreas:      []webhook.MatchedArea{},
+		TileGate:          ps.newTileGate(tilePending),
+		LogReference:      "test",
 	}
 	return nil
 }
@@ -402,7 +406,7 @@ func (ps *ProcessorService) processTestPokestop(raw json.RawMessage, target webh
 		var perLang map[string]map[string]any
 		if ps.enricher.GameData != nil && ps.enricher.Translations != nil {
 			perLang = map[string]map[string]any{
-				target.Language: ps.enricher.LureTranslate(enrichmentData, lure.LureID, target.Language),
+				target.Language: ps.enricher.LureTranslate(enrichmentData, &lure, target.Language),
 			}
 		}
 		if ps.renderCh == nil {

--- a/processor/internal/enrichment/enrichment.go
+++ b/processor/internal/enrichment/enrichment.go
@@ -2,6 +2,7 @@ package enrichment
 
 import (
 	"maps"
+	"strings"
 	"time"
 
 	"github.com/pokemon/poracleng/processor/internal/gamedata"
@@ -160,8 +161,6 @@ func normalizeTrailingSlash(url string) string {
 // enrichment map. This should be called BEFORE addStaticMap so that static map
 // templates can reference address fields.
 func (e *Enricher) addGeoResult(m map[string]any, lat, lon float64) {
-	m["geocodeLatitude"] = lat
-	m["geocodeLongitude"] = lon
 	if e.Geocoder == nil {
 		return
 	}
@@ -169,23 +168,17 @@ func (e *Enricher) addGeoResult(m map[string]any, lat, lon float64) {
 	e.addAddressFields(m, addr)
 }
 
-// LocalizedGeoFields returns address fields localized for lang using the
-// geocode coordinates captured during base enrichment. These fields live in
-// per-language enrichment so they override the base address for each user
-// without changing DTS template field names.
-func (e *Enricher) LocalizedGeoFields(base map[string]any, lang string) map[string]any {
-	if e.Geocoder == nil || base == nil || lang == "" {
-		return nil
+// addLocalizedGeoResult writes per-language address fields into m using the
+// localized reverse-geocode result. The base enrichment already fetched the
+// default-locale address, so blank/default language is a no-op.
+func (e *Enricher) addLocalizedGeoResult(m map[string]any, lat, lon float64, lang string) {
+	lang = strings.ToLower(strings.TrimSpace(lang))
+	defaultLocale := strings.ToLower(strings.TrimSpace(e.DefaultLocale))
+	if e.Geocoder == nil || lang == "" || lang == defaultLocale {
+		return
 	}
-	lat, okLat := floatFromAny(base["geocodeLatitude"])
-	lon, okLon := floatFromAny(base["geocodeLongitude"])
-	if !okLat || !okLon {
-		return nil
-	}
-	m := make(map[string]any, 16)
 	addr := e.Geocoder.GetAddressForLanguage(lat, lon, lang)
 	e.addAddressFields(m, addr)
-	return m
 }
 
 func (e *Enricher) addAddressFields(m map[string]any, addr *geocoding.Address) {
@@ -205,23 +198,6 @@ func (e *Enricher) addAddressFields(m map[string]any, addr *geocoding.Address) {
 	m["neighbourhood"] = addr.Neighbourhood
 	m["suburb"] = addr.Suburb
 	m["formattedAddress"] = addr.FormattedAddress
-}
-
-func floatFromAny(v any) (float64, bool) {
-	switch n := v.(type) {
-	case float64:
-		return n, true
-	case float32:
-		return float64(n), true
-	case int:
-		return float64(n), true
-	case int64:
-		return float64(n), true
-	case int32:
-		return float64(n), true
-	default:
-		return 0, false
-	}
 }
 
 // Tile mode constants. Defined here to avoid import cycles with cmd/processor.

--- a/processor/internal/enrichment/enrichment.go
+++ b/processor/internal/enrichment/enrichment.go
@@ -160,10 +160,35 @@ func normalizeTrailingSlash(url string) string {
 // enrichment map. This should be called BEFORE addStaticMap so that static map
 // templates can reference address fields.
 func (e *Enricher) addGeoResult(m map[string]any, lat, lon float64) {
+	m["geocodeLatitude"] = lat
+	m["geocodeLongitude"] = lon
 	if e.Geocoder == nil {
 		return
 	}
 	addr := e.Geocoder.GetAddress(lat, lon)
+	e.addAddressFields(m, addr)
+}
+
+// LocalizedGeoFields returns address fields localized for lang using the
+// geocode coordinates captured during base enrichment. These fields live in
+// per-language enrichment so they override the base address for each user
+// without changing DTS template field names.
+func (e *Enricher) LocalizedGeoFields(base map[string]any, lang string) map[string]any {
+	if e.Geocoder == nil || base == nil || lang == "" {
+		return nil
+	}
+	lat, okLat := floatFromAny(base["geocodeLatitude"])
+	lon, okLon := floatFromAny(base["geocodeLongitude"])
+	if !okLat || !okLon {
+		return nil
+	}
+	m := make(map[string]any, 16)
+	addr := e.Geocoder.GetAddressForLanguage(lat, lon, lang)
+	e.addAddressFields(m, addr)
+	return m
+}
+
+func (e *Enricher) addAddressFields(m map[string]any, addr *geocoding.Address) {
 	if addr == nil {
 		return
 	}
@@ -180,6 +205,23 @@ func (e *Enricher) addGeoResult(m map[string]any, lat, lon float64) {
 	m["neighbourhood"] = addr.Neighbourhood
 	m["suburb"] = addr.Suburb
 	m["formattedAddress"] = addr.FormattedAddress
+}
+
+func floatFromAny(v any) (float64, bool) {
+	switch n := v.(type) {
+	case float64:
+		return n, true
+	case float32:
+		return float64(n), true
+	case int:
+		return float64(n), true
+	case int64:
+		return float64(n), true
+	case int32:
+		return float64(n), true
+	default:
+		return 0, false
+	}
 }
 
 // Tile mode constants. Defined here to avoid import cycles with cmd/processor.

--- a/processor/internal/enrichment/fort.go
+++ b/processor/internal/enrichment/fort.go
@@ -203,3 +203,13 @@ func (e *Enricher) FortUpdate(lat, lon float64, fortID string, fort *webhook.For
 
 	return m, pending
 }
+
+// FortUpdateTranslate adds per-language enrichment for fort update alerts.
+func (e *Enricher) FortUpdateTranslate(lat, lon float64, lang string) map[string]any {
+	m := make(map[string]any, 10)
+	e.addLocalizedGeoResult(m, lat, lon, lang)
+	if len(m) == 0 {
+		return nil
+	}
+	return m
+}

--- a/processor/internal/enrichment/gym.go
+++ b/processor/internal/enrichment/gym.go
@@ -73,12 +73,13 @@ func (e *Enricher) Gym(lat, lon float64, teamID, oldTeamID, slotsAvailable, oldS
 // (preserved across Uncontested gaps). Use -1 when no prior value is known
 // (first sighting). Matches PoracleJS app.js semantics: previousControl* is
 // derived from the cache, never from the webhook (Golbat doesn't send it).
-func (e *Enricher) GymTranslate(base map[string]any, teamID, oldTeamID, lastOwnerID int, lang string) map[string]any {
+func (e *Enricher) GymTranslate(base map[string]any, lat, lon float64, teamID, oldTeamID, lastOwnerID int, lang string) map[string]any {
 	if e.GameData == nil || e.Translations == nil {
 		return nil
 	}
 
-	m := make(map[string]any, 8) // only translated fields; caller merges base + perLang
+	m := make(map[string]any, 18) // only translated fields; caller merges base + perLang
+	defer e.addLocalizedGeoResult(m, lat, lon, lang)
 
 	tr := e.Translations.For(lang)
 	enTr := e.Translations.For("en")

--- a/processor/internal/enrichment/invasion.go
+++ b/processor/internal/enrichment/invasion.go
@@ -164,12 +164,13 @@ func (e *Enricher) Invasion(lat, lon float64, expiration int64, pokestopID, poke
 // InvasionTranslate adds per-language translated fields.
 // showcaseRaw is the raw JSON bytes of the showcase_rankings field from the
 // Golbat webhook; pass nil for non-Showcase incidents and regular invasions.
-func (e *Enricher) InvasionTranslate(base map[string]any, gruntTypeID int, lineup []webhook.InvasionLineupEntry, showcaseRaw json.RawMessage, lang string) map[string]any {
+func (e *Enricher) InvasionTranslate(base map[string]any, lat, lon float64, gruntTypeID int, lineup []webhook.InvasionLineupEntry, showcaseRaw json.RawMessage, lang string) map[string]any {
 	if e.GameData == nil || e.Translations == nil {
 		return nil
 	}
 
-	m := make(map[string]any, 15) // only translated fields; caller merges base + perLang
+	m := make(map[string]any, 25) // only translated fields; caller merges base + perLang
+	defer e.addLocalizedGeoResult(m, lat, lon, lang)
 
 	gd := e.GameData
 	tr := e.Translations.For(lang)

--- a/processor/internal/enrichment/invasion_test.go
+++ b/processor/internal/enrichment/invasion_test.go
@@ -189,7 +189,7 @@ func TestInvasionTranslateGruntName(t *testing.T) {
 
 	e := newInvasionEnricher(t, gd, bundle)
 	base := map[string]any{"gameWeatherId": 0, "gruntGender": 0}
-	m := e.InvasionTranslate(base, 44, nil, nil, "en")
+	m := e.InvasionTranslate(base, 0, 0, 44, nil, nil, "en")
 
 	if m["gruntName"] != "Grunt" {
 		t.Errorf("gruntName = %q, want %q", m["gruntName"], "Grunt")
@@ -228,7 +228,7 @@ func TestInvasionTranslateGruntNameGerman(t *testing.T) {
 
 	e := newInvasionEnricher(t, gd, bundle)
 	base := map[string]any{"gameWeatherId": 0, "gruntGender": 0}
-	m := e.InvasionTranslate(base, 44, nil, nil, "de")
+	m := e.InvasionTranslate(base, 0, 0, 44, nil, nil, "de")
 
 	if m["gruntName"] != "Ruepel" {
 		t.Errorf("gruntName = %q, want %q", m["gruntName"], "Ruepel")
@@ -269,7 +269,7 @@ func TestInvasionTranslateGender(t *testing.T) {
 
 	e := newInvasionEnricher(t, gd, bundle)
 	base := map[string]any{"gameWeatherId": 0, "gruntGender": 1}
-	m := e.InvasionTranslate(base, 44, nil, nil, "en")
+	m := e.InvasionTranslate(base, 0, 0, 44, nil, nil, "en")
 
 	if m["genderName"] != "Male" {
 		t.Errorf("genderName = %q, want %q", m["genderName"], "Male")
@@ -323,7 +323,7 @@ func TestInvasionTranslateRewardsTwoSlots(t *testing.T) {
 
 	e := newInvasionEnricher(t, gd, bundle)
 	base := map[string]any{"gameWeatherId": 0, "gruntGender": 1}
-	m := e.InvasionTranslate(base, 44, nil, nil, "en")
+	m := e.InvasionTranslate(base, 0, 0, 44, nil, nil, "en")
 
 	rewardsList, ok := m["gruntRewardsList"].(map[string]any)
 	if !ok {
@@ -414,7 +414,7 @@ func TestInvasionTranslateRewardsSingleSlot(t *testing.T) {
 
 	e := newInvasionEnricher(t, gd, bundle)
 	base := map[string]any{"gameWeatherId": 0, "gruntGender": 0}
-	m := e.InvasionTranslate(base, 44, nil, nil, "en")
+	m := e.InvasionTranslate(base, 0, 0, 44, nil, nil, "en")
 
 	rewardsList, ok := m["gruntRewardsList"].(map[string]any)
 	if !ok {
@@ -479,7 +479,7 @@ func TestInvasionTranslateRewardsThirdSlotFallback(t *testing.T) {
 
 	e := newInvasionEnricher(t, gd, bundle)
 	base := map[string]any{"gameWeatherId": 0, "gruntGender": 0}
-	m := e.InvasionTranslate(base, 44, nil, nil, "en")
+	m := e.InvasionTranslate(base, 0, 0, 44, nil, nil, "en")
 
 	rewardsList, ok := m["gruntRewardsList"].(map[string]any)
 	if !ok {
@@ -525,7 +525,7 @@ func TestInvasionTranslateNoGrunt(t *testing.T) {
 
 	e := newInvasionEnricher(t, gd, bundle)
 	base := map[string]any{"gameWeatherId": 0, "gruntGender": 0}
-	m := e.InvasionTranslate(base, 0, nil, nil, "en")
+	m := e.InvasionTranslate(base, 0, 0, 0, nil, nil, "en")
 
 	if _, ok := m["gruntRewardsList"]; ok {
 		t.Error("gruntRewardsList should not be set when no grunt found")
@@ -567,15 +567,15 @@ func newShowcaseBundle(t *testing.T) *i18n.Bundle {
 	t.Helper()
 	return newInvasionBundle(t, map[string]map[string]string{
 		"en": {
-			"poke_25":       "Pikachu",
-			"poke_6":        "Charizard",
-			"form_0":        "Normal",
-			"form_65":       "Alolan",
-			"gender_1":      "Male",
-			"gender_2":      "Female",
-			"alignment_1":   "Shadow",
-			"alignment_2":   "Purified",
-			"costume_3":     "Ash",
+			"poke_25":        "Pikachu",
+			"poke_6":         "Charizard",
+			"form_0":         "Normal",
+			"form_65":        "Alolan",
+			"gender_1":       "Male",
+			"gender_2":       "Female",
+			"alignment_1":    "Shadow",
+			"alignment_2":    "Purified",
+			"costume_3":      "Ash",
 			"display_type_9": "Showcase",
 		},
 	})
@@ -589,7 +589,7 @@ func TestShowcaseRankingsMissing(t *testing.T) {
 	e := newInvasionEnricher(t, gd, bundle)
 	base := map[string]any{"gameWeatherId": 0, "gruntGender": 0, "displayTypeId": 9}
 
-	m := e.InvasionTranslate(base, 0, nil, nil, "en")
+	m := e.InvasionTranslate(base, 0, 0, 0, nil, nil, "en")
 
 	if m["showcasePresent"] != false {
 		t.Errorf("showcasePresent = %v, want false", m["showcasePresent"])
@@ -627,7 +627,7 @@ func TestShowcaseRankingsPopulated(t *testing.T) {
 		]
 	}`)
 
-	m := e.InvasionTranslate(base, 0, nil, rawJSON, "en")
+	m := e.InvasionTranslate(base, 0, 0, 0, nil, rawJSON, "en")
 
 	if m["showcasePresent"] != true {
 		t.Errorf("showcasePresent = %v, want true", m["showcasePresent"])
@@ -714,7 +714,7 @@ func TestShowcaseRankingsBadJSON(t *testing.T) {
 	e := newInvasionEnricher(t, gd, bundle)
 	base := map[string]any{"gameWeatherId": 0, "gruntGender": 0, "displayTypeId": 9}
 
-	m := e.InvasionTranslate(base, 0, nil, []byte(`not-valid-json`), "en")
+	m := e.InvasionTranslate(base, 0, 0, 0, nil, []byte(`not-valid-json`), "en")
 
 	if m["showcasePresent"] != false {
 		t.Errorf("showcasePresent = %v, want false on bad JSON", m["showcasePresent"])
@@ -737,7 +737,7 @@ func TestShowcaseAlignmentPrefix(t *testing.T) {
 		]
 	}`)
 
-	m := e.InvasionTranslate(base, 0, nil, rawJSON, "en")
+	m := e.InvasionTranslate(base, 0, 0, 0, nil, rawJSON, "en")
 	showcase := m["showcase"].([]map[string]any)
 	if len(showcase) != 1 {
 		t.Fatalf("expected 1 entry, got %d", len(showcase))
@@ -764,7 +764,7 @@ func TestShowcaseRankingsNotPopulatedForKecleon(t *testing.T) {
 	e := newInvasionEnricher(t, gd, bundle)
 	base := map[string]any{"gameWeatherId": 0, "gruntGender": 0, "displayTypeId": 8} // Kecleon
 
-	m := e.InvasionTranslate(base, 0, nil, nil, "en")
+	m := e.InvasionTranslate(base, 0, 0, 0, nil, nil, "en")
 
 	if m["showcasePresent"] != false {
 		t.Errorf("showcasePresent should be false for Kecleon incident")

--- a/processor/internal/enrichment/localized_geocoding_test.go
+++ b/processor/internal/enrichment/localized_geocoding_test.go
@@ -1,0 +1,104 @@
+package enrichment
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/pokemon/poracleng/processor/internal/gamedata"
+	"github.com/pokemon/poracleng/processor/internal/geocoding"
+	"github.com/pokemon/poracleng/processor/internal/i18n"
+	"github.com/pokemon/poracleng/processor/internal/webhook"
+)
+
+func TestLureTranslateAddsLocalizedGeocoding(t *testing.T) {
+	const body = `{
+		"lat": "52.517037",
+		"lon": "13.388860",
+		"display_name": "Lokalisierte Strasse 1, Berlin DE, Deutschland",
+		"address": {
+			"country": "Deutschland",
+			"country_code": "de",
+			"city": "Berlin DE",
+			"postcode": "10117",
+			"road": "Lokalisierte Strasse",
+			"house_number": "1"
+		}
+	}`
+	var gotLanguage string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotLanguage = r.URL.Query().Get("accept-language")
+		w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	geocoder, err := geocoding.New(geocoding.Config{
+		Provider:       "nominatim",
+		ProviderURL:    srv.URL,
+		Timeout:        int((2 * time.Second) / time.Millisecond),
+		CacheDetail:    3,
+		IncludeCountry: true,
+	})
+	if err != nil {
+		t.Fatalf("geocoding.New: %v", err)
+	}
+
+	bundle := i18n.NewBundle()
+	bundle.AddTranslator(i18n.NewTranslator("de", map[string]string{"lure_501": "Lockmodul"}))
+	bundle.AddTranslator(i18n.NewTranslator("en", map[string]string{"lure_501": "Lure Module"}))
+
+	e := &Enricher{
+		Geocoder:      geocoder,
+		DefaultLocale: "en",
+		Translations:  bundle,
+		GameData: &gamedata.GameData{Util: &gamedata.UtilData{Lures: map[int]gamedata.LureInfo{
+			501: {},
+		}}},
+	}
+	lure := &webhook.LureWebhook{LureID: 501, Latitude: 52.517, Longitude: 13.389}
+
+	got := e.LureTranslate(map[string]any{}, lure, "de")
+	if gotLanguage != "de" {
+		t.Fatalf("accept-language=%q, want de", gotLanguage)
+	}
+	if got["city"] != "Berlin DE" {
+		t.Fatalf("city=%q, want Berlin DE", got["city"])
+	}
+	if got["formattedAddress"] == "" || got["addr"] == "" {
+		t.Fatalf("expected localized address fields, got formatted=%q addr=%q", got["formattedAddress"], got["addr"])
+	}
+}
+
+func TestLureTranslateSkipsLocalizedGeocodingForDefaultLocale(t *testing.T) {
+	called := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	geocoder, err := geocoding.New(geocoding.Config{Provider: "nominatim", ProviderURL: srv.URL})
+	if err != nil {
+		t.Fatalf("geocoding.New: %v", err)
+	}
+	bundle := i18n.NewBundle()
+	bundle.AddTranslator(i18n.NewTranslator("en", map[string]string{"lure_501": "Lure Module"}))
+
+	e := &Enricher{
+		Geocoder:      geocoder,
+		DefaultLocale: "en",
+		Translations:  bundle,
+		GameData: &gamedata.GameData{Util: &gamedata.UtilData{Lures: map[int]gamedata.LureInfo{
+			501: {},
+		}}},
+	}
+
+	got := e.LureTranslate(map[string]any{}, &webhook.LureWebhook{LureID: 501, Latitude: 52.517, Longitude: 13.389}, "en")
+	if called {
+		t.Fatal("default-locale translate should not perform a localized geocode lookup")
+	}
+	if _, ok := got["addr"]; ok {
+		t.Fatalf("default-locale translate should not shadow base addr, got %q", got["addr"])
+	}
+}

--- a/processor/internal/enrichment/lure.go
+++ b/processor/internal/enrichment/lure.go
@@ -88,12 +88,14 @@ func (e *Enricher) Lure(lure *webhook.LureWebhook, tileMode int) (map[string]any
 }
 
 // LureTranslate adds per-language translated fields.
-func (e *Enricher) LureTranslate(base map[string]any, lureID int, lang string) map[string]any {
-	if e.GameData == nil || e.Translations == nil {
+func (e *Enricher) LureTranslate(base map[string]any, lure *webhook.LureWebhook, lang string) map[string]any {
+	if e.GameData == nil || e.Translations == nil || lure == nil {
 		return nil
 	}
 
-	m := make(map[string]any, 8)
+	m := make(map[string]any, 18)
+	defer e.addLocalizedGeoResult(m, lure.Latitude, lure.Longitude, lang)
+	lureID := lure.LureID
 
 	gd := e.GameData
 	tr := e.Translations.For(lang)

--- a/processor/internal/enrichment/maxbattle.go
+++ b/processor/internal/enrichment/maxbattle.go
@@ -128,7 +128,8 @@ func (e *Enricher) MaxbattleTranslate(base map[string]any, mb *webhook.Maxbattle
 		return nil
 	}
 
-	m := make(map[string]any, 10) // only translated fields; caller merges base + perLang
+	m := make(map[string]any, 20) // only translated fields; caller merges base + perLang
+	defer e.addLocalizedGeoResult(m, mb.Latitude, mb.Longitude, lang)
 
 	gd := e.GameData
 	tr := e.Translations.For(lang)

--- a/processor/internal/enrichment/nest.go
+++ b/processor/internal/enrichment/nest.go
@@ -125,12 +125,15 @@ func (e *Enricher) Nest(nest *webhook.NestWebhook, tileMode int) (map[string]any
 }
 
 // NestTranslate adds per-language translated fields.
-func (e *Enricher) NestTranslate(base map[string]any, pokemonID, form int, lang string) map[string]any {
-	if e.GameData == nil || e.Translations == nil {
+func (e *Enricher) NestTranslate(base map[string]any, nest *webhook.NestWebhook, lang string) map[string]any {
+	if e.GameData == nil || e.Translations == nil || nest == nil {
 		return nil
 	}
 
-	m := make(map[string]any, 5) // only translated fields; caller merges base + perLang
+	m := make(map[string]any, 15) // only translated fields; caller merges base + perLang
+	defer e.addLocalizedGeoResult(m, nest.Lat, nest.Lon, lang)
+	pokemonID := nest.PokemonID
+	form := nest.Form
 
 	tr := e.Translations.For(lang)
 	TranslateMonsterNamesEng(m, e.GameData, tr, e.Translations, pokemonID, form, 0)

--- a/processor/internal/enrichment/pokemon.go
+++ b/processor/internal/enrichment/pokemon.go
@@ -330,7 +330,8 @@ func (e *Enricher) PokemonTranslate(base map[string]any, pokemon *webhook.Pokemo
 		return nil
 	}
 
-	m := make(map[string]any, 20) // only translated fields; caller merges base + perLang
+	m := make(map[string]any, 30) // only translated fields; caller merges base + perLang
+	defer e.addLocalizedGeoResult(m, pokemon.Latitude, pokemon.Longitude, lang)
 
 	gd := e.GameData
 	tr := e.Translations.For(lang)

--- a/processor/internal/enrichment/quest.go
+++ b/processor/internal/enrichment/quest.go
@@ -163,7 +163,8 @@ func (e *Enricher) QuestTranslate(base map[string]any, quest *webhook.QuestWebho
 		return nil
 	}
 
-	m := make(map[string]any, 20) // only translated fields; caller merges base + perLang
+	m := make(map[string]any, 30) // only translated fields; caller merges base + perLang
+	defer e.addLocalizedGeoResult(m, quest.Latitude, quest.Longitude, lang)
 
 	tr := e.Translations.For(lang)
 	enTr := e.Translations.For("en")

--- a/processor/internal/enrichment/raid.go
+++ b/processor/internal/enrichment/raid.go
@@ -205,7 +205,8 @@ func (e *Enricher) RaidTranslate(base map[string]any, raid *webhook.RaidWebhook,
 		return nil
 	}
 
-	m := make(map[string]any, 15) // only translated fields; caller merges base + perLang
+	m := make(map[string]any, 25) // only translated fields; caller merges base + perLang
+	defer e.addLocalizedGeoResult(m, raid.Latitude, raid.Longitude, lang)
 
 	gd := e.GameData
 	tr := e.Translations.For(lang)

--- a/processor/internal/enrichment/weather.go
+++ b/processor/internal/enrichment/weather.go
@@ -64,7 +64,10 @@ func (e *Enricher) WeatherTranslate(base map[string]any, oldWeatherID, newWeathe
 		return nil, nil
 	}
 
-	m := make(map[string]any, 10) // only translated fields; caller merges base + perLang
+	m := make(map[string]any, 20) // only translated fields; caller merges base + perLang
+	lat, _ := base["latitude"].(float64)
+	lon, _ := base["longitude"].(float64)
+	defer e.addLocalizedGeoResult(m, lat, lon, lang)
 
 	gd := e.GameData
 	tr := e.Translations.For(lang)
@@ -118,8 +121,6 @@ func (e *Enricher) WeatherTranslate(base map[string]any, oldWeatherID, newWeathe
 		// all other base fields for the tileserver payload.
 		if showAlteredPokemonStaticMap {
 			m["activePokemons"] = enrichedPokemon
-			lat, _ := base["latitude"].(float64)
-			lon, _ := base["longitude"].(float64)
 			pending = e.addStaticMap(m, "weather", lat, lon, base, tileMode)
 		}
 	}

--- a/processor/internal/geocoding/cache.go
+++ b/processor/internal/geocoding/cache.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -67,6 +68,18 @@ func NewCache(diskPath string, memTTL time.Duration, memMaxSize int) (*Cache, er
 func CacheKey(lat, lon float64, detail int) string {
 	format := fmt.Sprintf("%%.%df-%%.%df", detail, detail)
 	return fmt.Sprintf(format, lat, lon)
+}
+
+// CacheKeyForLanguage builds a reverse geocode cache key. Blank language keeps
+// the historical coordinate-only key; localized lookups include the language
+// code so provider-localized address data stays isolated per user locale.
+func CacheKeyForLanguage(lat, lon float64, detail int, language string) string {
+	key := CacheKey(lat, lon, detail)
+	language = strings.ToLower(strings.TrimSpace(language))
+	if language == "" {
+		return key
+	}
+	return language + ":" + key
 }
 
 // Get looks up an address by key. It checks memory first, then disk.

--- a/processor/internal/geocoding/geocoder.go
+++ b/processor/internal/geocoding/geocoder.go
@@ -1,6 +1,7 @@
 package geocoding
 
 import (
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -120,14 +121,23 @@ func unknownAddress() *Address {
 // and concurrency control. Returns an Address with all fields populated, or
 // a minimal "Unknown" address on error. Never returns nil.
 func (g *Geocoder) GetAddress(lat, lon float64) *Address {
+	return g.GetAddressForLanguage(lat, lon, "")
+}
+
+// GetAddressForLanguage performs a reverse geocode lookup in the requested
+// language when the configured provider supports language-specific results.
+// The language code is part of the cache key so localized addresses never
+// bleed across users with different locales.
+func (g *Geocoder) GetAddressForLanguage(lat, lon float64, language string) *Address {
 	if g.config.ForwardOnly {
 		return unknownAddress()
 	}
+	language = normalizeLanguage(language)
 
 	// Cache lookup
 	var cacheKey string
 	if g.cache != nil && g.config.CacheDetail > 0 {
-		cacheKey = CacheKey(lat, lon, g.config.CacheDetail)
+		cacheKey = CacheKeyForLanguage(lat, lon, g.config.CacheDetail, language)
 		if addr, ok := g.cache.Get(cacheKey); ok {
 			g.statHits.Add(1)
 			metrics.GeocodeTotal.WithLabelValues("cache_hit").Inc()
@@ -164,7 +174,7 @@ func (g *Geocoder) GetAddress(lat, lon float64) *Address {
 	defer metrics.GeocodeInFlight.Dec()
 
 	start := time.Now()
-	addr, err := g.provider.Reverse(lat, lon)
+	addr, err := g.provider.Reverse(lat, lon, language)
 	duration := time.Since(start)
 
 	metrics.GeocodeDuration.Observe(duration.Seconds())
@@ -208,6 +218,10 @@ func (g *Geocoder) GetAddress(lat, lon float64) *Address {
 
 	log.Debugf("Geocode %f,%f → %s (%dms)", lat, lon, addr.Addr, duration.Milliseconds())
 	return addr
+}
+
+func normalizeLanguage(language string) string {
+	return strings.ToLower(strings.TrimSpace(language))
 }
 
 // Forward performs a forward geocode (address search). Results are not cached.

--- a/processor/internal/geocoding/geocoder_test.go
+++ b/processor/internal/geocoding/geocoder_test.go
@@ -1,0 +1,82 @@
+package geocoding
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+type languageProvider struct {
+	mu        sync.Mutex
+	languages []string
+}
+
+func (p *languageProvider) Reverse(lat, lon float64, language string) (*Address, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.languages = append(p.languages, language)
+	return &Address{City: language, CountryCode: "DE"}, nil
+}
+
+func (p *languageProvider) Forward(query string) ([]ForwardResult, error) { return nil, nil }
+
+func (p *languageProvider) calls() []string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	out := make([]string, len(p.languages))
+	copy(out, p.languages)
+	return out
+}
+
+func TestGeocoderLanguageAffectsProviderAndCacheKey(t *testing.T) {
+	cache, err := NewCache(t.TempDir(), 24*time.Hour, 100)
+	if err != nil {
+		t.Fatalf("NewCache: %v", err)
+	}
+	defer cache.Close()
+
+	addrTmpl, err := CompileAddressTemplate("{{{city}}}")
+	if err != nil {
+		t.Fatalf("CompileAddressTemplate: %v", err)
+	}
+	provider := &languageProvider{}
+	g := &Geocoder{
+		provider: provider,
+		cache:    cache,
+		config: Config{
+			CacheDetail:      3,
+			FailureThreshold: 5,
+			CooldownMs:       1,
+		},
+		addrTmpl: addrTmpl,
+		sem:      make(chan struct{}, 1),
+	}
+
+	if got := g.GetAddressForLanguage(52.517, 13.389, "DE"); got.City != "de" {
+		t.Fatalf("de city=%q, want de", got.City)
+	}
+	if got := g.GetAddressForLanguage(52.517, 13.389, "en"); got.City != "en" {
+		t.Fatalf("en city=%q, want en", got.City)
+	}
+	if got := g.GetAddressForLanguage(52.517, 13.389, "de"); got.City != "de" {
+		t.Fatalf("cached de city=%q, want de", got.City)
+	}
+
+	calls := provider.calls()
+	if len(calls) != 2 {
+		t.Fatalf("provider calls=%v, want two cache misses", calls)
+	}
+	if calls[0] != "de" || calls[1] != "en" {
+		t.Fatalf("provider languages=%v, want [de en]", calls)
+	}
+}
+
+func TestCacheKeyForLanguage(t *testing.T) {
+	base := CacheKey(52.517, 13.389, 3)
+	if got := CacheKeyForLanguage(52.517, 13.389, 3, ""); got != base {
+		t.Fatalf("blank language key=%q, want %q", got, base)
+	}
+	if got := CacheKeyForLanguage(52.517, 13.389, 3, " DE "); got != "de:"+base {
+		t.Fatalf("localized key=%q, want %q", got, "de:"+base)
+	}
+}

--- a/processor/internal/geocoding/geocoding.go
+++ b/processor/internal/geocoding/geocoding.go
@@ -43,7 +43,7 @@ type ForwardResult struct {
 
 // Provider performs geocoding API calls.
 type Provider interface {
-	Reverse(lat, lon float64) (*Address, error)
+	Reverse(lat, lon float64, language string) (*Address, error)
 	Forward(query string) ([]ForwardResult, error)
 }
 

--- a/processor/internal/geocoding/google.go
+++ b/processor/internal/geocoding/google.go
@@ -63,11 +63,20 @@ type googleGeometry struct {
 }
 
 // Reverse performs a reverse geocode lookup via Google.
-func (g *Google) Reverse(lat, lon float64) (*Address, error) {
-	u := fmt.Sprintf("https://maps.googleapis.com/maps/api/geocode/json?latlng=%f,%f&key=%s",
-		lat, lon, g.randomKey())
+func (g *Google) Reverse(lat, lon float64, language string) (*Address, error) {
+	u, err := url.Parse("https://maps.googleapis.com/maps/api/geocode/json")
+	if err != nil {
+		return nil, fmt.Errorf("google geocode: parse URL")
+	}
+	q := u.Query()
+	q.Set("latlng", fmt.Sprintf("%f,%f", lat, lon))
+	q.Set("key", g.randomKey())
+	if language = strings.TrimSpace(language); language != "" {
+		q.Set("language", language)
+	}
+	u.RawQuery = q.Encode()
 
-	resp, err := g.client.Get(u)
+	resp, err := g.client.Get(u.String())
 	if err != nil {
 		return nil, fmt.Errorf("google geocode: request failed (key redacted)")
 	}

--- a/processor/internal/geocoding/google.go
+++ b/processor/internal/geocoding/google.go
@@ -64,10 +64,7 @@ type googleGeometry struct {
 
 // Reverse performs a reverse geocode lookup via Google.
 func (g *Google) Reverse(lat, lon float64, language string) (*Address, error) {
-	u, err := url.Parse("https://maps.googleapis.com/maps/api/geocode/json")
-	if err != nil {
-		return nil, fmt.Errorf("google geocode: parse URL")
-	}
+	u, _ := url.Parse("https://maps.googleapis.com/maps/api/geocode/json")
 	q := u.Query()
 	q.Set("latlng", fmt.Sprintf("%f,%f", lat, lon))
 	q.Set("key", g.randomKey())

--- a/processor/internal/geocoding/nominatim.go
+++ b/processor/internal/geocoding/nominatim.go
@@ -89,7 +89,7 @@ func nominatimToOCFMT(a nominatimAddress, streetName, city string) map[string]st
 }
 
 // Reverse performs a reverse geocode lookup.
-func (n *Nominatim) Reverse(lat, lon float64) (*Address, error) {
+func (n *Nominatim) Reverse(lat, lon float64, language string) (*Address, error) {
 	u, err := url.Parse(n.baseURL + "/reverse")
 	if err != nil {
 		return nil, fmt.Errorf("nominatim: parse URL: %w", err)
@@ -99,6 +99,9 @@ func (n *Nominatim) Reverse(lat, lon float64) (*Address, error) {
 	q.Set("lat", strconv.FormatFloat(lat, 'f', -1, 64))
 	q.Set("lon", strconv.FormatFloat(lon, 'f', -1, 64))
 	q.Set("addressdetails", "1")
+	if language = strings.TrimSpace(language); language != "" {
+		q.Set("accept-language", language)
+	}
 	u.RawQuery = q.Encode()
 
 	body, err := n.doGet(u.String())

--- a/processor/internal/geocoding/nominatim_test.go
+++ b/processor/internal/geocoding/nominatim_test.go
@@ -41,7 +41,7 @@ func TestNominatimReverseOCFMT(t *testing.T) {
 	defer srv.Close()
 
 	n := NewNominatim(srv.URL, 2*time.Second, true)
-	addr, err := n.Reverse(52.517, 13.389)
+	addr, err := n.Reverse(52.517, 13.389, "")
 	if err != nil {
 		t.Fatalf("Reverse: %v", err)
 	}
@@ -88,7 +88,7 @@ func TestNominatimReverseCountryExcluded(t *testing.T) {
 	defer srv.Close()
 
 	n := NewNominatim(srv.URL, 2*time.Second, false)
-	addr, err := n.Reverse(52.517, 13.389)
+	addr, err := n.Reverse(52.517, 13.389, "")
 	if err != nil {
 		t.Fatalf("Reverse: %v", err)
 	}
@@ -123,11 +123,29 @@ func TestNominatimFallsBackToDisplayName(t *testing.T) {
 	defer srv.Close()
 
 	n := NewNominatim(srv.URL, 2*time.Second, true)
-	addr, err := n.Reverse(0, 0)
+	addr, err := n.Reverse(0, 0, "")
 	if err != nil {
 		t.Fatalf("Reverse: %v", err)
 	}
 	if addr.FormattedAddress == "" {
 		t.Errorf("FormattedAddress should fall back to display_name when components are empty, got empty")
+	}
+}
+
+func TestNominatimReverseSendsLanguage(t *testing.T) {
+	const body = `{"lat":"0","lon":"0","display_name":"Ort","address":{"country_code":"de"}}`
+	var got string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = r.URL.Query().Get("accept-language")
+		w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	n := NewNominatim(srv.URL, 2*time.Second, true)
+	if _, err := n.Reverse(0, 0, "de"); err != nil {
+		t.Fatalf("Reverse: %v", err)
+	}
+	if got != "de" {
+		t.Errorf("accept-language=%q, want de", got)
 	}
 }

--- a/processor/internal/geocoding/photon.go
+++ b/processor/internal/geocoding/photon.go
@@ -65,7 +65,7 @@ type photonProperties struct {
 }
 
 // Reverse performs a reverse geocode lookup using Photon.
-func (p *Photon) Reverse(lat, lon float64) (*Address, error) {
+func (p *Photon) Reverse(lat, lon float64, language string) (*Address, error) {
 	u, err := url.Parse(p.baseURL + "/reverse")
 	if err != nil {
 		return nil, fmt.Errorf("photon: parse URL: %w", err)
@@ -74,6 +74,9 @@ func (p *Photon) Reverse(lat, lon float64) (*Address, error) {
 	q.Set("lat", fmt.Sprintf("%f", lat))
 	q.Set("lon", fmt.Sprintf("%f", lon))
 	q.Set("radius", "10")
+	if language = strings.TrimSpace(language); language != "" {
+		q.Set("lang", language)
+	}
 	u.RawQuery = q.Encode()
 
 	resp, err := p.client.Get(u.String())

--- a/processor/internal/geocoding/photon_test.go
+++ b/processor/internal/geocoding/photon_test.go
@@ -126,7 +126,7 @@ func TestPhotonReverse(t *testing.T) {
 	defer srv.Close()
 
 	p := NewPhoton(srv.URL, 2*time.Second, true)
-	addr, err := p.Reverse(52.517, 13.389)
+	addr, err := p.Reverse(52.517, 13.389, "")
 	if err != nil {
 		t.Fatalf("Reverse: %v", err)
 	}
@@ -164,7 +164,7 @@ func TestPhotonReverseEmptyFeatures(t *testing.T) {
 	defer srv.Close()
 
 	p := NewPhoton(srv.URL, 2*time.Second, true)
-	if _, err := p.Reverse(0, 0); err == nil {
+	if _, err := p.Reverse(0, 0, ""); err == nil {
 		t.Fatal("expected error for empty features")
 	}
 }
@@ -176,7 +176,7 @@ func TestPhotonReverseServerError(t *testing.T) {
 	defer srv.Close()
 
 	p := NewPhoton(srv.URL, 2*time.Second, true)
-	if _, err := p.Reverse(0, 0); err == nil {
+	if _, err := p.Reverse(0, 0, ""); err == nil {
 		t.Fatal("expected error for 500 response")
 	}
 }
@@ -203,7 +203,7 @@ func TestPhotonReverseCountryExcluded(t *testing.T) {
 	defer srv.Close()
 
 	p := NewPhoton(srv.URL, 2*time.Second, false)
-	addr, err := p.Reverse(52.517, 13.389)
+	addr, err := p.Reverse(52.517, 13.389, "")
 	if err != nil {
 		t.Fatalf("Reverse: %v", err)
 	}
@@ -220,6 +220,24 @@ func TestPhotonReverseCountryExcluded(t *testing.T) {
 	// {{{country}}} still work; we only control FormattedAddress shape.
 	if addr.Country != "Germany" || addr.CountryCode != "DE" {
 		t.Errorf("component fields should stay populated, got Country=%q CountryCode=%q", addr.Country, addr.CountryCode)
+	}
+}
+
+func TestPhotonReverseSendsLanguage(t *testing.T) {
+	const body = `{"features":[{"geometry":{"coordinates":[0,0]},"properties":{"countrycode":"DE","country":"Deutschland"}}]}`
+	var got string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = r.URL.Query().Get("lang")
+		w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	p := NewPhoton(srv.URL, 2*time.Second, true)
+	if _, err := p.Reverse(0, 0, "de"); err != nil {
+		t.Fatalf("Reverse: %v", err)
+	}
+	if got != "de" {
+		t.Errorf("lang=%q, want de", got)
 	}
 }
 


### PR DESCRIPTION
- Extend Provider interface: Reverse(lat, lon, language string)
- Plumb language through Nominatim (accept-language), Photon (lang), Google (language)
- CacheKeyForLanguage isolates localized results in the on-disk cache
- addLocalizedGeocoding clones PerLangEnrichment then merges per-language address fields
- Base enrichment stores geocodeLatitude/geocodeLongitude for later per-lang lookups
- Tests for language forwarding and cache key isolation

made by gpt 5.5, approved by deepseek v4 pro