### PR TITLE
Fix: default_distance breaks area: tracking (false mutual-exclusion)

### DIFF
--- a/processor/internal/bot/commands/helpers.go
+++ b/processor/internal/bot/commands/helpers.go
@@ -137,8 +137,15 @@ func extractPings(args []string) (pings string, remaining []string) {
 }
 
 // enforceDistance applies default and max distance limits from config.
-func enforceDistance(ctx *bot.CommandContext, distance int) int {
-	if distance == 0 && ctx.Config.Tracking.DefaultDistance > 0 {
+// enforceDistance applies the configured default_distance (when the user gave
+// no explicit d:) and clamps to max_distance. areaMode must be true when the
+// rule uses an area: override: area-mode and distance-mode are mutually
+// exclusive, so default_distance must NOT be injected there — otherwise it both
+// trips the area-vs-distance rejection in parseOverride and (if stored) makes
+// the matcher prefer the haversine check over the area overlap, ignoring the
+// override_areas the user asked for.
+func enforceDistance(ctx *bot.CommandContext, distance int, areaMode bool) int {
+	if !areaMode && distance == 0 && ctx.Config.Tracking.DefaultDistance > 0 {
 		distance = ctx.Config.Tracking.DefaultDistance
 	}
 	if ctx.Config.Tracking.MaxDistance > 0 && distance > ctx.Config.Tracking.MaxDistance {
@@ -377,7 +384,7 @@ func parseCommonTrackFields(ctx *bot.CommandContext, parsed *bot.ParsedArgs, dts
 	if d, ok := parsed.Singles["d"]; ok {
 		f.Distance = d
 	}
-	f.Distance = enforceDistance(ctx, f.Distance)
+	f.Distance = enforceDistance(ctx, f.Distance, len(parsed.StringLists["area"]) > 0)
 
 	return f, nil
 }

--- a/processor/internal/bot/commands/track.go
+++ b/processor/internal/bot/commands/track.go
@@ -364,7 +364,7 @@ func (c *TrackCommand) parseFilters(ctx *bot.CommandContext, parsed *bot.ParsedA
 	if d, ok := parsed.Singles["d"]; ok {
 		f.distance = d
 	}
-	f.distance = enforceDistance(ctx, f.distance)
+	f.distance = enforceDistance(ctx, f.distance, len(parsed.StringLists["area"]) > 0)
 
 	// Template
 	if t, ok := parsed.Strings["template"]; ok {

--- a/processor/internal/bot/commands/track_test.go
+++ b/processor/internal/bot/commands/track_test.go
@@ -610,6 +610,37 @@ func TestTrack_RejectsLocationWithoutDistance(t *testing.T) {
 	}
 }
 
+// TestTrack_AreaWithDefaultDistance_NoMutualExclusion guards the bug where a
+// configured [tracking] default_distance made `!track X area:Y` (no explicit
+// d:) wrongly trip the area-vs-distance mutual-exclusion check: enforceDistance
+// injected the default into filters.distance, so parseOverride saw distance>0.
+// In area-mode the default must not apply — and the stored rule must keep
+// distance 0 so the matcher honours override_areas (distance>0 ⇒ haversine).
+func TestTrack_AreaWithDefaultDistance_NoMutualExclusion(t *testing.T) {
+	ctx, _ := newTestTrackCtx(t)
+	ctx.Config.Tracking.DefaultDistance = 1000
+
+	cmd := &TrackCommand{}
+	replies := cmd.Run(ctx, []string{"25", "iv100", "area:london"})
+
+	if anyContains(replies, "mutually exclusive") {
+		t.Fatalf("default_distance must not force area→distance exclusion; got %+v", replies)
+	}
+	if !anyReact(replies, "✅") {
+		t.Fatalf("expected success react, got %+v", replies)
+	}
+	rows := ctx.Tracking.Monsters.(*store.MockTrackingStore[db.MonsterTrackingAPI]).AllRows()
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 stored rule, got %d", len(rows))
+	}
+	if rows[0].Distance != 0 {
+		t.Fatalf("area-mode rule must store distance 0 (not default_distance), got %d", rows[0].Distance)
+	}
+	if len(rows[0].OverrideAreas) == 0 {
+		t.Fatalf("expected override_areas set on the stored rule, got %+v", rows[0].OverrideAreas)
+	}
+}
+
 func TestTrack_RejectsAreaWithDistance(t *testing.T) {
 	ctx, _ := newTestTrackCtx(t)
 	ctx.HasLocation = true


### PR DESCRIPTION
## Bug

`!track raichu area:san...` (no `d:` specified) is rejected with:

> 🙅 `area:` and `d:` are mutually exclusive (area-mode vs distance-mode). Pick one.

Reported by a user who has `[tracking] default_distance` configured — which is exactly the trigger.

## Root cause

`enforceDistance` (`helpers.go`) injects `default_distance` whenever the user gave no explicit `d:`:

```go
if distance == 0 && ctx.Config.Tracking.DefaultDistance > 0 { distance = ...DefaultDistance }
```

So `filters.distance` becomes non-zero even though the user only typed `area:`. `parseOverride` then sees `distance > 0` and fires Rule 2 (`hasAreas && distance > 0` → mutually exclusive).

It's worse than a false rejection: even if the rule were stored, a non-zero distance alongside `override_areas` would make the **matcher ignore the area override** — `ValidateHumansGeneric` uses the haversine check when `distance > 0` and only falls back to area overlap when `distance == 0`.

Shared `enforceDistance` / `parseCommonTrackFields`, so this affected **all** tracking commands (raid, egg, gym, quest, …), not just `!track`.

## Fix

Don't inject `default_distance` in area-mode. `enforceDistance` gains an `areaMode` flag (true when `area:` is present); the two callers pass `len(parsed.StringLists["area"]) > 0`. The `max_distance` clamp and explicit-`d:` behaviour are unchanged, so:
- `area:Y` (no `d:`) → distance stays **0**, area-mode honoured ✓
- `area:Y d:500` → still correctly **rejected** (genuine mutual exclusion) ✓
- `location:Z` / plain distance-mode → `default_distance` still applies ✓

## Tests

New `TestTrack_AreaWithDefaultDistance_NoMutualExclusion` reproduces the user's case (default_distance set + `area:london`, no `d:`) and asserts: no mutual-exclusion error, success react, **and** the stored rule keeps `distance == 0` with `override_areas` set (so matching works). Existing `area:+d:` rejection and all `parseOverride` tests still pass. Full gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)