### PR TITLE
fix(track): non-PVP rules store default PVP rank 1/4096 (not 0/0)

### DIFF
--- a/processor/internal/bot/commands/track.go
+++ b/processor/internal/bot/commands/track.go
@@ -139,10 +139,13 @@ func (c *TrackCommand) Run(ctx *bot.CommandContext, args []string) []bot.Reply {
 	}
 
 	// Build insert structs — one per pokemon per PVP league
-	// If no PVP, one entry per pokemon with zeroed PVP fields
+	// If no PVP, one entry per pokemon with no PVP league. Best/Worst use the
+	// no-constraint rank defaults (1 / 4096) so non-PVP rows match the DB column
+	// defaults and the API (a zero-value entry would store 0/0, breaking dedup
+	// parity with API-created rows and surfacing 0/0 instead of null in the v2 API).
 	pvpList := pvpEntries
 	if len(pvpList) == 0 {
-		pvpList = []pvpEntry{{}} // single entry with zero PVP
+		pvpList = []pvpEntry{{Best: 1, Worst: 4096}} // single entry, no PVP league
 	}
 	insert := make([]db.MonsterTrackingAPI, 0, len(monsterList)*len(pvpList))
 	for _, mon := range monsterList {

--- a/processor/internal/bot/commands/track_test.go
+++ b/processor/internal/bot/commands/track_test.go
@@ -360,6 +360,25 @@ func TestTrack_WithIVFilter(t *testing.T) {
 	assert.Equal(t, 100, rows[0].MaxIV)
 }
 
+// TestTrack_NonPVP_RankDefaults verifies that a non-PVP !track stores the
+// no-constraint PVP rank defaults (best 1 / worst 4096), matching the DB column
+// defaults and the v1/v2 API — not the zero-value 0/0 the base entry used to
+// store, which broke dedup parity with API-created rows and surfaced as 0/0
+// (instead of null) in the v2 API response.
+func TestTrack_NonPVP_RankDefaults(t *testing.T) {
+	ctx := trackCtx(t)
+	replies := runTrack(t, ctx, "25")
+
+	require.NotEmpty(t, replies)
+	assert.Equal(t, "✅", replies[0].React, "reply: %s", replies[0].Text)
+
+	rows, _ := ctx.Tracking.Monsters.SelectByIDProfile("user1", 1)
+	require.Len(t, rows, 1)
+	assert.Equal(t, 0, rows[0].PVPRankingLeague, "non-PVP rule has no league")
+	assert.Equal(t, 1, rows[0].PVPRankingBest, "non-PVP rule should default best rank to 1")
+	assert.Equal(t, 4096, rows[0].PVPRankingWorst, "non-PVP rule should default worst rank to 4096")
+}
+
 func TestTrack_WithDistance(t *testing.T) {
 	ctx := trackCtx(t)
 	ctx.HasLocation = true


### PR DESCRIPTION
## Problem

`!track` for a **non-PVP** rule stored `pvp_ranking_best=0` / `pvp_ranking_worst=0`, while every other path uses the no-constraint defaults `1` / `4096`:
- `monsters` DB column defaults: `pvp_ranking_best DEFAULT 1`, `pvp_ranking_worst DEFAULT 4096`
- v1 API (`trackingMonster.go`): `intValue(1)` / `intValue(4096)`
- v2 API (`v2_pokemon.go`): `valueOr(…, 1)` / `valueOr(…, 4096)` (and null-hides them)

Root cause: when no PVP league is given, the per-pokemon loop runs over a single **zero-value** `pvpEntry{}` (`track.go`), so the row copies `Best:0 / Worst:0`. The per-league PVP builder already normalises `0→1` / `0→4096`, but the non-PVP base entry skipped it.

## Impact

Best/Worst are only checked at match time when `league != 0`, so **alerting is unaffected**. But the inconsistency:
- breaks **dedup parity** — a `!track`-created non-PVP rule (`0/0`) wouldn't dedupe against an API-created one (`1/4096`) for the same pokemon, producing duplicate rows;
- surfaces as `0/0` instead of `null` in the **v2 API** response (which hides the `1/4096` wildcards).

## Fix

The non-PVP base entry now uses `{Best: 1, Worst: 4096}` — matching the DB defaults and the API. One-line change + a regression test (`TestTrack_NonPVP_RankDefaults`).

> Note: existing rows already stored with `0/0` by the old `!track` are not migrated by this change (out of scope); going forward, new `!track` rules and API rules are consistent.

## Test plan
- [x] `TestTrack_NonPVP_RankDefaults` — a plain `!track 25` stores `league=0, best=1, worst=4096`
- [x] Full gate green (`go build ./... && go vet ./... && go test -count=1 ./... && golangci-lint run ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)