### PR TITLE
Fix: name: resolution for telegram:channel (and other named targets)

### DIFF
--- a/processor/internal/bot/target_test.go
+++ b/processor/internal/bot/target_test.go
@@ -122,6 +122,42 @@ func TestBuildTarget_NonAdminChannelUsesConfiguredPrefix(t *testing.T) {
 	}
 }
 
+// TestBuildTarget_NameResolvesNamedTargets ensures `name:` resolves not just
+// Discord webhooks but every named, non-command destination — notably
+// telegram:channel (the Telegram analogue of a Discord webhook). A store
+// refactor narrowed the lookup to type='webhook', breaking telegram:channel
+// resolution; this guards against that regression.
+func TestBuildTarget_NameResolvesNamedTargets(t *testing.T) {
+	cases := []struct {
+		hookType string
+		hookName string
+		hookID   string
+	}{
+		{TypeWebhook, "MyHook", "wh1"},
+		{"telegram:channel", "innsbrucktop100", "-1001234567890"},
+		{TypeTelegramGroup, "mygroup", "-100999"},
+		{TypeDiscordChannel, "namedchan", "chX"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.hookType, func(t *testing.T) {
+			humans := store.NewMockHumanStore()
+			humans.AddHuman(&store.Human{ID: "user1", Type: TypeDiscordUser, Name: "Alice", Enabled: true})
+			humans.AddHuman(&store.Human{ID: tc.hookID, Type: tc.hookType, Name: tc.hookName, Enabled: true})
+			ctx := &CommandContext{
+				UserID: "user1", Platform: "discord", IsDM: true, IsAdmin: true,
+				TargetID: "user1", Humans: humans,
+			}
+			target, _, err := BuildTarget(ctx, []string{"name:" + tc.hookName, "pikachu"})
+			if err != nil {
+				t.Fatalf("name:%s (%s): unexpected error: %v", tc.hookName, tc.hookType, err)
+			}
+			if target == nil || target.ID != tc.hookID {
+				t.Fatalf("name:%s (%s): expected target %s, got %+v", tc.hookName, tc.hookType, tc.hookID, target)
+			}
+		})
+	}
+}
+
 func TestBuildTarget_NonAdminInUnregisteredChannelRejected(t *testing.T) {
 	ctx := newTargetCtx(t, false, false)
 	// Remove the channel from the mock store so it appears unregistered

--- a/processor/internal/store/human.go
+++ b/processor/internal/store/human.go
@@ -13,6 +13,14 @@ import (
 // errors.Is(err, store.ErrDuplicateLocation) to detect this condition.
 var ErrDuplicateLocation = errors.New("duplicate location label")
 
+// NamedTargetTypes are the human types that are addressed by name via the
+// `name:` command override — destinations you can't run commands inside, so
+// the only way to manage their tracking is by name. This is the Discord
+// webhook plus its cross-platform equivalents (discord:channel,
+// telegram:channel, telegram:group). LookupWebhookByName resolves against
+// exactly this set. Keep in sync with the apply.go named-target query.
+var NamedTargetTypes = []string{"webhook", "discord:channel", "telegram:channel", "telegram:group"}
+
 // Human represents a complete human record with all columns.
 // JSON fields (Area, CommunityMembership, AreaRestriction, BlockedAlerts)
 // are stored as JSON arrays in the database but exposed here as Go slices.
@@ -159,7 +167,9 @@ type HumanStore interface {
 	// ListAll returns all humans (for admin userlist).
 	ListAll() ([]*Human, error)
 
-	// LookupWebhookByName finds a webhook human by name.
+	// LookupWebhookByName resolves a named, non-command destination by name
+	// (the `name:` command override). Matches NamedTargetTypes — webhooks plus
+	// the channel/group destinations you can't run commands inside.
 	LookupWebhookByName(name string) (string, error)
 
 	// CountByName returns the number of humans with the given name.

--- a/processor/internal/store/human_sql.go
+++ b/processor/internal/store/human_sql.go
@@ -318,9 +318,14 @@ func (s *SQLHumanStore) ListAll() ([]*Human, error) {
 }
 
 func (s *SQLHumanStore) LookupWebhookByName(name string) (string, error) {
-	var id string
-	err := s.db.Get(&id, `SELECT id FROM humans WHERE name = ? AND type = 'webhook' LIMIT 1`, name)
+	query, args, err := sqlx.In(
+		`SELECT id FROM humans WHERE name = ? AND type IN (?) LIMIT 1`, name, NamedTargetTypes)
 	if err != nil {
+		return "", fmt.Errorf("build webhook lookup for %s: %w", name, err)
+	}
+	query = s.db.Rebind(query)
+	var id string
+	if err := s.db.Get(&id, query, args...); err != nil {
 		if err == sql.ErrNoRows {
 			return "", nil
 		}

--- a/processor/internal/store/mock_human.go
+++ b/processor/internal/store/mock_human.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 	"sync"
 )
@@ -286,7 +287,7 @@ func (m *MockHumanStore) LookupWebhookByName(name string) (string, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	for _, h := range m.humans {
-		if h.Type == "webhook" && h.Name == name {
+		if h.Name == name && slices.Contains(NamedTargetTypes, h.Type) {
 			return h.ID, nil
 		}
 	}


### PR DESCRIPTION
## Problem

User report: *"nameInnsbruckTop100 is not found anymore (webhook innsbrucktop100 not found), but it still sends to this group."*

`name:` target resolution stopped working for **telegram:channel** (the Telegram equivalent of a Discord webhook — you can't run commands inside it, so `name:` is the only way to manage its tracking). The channel still receives alerts (existing rules are intact), but you can no longer add/manage tracking against it by name. Same breakage for `telegram:group` and `discord:channel`.

## Root cause

The store-abstraction refactor (`9df80e2e`) replaced the old unfiltered name lookup:
```sql
SELECT ... FROM humans WHERE name = ? LIMIT 1
```
with `LookupWebhookByName`, which narrowed it to:
```sql
SELECT id FROM humans WHERE name = ? AND type = 'webhook' LIMIT 1
```
So only Discord `webhook` rows resolved; every other named destination returned "webhook X not found". The reporter's diagnosis was exactly right.

## Fix

Resolve `name:` against the canonical **named-target set** — `webhook`, `discord:channel`, `telegram:channel`, `telegram:group` — defined once as `store.NamedTargetTypes` and shared by both the SQL and mock `HumanStore` impls (so they can't drift). This matches the set already used by `!apply`'s named-target query.

This is also *more* correct than the original unfiltered query: it won't accidentally match person records (`discord:user`/`telegram:user`) by name.

`telegram:topic` is intentionally excluded (matches `!apply`; topic names contain spaces, so the single-token `name:` can't address them anyway).

## Tests

Added `TestBuildTarget_NameResolvesNamedTargets` — drives `BuildTarget` via the mock store for all four named types; it reproduced the bug (webhook passed, the other three failed with the user's exact error) and passes after the fix. The SQL impl has no CI-runnable DB test (those require `PORACLENG_TEST_DSN`), so the consumer-level mock test is the regression guard.

`go build`, `go vet`, changed-package tests, and `golangci-lint` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)