### PR TITLE
Fix: !track meganium (string prefixes swallowing pokemon names)

### DIFF
--- a/processor/internal/bot/argmatch.go
+++ b/processor/internal/bot/argmatch.go
@@ -592,8 +592,24 @@ func (am *ArgMatcher) tryPrefixSingle(tok, key, lang string, result *ParsedArgs)
 	return false
 }
 
+// tokenIsKnownPokemon reports whether the whole token resolves to a pokemon.
+// Used to stop open-valued string prefixes (mega:, form:, move:, …) from
+// swallowing a token that is actually a pokemon name via the no-colon
+// concatenation form — e.g. "meganium" would otherwise match the "mega"
+// prefix as mega+"nium", leaving no pokemon to resolve. Colon forms like
+// "mega:x" never resolve to a pokemon, so this guard doesn't affect them.
+func (am *ArgMatcher) tokenIsKnownPokemon(tok, lang string) bool {
+	if am.resolver == nil {
+		return false
+	}
+	return len(am.resolver.Resolve(tok, lang)) > 0
+}
+
 // tryPrefixString matches patterns like "form:alola" or "formalola", "template:2", "move:hydro pump".
 func (am *ArgMatcher) tryPrefixString(tok, key, lang string, result *ParsedArgs) bool {
+	if am.tokenIsKnownPokemon(tok, lang) {
+		return false
+	}
 	prefix := am.cachedPrefix(key, lang)
 	for _, p := range prefix {
 		if val, ok := stripPrefix(tok, p); ok {
@@ -609,6 +625,9 @@ func (am *ArgMatcher) tryPrefixString(tok, key, lang string, result *ParsedArgs)
 // Values are comma-split and lowercased; calling this multiple times on
 // different tokens accumulates all values in result.StringLists[shortKey].
 func (am *ArgMatcher) tryPrefixStringList(tok, key, lang string, result *ParsedArgs) bool {
+	if am.tokenIsKnownPokemon(tok, lang) {
+		return false
+	}
 	prefixes := am.cachedPrefix(key, lang)
 	for _, p := range prefixes {
 		val, ok := stripPrefix(tok, p)

--- a/processor/internal/bot/argmatch_test.go
+++ b/processor/internal/bot/argmatch_test.go
@@ -724,3 +724,56 @@ func TestArgMatch_LocationSingle(t *testing.T) {
 		t.Fatalf("location: got %q", parsed.Strings["location"])
 	}
 }
+
+func newMeganiumMatcher() *ArgMatcher {
+	bundle := i18n.NewBundle()
+	bundle.AddTranslator(i18n.NewTranslator("en", map[string]string{
+		"arg.prefix.mega": "mega",
+		"arg.mega":        "mega",
+		"poke_25":         "Pikachu",
+		"poke_154":        "Meganium",
+	}))
+	gd := &gamedata.GameData{
+		Monsters: map[gamedata.MonsterKey]*gamedata.Monster{
+			{ID: 25, Form: 0}:  {PokemonID: 25},
+			{ID: 154, Form: 0}: {PokemonID: 154},
+		},
+	}
+	resolver := NewPokemonResolver(gd, bundle, []string{"en"}, nil)
+	return NewArgMatcher(bundle, gd, resolver, []string{"en"})
+}
+
+// A string-prefix (here `mega`) must NOT swallow a token that is a known
+// pokemon. `meganium` (154) was matched as mega+"nium" before the fix.
+func TestPrefixDoesNotSwallowKnownPokemon(t *testing.T) {
+	am := newMeganiumMatcher()
+	params := []ParamDef{
+		{Type: ParamPrefixString, Key: "arg.prefix.mega"},
+		{Type: ParamKeyword, Key: "arg.mega"},
+		{Type: ParamPokemonName},
+	}
+
+	t.Run("meganium_resolves_as_pokemon", func(t *testing.T) {
+		p := am.Match([]string{"meganium"}, params, "en")
+		if p.Strings["mega"] != "" {
+			t.Fatalf("meganium wrongly consumed as mega prefix (val=%q)", p.Strings["mega"])
+		}
+		if len(p.Pokemon) != 1 || p.Pokemon[0].PokemonID != 154 {
+			t.Fatalf("meganium should resolve to pokemon 154; got %+v", p.Pokemon)
+		}
+	})
+
+	t.Run("mega_colon_x_still_works", func(t *testing.T) {
+		p := am.Match([]string{"mega:x"}, params, "en")
+		if p.Strings["mega"] != "x" {
+			t.Fatalf("mega:x should set mega=x; got %q", p.Strings["mega"])
+		}
+	})
+
+	t.Run("bare_mega_keyword_still_works", func(t *testing.T) {
+		p := am.Match([]string{"mega"}, params, "en")
+		if !p.HasKeyword("arg.mega") {
+			t.Fatalf("bare mega should set the arg.mega keyword")
+		}
+	})
+}


### PR DESCRIPTION
## Bug

`!track meganium` is rejected as "not a valid pokemon". Reported by a user.

## Root cause

The arg parser matches in two phases: string-prefix params (`mega:`, `form:`, `move:`, …) consume tokens **first**, then pokemon names resolve from whatever's left. `stripPrefix` accepts a no-colon **concatenation** form (the same feature that lets `iv100` work), so the `mega` prefix matched `meganium` as `mega`+`nium`, consuming the token before pokemon resolution ever saw it.

Numeric prefixes (`d`, `cap`, `gen`) are immune — their value must parse as a number, so `dratini` → `d`+`ratini` fails and falls through. Open-valued **string** prefixes have no such guard. I checked the full shipped pokedex against all 12 string-prefix words: **Meganium is the only current collision**, but the class is latent for every string prefix and any future pokemon.

## Fix

Class-level, not mega-specific: `tryPrefixString` / `tryPrefixStringList` now refuse to consume a token that resolves to a **known pokemon**. Colon forms (`mega:x`, `form:alola`) never resolve to a pokemon, so they're unaffected — `mega:x` still sets the discriminator, bare `mega` still sets the keyword.

### Why not reorder pokemon resolution globally?
Considered moving pokemon resolution ahead of the prefix phase, but `pokemonAlias.json` is operator-extensible, so a global reorder would let an alias named `everything`/`shiny`/`male`/`shadow`/`mega` **shadow those keywords**. The scoped guard fixes the whole prefix-collision class without that risk. (Multi-word pokemon were never at risk — `collapseMultiWord` pre-collapses them before matching.)

## Tests

`TestPrefixDoesNotSwallowKnownPokemon`: `meganium` → pokemon 154 (not consumed by `mega`); `mega:x` → `mega=x`; bare `mega` → keyword. Full suite + lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)