### PR TITLE
v2 mutes API: list/create/delete + snapshot inclusion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **v2 mutes API.** `GET/POST /api/v2/humans/{id}/mutes` and
+  `DELETE /api/v2/humans/{id}/mutes[?scope=&value=]` expose the in-memory alert
+  mutes (the `!mute` / alert-button feature) over HTTP, and the v2 full
+  snapshot now carries a `mutes` array. Mutes remain volatile — they are
+  cleared by a processor restart.
 - **OpenAPI 3.1 spec + interactive docs.** The processor now serves a single
   OpenAPI 3.1 document at `GET /openapi.json` with interactive documentation at
   `GET /docs` (both public, no `X-Poracle-Secret` required). The spec covers the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -715,8 +715,9 @@ The store is a separate pogreb instance from the geocoder cache — different wo
 - `!<type> mute ...` aliases (e.g. `!raid mute id:X`) route through `RouteToMuteFromType`.
 - `!tracked` shows the active mutes alongside tracking rules.
 - Mute buttons on alerts (see "Button actions" below) write the same `mute.Entry` shape via `buttonactions.HandleMute`.
+- **v2 mutes API** (`internal/api/v2_mutes.go`): `GET|POST /api/v2/humans/{id}/mutes`, `DELETE …/mutes?scope=&value=` (single) and `DELETE …/mutes` (all). Strict schemas, problem+json; mute identity is `(scope, value)` so deletes address via query params; DELETE returns `{deleted:[…]}` like v2 tracking. Area values validate against `AreaLogic` when present, else live `StateMgr` fences (production path). The v2 full snapshot includes a `mutes` array. The API documents the in-memory volatility — entries vanish on restart. Design: `docs/superpowers/specs/2026-06-11-mute-api-design.md`.
 
-Tracking-UID mutes (`!mute id:N` / `!mute raid id:N`) are documented in the design but rejected by the v1 parser — they need `MatchedUser.RuleUID` plumbing in the matcher first.
+Tracking-UID mutes are fully wired: the matcher compares `mute.Event.MatchedRuleUID` (populated per matched user in `cmd/processor/helpers.go`) against `tracking`-scope entries, created via `!mute id:N`, alert buttons, or the v2 mutes API.
 
 ## Button Actions
 

--- a/docs/superpowers/specs/2026-06-11-mute-api-design.md
+++ b/docs/superpowers/specs/2026-06-11-mute-api-design.md
@@ -42,12 +42,20 @@ params rejected (422); human must exist (404 otherwise).
 |---|---|---|
 | `GET` | `/api/v2/humans/{id}/mutes` | `{mutes:[<item>…]}` — **active** entries only (expired-but-unswept are filtered) |
 | `POST` | `/api/v2/humans/{id}/mutes` | Body `{scope, value?, duration_min?}` → `{mute:<item>, replaced:bool}`. Re-muting the same `(scope,value)` replaces the entry (extends expiry) and sets `replaced:true`, mirroring `Store.Add` |
-| `DELETE` | `/api/v2/humans/{id}/mutes?scope=&value=` | Remove one entry → `{removed:1}`; 404 when no matching mute exists |
-| `DELETE` | `/api/v2/humans/{id}/mutes` | No params: remove **all** the user's mutes → `{removed:n}` (n may be 0) |
+| `DELETE` | `/api/v2/humans/{id}/mutes?scope=&value=` | Remove one entry → `{deleted:[<item>]}`; 404 when no matching mute exists |
+| `DELETE` | `/api/v2/humans/{id}/mutes` | No params: remove **all** the user's mutes → `{deleted:[<item>…]}` (empty array when none) |
 
 `DELETE` with `scope` but a missing-yet-required `value` (any scope except `everything`)
 is a 422, as is `value` without `scope`. `scope=everything` takes no value in DELETE just
 as in POST.
+
+Response-shape conformance: DELETE returns the removed entries (`{deleted:[…]}`),
+mirroring v2 tracking's delete shape. POST returns `{mute:<item>, replaced:bool}` — a
+deliberate typed struct rather than the humans-action `{status:ok}`, permitted by the
+design doc's "status plus extra fields keep their own typed structs" rule; it returns the
+canonical entry (computed `expires_at`) so clients don't need a follow-up GET, and
+`replaced` mirrors the bot's muted/re-muted distinction. Unknown human → 404 via the same
+`GetLite` lookup as v2 tracking's `resolveHuman`.
 
 ## Item schema
 

--- a/docs/superpowers/specs/2026-06-11-mute-api-design.md
+++ b/docs/superpowers/specs/2026-06-11-mute-api-design.md
@@ -1,0 +1,104 @@
+# Mute API (v2) — Design
+
+**Date:** 2026-06-11
+**Branch:** `mute-api`
+**Status:** Approved (brainstorm 2026-06-11)
+
+## Goal
+
+Expose the existing in-memory mute store (`internal/mute`, GitHub #109) over HTTP so API
+clients (PoracleWeb and custom integrations) can list, create, and remove a user's mutes.
+Today mutes are reachable only via bot commands (`!mute`/`!unmute`), alert buttons, and —
+indirectly — `POST /api/command`.
+
+## Decisions (locked)
+
+1. **In-memory semantics kept.** Mutes remain volatile and are lost on restart, exactly as
+   the package documents. The API documents this on the wire; it does not add persistence.
+2. **Per-user v2 surface only.** Endpoints live under `/api/v2/humans/{id}/mutes` following
+   the v2 conventions (strict bodies, problem+json, `X-Poracle-Secret`). No global
+   all-users admin listing.
+3. **Snapshot inclusion.** `GET /api/v2/humans/{id}/tracking` gains a `mutes` array so one
+   call shows everything affecting a user's alerts.
+
+## Approach
+
+REST resource with **composite-key addressing**. A mute has no uid — its identity is
+`(scope, value)` per human (the store replaces on same-key Add). Item-level DELETE
+addresses entries by `?scope=&value=` query params rather than path segments, because
+values include area names with spaces and opaque fort ids; precedent is v2 tracking's
+`DELETE …/{type}?uid=` bulk form.
+
+Rejected alternatives: synthetic item paths `/mutes/{scope}/{value}` (path-encoding
+hazards for zero gain); action-style `POST /mutes/delete` (breaks v2 resource
+conventions).
+
+## Endpoints
+
+All on the shared huma instance; errors RFC 9457 `problem+json`; unknown body and query
+params rejected (422); human must exist (404 otherwise).
+
+| Method | Path | Behaviour |
+|---|---|---|
+| `GET` | `/api/v2/humans/{id}/mutes` | `{mutes:[<item>…]}` — **active** entries only (expired-but-unswept are filtered) |
+| `POST` | `/api/v2/humans/{id}/mutes` | Body `{scope, value?, duration_min?}` → `{mute:<item>, replaced:bool}`. Re-muting the same `(scope,value)` replaces the entry (extends expiry) and sets `replaced:true`, mirroring `Store.Add` |
+| `DELETE` | `/api/v2/humans/{id}/mutes?scope=&value=` | Remove one entry → `{removed:1}`; 404 when no matching mute exists |
+| `DELETE` | `/api/v2/humans/{id}/mutes` | No params: remove **all** the user's mutes → `{removed:n}` (n may be 0) |
+
+`DELETE` with `scope` but a missing-yet-required `value` (any scope except `everything`)
+is a 422, as is `value` without `scope`. `scope=everything` takes no value in DELETE just
+as in POST.
+
+## Item schema
+
+```json
+{ "scope": "gym", "value": "fae12cd34…", "expires_at": 1781190000, "remaining_secs": 3540 }
+```
+
+- `scope` — string enum: `gym | pokemon | area | pokestop | station | tracking | everything`.
+  These are the existing `mute.Scope*` constants, already user-visible in command syntax.
+- `value` — string; `null` for `everything`. Pokemon dex ids and tracking-rule uids are
+  numeric **strings** on the wire (the store compares strings; one honest representation).
+- `expires_at` — unix seconds.
+- `remaining_secs` — derived convenience for UIs (`Entry.RemainingAt`), never negative.
+
+Field descriptions state the volatility: in-memory, cleared by processor restart.
+
+## Create validation (mirrors the bot parser)
+
+- `scope` required, in the enum.
+- `value` required for every scope except `everything`, where it must be **absent**.
+- `pokemon` / `tracking` values must parse as positive integers.
+- `area` values validated case-insensitively against loaded geofence names (as
+  `!mute area` does); stored as given.
+- `duration_min` optional int, default **60**, bounds **1–10080** (one week).
+- A `tracking` uid is **not** ownership-checked: a wrong uid never matches anything
+  (harmless), and checking would mean scanning all ten rule-type stores per call.
+
+## Snapshot change
+
+`GET /api/v2/humans/{id}/tracking` response gains `"mutes": [<item>…]` — always present,
+`[]` when none, same item schema and active-only filtering as the list endpoint.
+
+## Implementation shape
+
+- New `internal/api/v2_mutes.go` + `v2_mutes_test.go`, following the `RegisterV2*`
+  pattern; registered from `main.go` alongside the other v2 humans sub-resources and in
+  `registerAllHumaOpsForTest` for the golden spec.
+- Deps: the existing `*mute.Store` (already on `ProcessorService`), `store.HumanStore`
+  (existence check), and the state manager (area-name validation).
+- Store addition: `ListActive(humanID string, now int64) []Entry` — like `List` but
+  skipping expired entries, so list/snapshot don't surface entries the sweeper hasn't
+  reaped yet. No other store changes.
+- Snapshot: `v2_snapshot.go` adds the `Mutes` field, populated via the same helper that
+  converts `mute.Entry` → wire item.
+- No state reload, no dispatcher interaction, no DB.
+
+## Testing
+
+- httptest unit tests: create (fresh + replace), default and bounded duration, every
+  validation rejection (bad scope, missing/forbidden value, non-numeric pokemon/tracking,
+  unknown area, duration out of bounds), unknown human 404, list filters expired entries,
+  delete one / delete all / delete miss 404, snapshot includes mutes.
+- Golden OpenAPI spec regenerated; new schemas pinned.
+- Docs: API surface notes in CLAUDE.md (Mute Infrastructure section) + CHANGELOG entry.

--- a/processor/cmd/processor/main.go
+++ b/processor/cmd/processor/main.go
@@ -427,6 +427,7 @@ func main() {
 		Translations: proc.enricher.Translations,
 		Dispatcher:   proc.dispatcher,
 		Summaries:    summaryScheduleStore,
+		Mutes:        proc.muteStore,
 		ReloadFunc:   proc.triggerReload,
 	}
 	// Strict v2 tracking surface (huma). v1 gin routes below are left untouched
@@ -459,6 +460,10 @@ func main() {
 	// profile actions with a strict typed active_hours schema; v1 gin profile
 	// routes stay frozen.
 	api.RegisterV2Profiles(humaAPI, trackingDeps)
+
+	// Strict v2 mutes surface (huma, sub-resource of human) over the in-memory
+	// mute store — net-new in v2 (the bot/buttons were the only mute writers).
+	api.RegisterV2Mutes(humaAPI, trackingDeps)
 
 	tracking := apiGroup.Group("/tracking")
 	tracking.GET("/pokemon/refresh", api.HandleReload(func() error {

--- a/processor/internal/api/huma_openapi_golden_test.go
+++ b/processor/internal/api/huma_openapi_golden_test.go
@@ -135,10 +135,11 @@ func registerAllHumaOpsForTest(humaAPI huma.API) {
 	RegisterV2TrackingIncident(humaAPI, trackingDeps)
 	RegisterV2TrackingSnapshot(humaAPI, trackingDeps) // MUST follow per-type.
 
-	// Strict v2 humans / locations / profiles.
+	// Strict v2 humans / locations / profiles / mutes.
 	RegisterV2Humans(humaAPI, trackingDeps)
 	RegisterV2Locations(humaAPI, trackingDeps)
 	RegisterV2Profiles(humaAPI, trackingDeps)
+	RegisterV2Mutes(humaAPI, trackingDeps)
 
 	// Strict v2 roles.
 	RegisterV2Roles(humaAPI, &RoleDeps{})

--- a/processor/internal/api/testdata/openapi.golden.json
+++ b/processor/internal/api/testdata/openapi.golden.json
@@ -2850,6 +2850,56 @@
         ],
         "type": "object"
       },
+      "V2CreateMuteInputBody": {
+        "additionalProperties": false,
+        "properties": {
+          "duration_min": {
+            "description": "Mute length in minutes. Defaults to 60; maximum one week (10080).",
+            "format": "int64",
+            "maximum": 10080,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "scope": {
+            "description": "Mute scope. value is required for every scope except 'everything', where it must be absent.",
+            "enum": [
+              "gym",
+              "pokemon",
+              "area",
+              "pokestop",
+              "station",
+              "tracking",
+              "everything"
+            ],
+            "type": "string"
+          },
+          "value": {
+            "description": "Scope identifier: gym/pokestop/station id, pokemon dex id or tracking-rule uid (numeric string), or area name (matched case-insensitively against loaded geofences).",
+            "type": "string"
+          }
+        },
+        "required": [
+          "scope"
+        ],
+        "type": "object"
+      },
+      "V2CreateMuteOutputBody": {
+        "additionalProperties": false,
+        "properties": {
+          "mute": {
+            "$ref": "#/components/schemas/V2MuteItem"
+          },
+          "replaced": {
+            "description": "True when an existing mute with the same scope and value was extended rather than a new one created.",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "mute",
+          "replaced"
+        ],
+        "type": "object"
+      },
       "V2CreateOutputV2EggRuleBody": {
         "additionalProperties": false,
         "properties": {
@@ -8686,6 +8736,25 @@
         ],
         "type": "object"
       },
+      "V2DeletedMutesOutputBody": {
+        "additionalProperties": false,
+        "properties": {
+          "deleted": {
+            "description": "The removed mutes (empty when a delete-all found none).",
+            "items": {
+              "$ref": "#/components/schemas/V2MuteItem"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "deleted"
+        ],
+        "type": "object"
+      },
       "V2EggRule": {
         "additionalProperties": false,
         "properties": {
@@ -10883,6 +10952,67 @@
         },
         "type": "object"
       },
+      "V2MuteItem": {
+        "additionalProperties": false,
+        "properties": {
+          "expires_at": {
+            "description": "Unix seconds when the mute lapses.",
+            "format": "int64",
+            "type": "integer"
+          },
+          "remaining_secs": {
+            "description": "Seconds until expiry at response time (UI convenience, derived from expires_at).",
+            "format": "int64",
+            "type": "integer"
+          },
+          "scope": {
+            "description": "What the mute suppresses: a specific gym/pokestop/station (by id), a pokemon species (by dex id), a geofence area (by name), one tracking rule (by uid), or everything.",
+            "enum": [
+              "gym",
+              "pokemon",
+              "area",
+              "pokestop",
+              "station",
+              "tracking",
+              "everything"
+            ],
+            "type": "string"
+          },
+          "value": {
+            "description": "Scope-specific identifier (gym/pokestop/station id, dex id or rule uid as a numeric string, canonical area name). Null for scope=everything.",
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "scope",
+          "value",
+          "expires_at",
+          "remaining_secs"
+        ],
+        "type": "object"
+      },
+      "V2MutesOutputBody": {
+        "additionalProperties": false,
+        "properties": {
+          "mutes": {
+            "description": "Active (non-expired) mutes. Mutes are held in memory only and are cleared by a processor restart.",
+            "items": {
+              "$ref": "#/components/schemas/V2MuteItem"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "mutes"
+        ],
+        "type": "object"
+      },
       "V2NestRule": {
         "additionalProperties": false,
         "properties": {
@@ -11631,6 +11761,16 @@
           "locations": {
             "$ref": "#/components/schemas/LocationsPayload"
           },
+          "mutes": {
+            "description": "Active (non-expired) alert mutes — same items as GET …/mutes. Mutes are held in memory only and are cleared by a processor restart.",
+            "items": {
+              "$ref": "#/components/schemas/V2MuteItem"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
           "profiles": {
             "items": {
               "$ref": "#/components/schemas/ProfileResponse"
@@ -11665,7 +11805,8 @@
           "tracking",
           "profiles",
           "locations",
-          "summaries"
+          "summaries",
+          "mutes"
         ],
         "type": "object"
       },
@@ -15190,6 +15331,188 @@
         "summary": "Update a saved location's coords",
         "tags": [
           "v2-locations"
+        ]
+      }
+    },
+    "/v2/humans/{id}/mutes": {
+      "delete": {
+        "description": "With ?scope= (and ?value= for every scope except 'everything'): removes that single mute, 404 when it does not exist. With no params: removes every mute the human has. Returns the removed entries.",
+        "operationId": "v2-delete-human-mutes",
+        "parameters": [
+          {
+            "description": "Human id (the owning user)",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "description": "Human id (the owning user)",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Scope of the mute to remove. Omit (together with value) to remove all mutes.",
+            "explode": false,
+            "in": "query",
+            "name": "scope",
+            "schema": {
+              "description": "Scope of the mute to remove. Omit (together with value) to remove all mutes.",
+              "enum": [
+                "gym",
+                "pokemon",
+                "area",
+                "pokestop",
+                "station",
+                "tracking",
+                "everything"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Value of the mute to remove, as returned by the list endpoint. Required with scope, except scope=everything which takes none.",
+            "explode": false,
+            "in": "query",
+            "name": "value",
+            "schema": {
+              "description": "Value of the mute to remove, as returned by the list endpoint. Required with scope, except scope=everything which takes none.",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/V2DeletedMutesOutputBody"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "default": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            },
+            "description": "Error"
+          }
+        },
+        "security": [
+          {
+            "poracleSecret": []
+          }
+        ],
+        "summary": "Remove one mute or all mutes",
+        "tags": [
+          "v2-mutes"
+        ]
+      },
+      "get": {
+        "description": "Returns the human's active (non-expired) alert mutes. Mutes are held in memory only and are cleared by a processor restart.",
+        "operationId": "v2-list-human-mutes",
+        "parameters": [
+          {
+            "description": "Human id (the owning user)",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "description": "Human id (the owning user)",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/V2MutesOutputBody"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "default": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            },
+            "description": "Error"
+          }
+        },
+        "security": [
+          {
+            "poracleSecret": []
+          }
+        ],
+        "summary": "List a human's active mutes",
+        "tags": [
+          "v2-mutes"
+        ]
+      },
+      "post": {
+        "description": "Suppresses the human's alerts matching the scope for duration_min minutes (default 60, max one week). Re-muting the same scope+value extends the expiry and reports replaced=true. Mutes are held in memory only and are cleared by a processor restart.",
+        "operationId": "v2-create-human-mute",
+        "parameters": [
+          {
+            "description": "Human id (the owning user)",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "description": "Human id (the owning user)",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/V2CreateMuteInputBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/V2CreateMuteOutputBody"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "default": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            },
+            "description": "Error"
+          }
+        },
+        "security": [
+          {
+            "poracleSecret": []
+          }
+        ],
+        "summary": "Mute alerts for a scope",
+        "tags": [
+          "v2-mutes"
         ]
       }
     },

--- a/processor/internal/api/tracking.go
+++ b/processor/internal/api/tracking.go
@@ -16,6 +16,7 @@ import (
 	"github.com/pokemon/poracleng/processor/internal/db"
 	"github.com/pokemon/poracleng/processor/internal/delivery"
 	"github.com/pokemon/poracleng/processor/internal/i18n"
+	"github.com/pokemon/poracleng/processor/internal/mute"
 	"github.com/pokemon/poracleng/processor/internal/rowtext"
 	"github.com/pokemon/poracleng/processor/internal/state"
 	"github.com/pokemon/poracleng/processor/internal/store"
@@ -33,6 +34,7 @@ type TrackingDeps struct {
 	Dispatcher   *delivery.Dispatcher
 	AreaLogic    *bot.AreaLogic             // nil-safe: area validation skipped when nil
 	Summaries    store.SummaryScheduleStore // nil-safe: snapshot summaries omitted when nil
+	Mutes        *mute.Store                // in-memory mute store (v2 mutes endpoints + snapshot mutes; nil-safe in snapshot, required by RegisterV2Mutes)
 	ReloadFunc   func()                     // triggers debounced state reload (from ProcessorService.triggerReload)
 
 	// v2SnapshotProviders is the per-instance registry of type-erased snapshot

--- a/processor/internal/api/v2_mutes.go
+++ b/processor/internal/api/v2_mutes.go
@@ -1,0 +1,269 @@
+package api
+
+import (
+	"context"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/danielgtaylor/huma/v2"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/pokemon/poracleng/processor/internal/mute"
+	"github.com/pokemon/poracleng/processor/internal/store"
+)
+
+// v2_mutes.go is the strict /api/v2 surface over the in-memory mute store
+// (internal/mute, #109). Design: docs/superpowers/specs/2026-06-11-mute-api-design.md.
+//
+// Mutes are deliberately volatile — lost on processor restart — and this API
+// keeps those semantics; the wire descriptions say so. A mute has no uid: its
+// identity is (scope, value) per human, so item deletion addresses entries via
+// ?scope=&value= query params (area names and fort ids are hostile to path
+// segments). DELETE returns the removed entries ({deleted:[…]}) mirroring v2
+// tracking's delete shape; POST returns the canonical entry plus a replaced
+// flag (re-muting the same scope+value extends expiry, like Store.Add and the
+// bot's muted/re-muted distinction).
+
+const (
+	// muteDefaultDuration (minutes) matches the bot and button default. The
+	// scope enum and the 10080-minute (one week) duration ceiling live in the
+	// struct tags below — Go struct tags must be literals.
+	muteDefaultDuration = 60
+	muteVolatilityNote  = "Mutes are held in memory only and are cleared by a processor restart."
+)
+
+// v2MuteItem is one active mute on the wire.
+type v2MuteItem struct {
+	Scope         string  `json:"scope" enum:"gym,pokemon,area,pokestop,station,tracking,everything" doc:"What the mute suppresses: a specific gym/pokestop/station (by id), a pokemon species (by dex id), a geofence area (by name), one tracking rule (by uid), or everything."`
+	Value         *string `json:"value" doc:"Scope-specific identifier (gym/pokestop/station id, dex id or rule uid as a numeric string, canonical area name). Null for scope=everything."`
+	ExpiresAt     int64   `json:"expires_at" doc:"Unix seconds when the mute lapses."`
+	RemainingSecs int64   `json:"remaining_secs" doc:"Seconds until expiry at response time (UI convenience, derived from expires_at)."`
+}
+
+// v2MutesOutput is the GET list response: {mutes:[…]}.
+type v2MutesOutput struct {
+	Body struct {
+		Mutes []v2MuteItem `json:"mutes" doc:"Active (non-expired) mutes. Mutes are held in memory only and are cleared by a processor restart."`
+	}
+}
+
+// v2CreateMuteInput is the POST body: scope + value + optional duration.
+type v2CreateMuteInput struct {
+	ID   string `path:"id" doc:"Human id (the owning user)"`
+	Body struct {
+		Scope       string `json:"scope" enum:"gym,pokemon,area,pokestop,station,tracking,everything" doc:"Mute scope. value is required for every scope except 'everything', where it must be absent."`
+		Value       string `json:"value,omitempty" required:"false" doc:"Scope identifier: gym/pokestop/station id, pokemon dex id or tracking-rule uid (numeric string), or area name (matched case-insensitively against loaded geofences)."`
+		DurationMin int    `json:"duration_min,omitempty" required:"false" minimum:"1" maximum:"10080" doc:"Mute length in minutes. Defaults to 60; maximum one week (10080)."`
+	}
+}
+
+// v2CreateMuteOutput is the POST response: the canonical entry + replaced flag.
+type v2CreateMuteOutput struct {
+	Body struct {
+		Mute     v2MuteItem `json:"mute"`
+		Replaced bool       `json:"replaced" doc:"True when an existing mute with the same scope and value was extended rather than a new one created."`
+	}
+}
+
+// v2DeleteMutesInput addresses one entry (scope+value), one everything-mute
+// (scope only), or — with no params — every mute the human has.
+type v2DeleteMutesInput struct {
+	ID    string `path:"id" doc:"Human id (the owning user)"`
+	Scope string `query:"scope" enum:"gym,pokemon,area,pokestop,station,tracking,everything" required:"false" doc:"Scope of the mute to remove. Omit (together with value) to remove all mutes."`
+	Value string `query:"value" required:"false" doc:"Value of the mute to remove, as returned by the list endpoint. Required with scope, except scope=everything which takes none."`
+}
+
+// v2DeletedMutesOutput mirrors v2 tracking's delete shape: {deleted:[…]}.
+type v2DeletedMutesOutput struct {
+	Body struct {
+		Deleted []v2MuteItem `json:"deleted" doc:"The removed mutes (empty when a delete-all found none)."`
+	}
+}
+
+// muteEntryToItem converts a store entry to the wire item. Value is
+// present-but-null for scope=everything, matching the v2 null conventions.
+func muteEntryToItem(e mute.Entry, now int64) v2MuteItem {
+	item := v2MuteItem{Scope: e.ScopeType, ExpiresAt: e.ExpiresAt}
+	if e.ScopeType != mute.ScopeEverything {
+		v := e.ScopeValue
+		item.Value = &v
+	}
+	if rem := e.ExpiresAt - now; rem > 0 {
+		item.RemainingSecs = rem
+	}
+	return item
+}
+
+// muteResolveHuman 404s when the human does not exist; returns the full record
+// (community membership feeds area validation).
+func muteResolveHuman(deps *TrackingDeps, id string) (*store.Human, error) {
+	human, err := deps.Humans.Get(id)
+	if err != nil {
+		log.Errorf("v2 mutes: human lookup %s: %s", id, err)
+		return nil, huma.Error500InternalServerError("database error")
+	}
+	if human == nil {
+		return nil, huma.Error404NotFound("human not found")
+	}
+	return human, nil
+}
+
+// validateMuteValue applies the per-scope value rules shared with the bot
+// parser: required except for everything (where it is forbidden), numeric for
+// pokemon/tracking, and a known geofence area for area (canonicalised).
+// Returns the value to store.
+func validateMuteValue(deps *TrackingDeps, human *store.Human, scope, value string) (string, error) {
+	if scope == mute.ScopeEverything {
+		if value != "" {
+			return "", huma.Error422UnprocessableEntity("scope 'everything' takes no value")
+		}
+		return "", nil
+	}
+	if value == "" {
+		return "", huma.Error422UnprocessableEntity("value is required for scope '" + scope + "'")
+	}
+	switch scope {
+	case mute.ScopePokemon, mute.ScopeTracking:
+		if n, err := strconv.Atoi(value); err != nil || n <= 0 {
+			return "", huma.Error422UnprocessableEntity("value for scope '" + scope + "' must be a positive integer")
+		}
+	case mute.ScopeArea:
+		// Prefer AreaLogic (community-aware, like the bot); fall back to the
+		// live state's fences — production trackingDeps carries no AreaLogic,
+		// and StateMgr stays correct across geofence reloads. Both paths
+		// canonicalise the name so the stored value matches `!tracked` output.
+		if deps.AreaLogic != nil {
+			resolved, ok := deps.AreaLogic.ResolveAvailableArea(value, human.CommunityMembership, false)
+			if !ok {
+				return "", huma.Error422UnprocessableEntity("unknown area: " + value)
+			}
+			return resolved, nil
+		}
+		if deps.StateMgr != nil {
+			if st := deps.StateMgr.Get(); st != nil {
+				for _, f := range st.Fences {
+					if strings.EqualFold(f.Name, value) {
+						return f.Name, nil
+					}
+				}
+				return "", huma.Error422UnprocessableEntity("unknown area: " + value)
+			}
+		}
+	}
+	return value, nil
+}
+
+// RegisterV2Mutes registers the strict v2 mutes endpoints (list, create,
+// delete one / delete all) under /api/v2/humans/{id}/mutes.
+func RegisterV2Mutes(humaAPI huma.API, deps *TrackingDeps) {
+	tag := []string{"v2-mutes"}
+	sec := []map[string][]string{{"poracleSecret": {}}}
+
+	registerV2MutesList(humaAPI, deps, tag, sec)
+	registerV2MutesCreate(humaAPI, deps, tag, sec)
+	registerV2MutesDelete(humaAPI, deps, tag, sec)
+}
+
+func registerV2MutesList(api huma.API, deps *TrackingDeps, tag []string, sec []map[string][]string) {
+	huma.Register(api, huma.Operation{
+		OperationID: "v2-list-human-mutes", Method: "GET", Path: "/v2/humans/{id}/mutes",
+		Summary:     "List a human's active mutes",
+		Description: "Returns the human's active (non-expired) alert mutes. " + muteVolatilityNote,
+		Tags:        tag, Security: sec, RejectUnknownQueryParameters: true,
+	}, func(_ context.Context, in *v2HumanIDInput) (*v2MutesOutput, error) {
+		if _, err := muteResolveHuman(deps, in.ID); err != nil {
+			return nil, err
+		}
+		now := time.Now().Unix()
+		out := &v2MutesOutput{}
+		out.Body.Mutes = make([]v2MuteItem, 0)
+		for _, e := range deps.Mutes.ListActive(in.ID, now) {
+			out.Body.Mutes = append(out.Body.Mutes, muteEntryToItem(e, now))
+		}
+		return out, nil
+	})
+}
+
+func registerV2MutesCreate(api huma.API, deps *TrackingDeps, tag []string, sec []map[string][]string) {
+	huma.Register(api, huma.Operation{
+		OperationID: "v2-create-human-mute", Method: "POST", Path: "/v2/humans/{id}/mutes",
+		Summary:     "Mute alerts for a scope",
+		Description: "Suppresses the human's alerts matching the scope for duration_min minutes (default 60, max one week). Re-muting the same scope+value extends the expiry and reports replaced=true. " + muteVolatilityNote,
+		Tags:        tag, Security: sec, RejectUnknownQueryParameters: true,
+	}, func(_ context.Context, in *v2CreateMuteInput) (*v2CreateMuteOutput, error) {
+		human, err := muteResolveHuman(deps, in.ID)
+		if err != nil {
+			return nil, err
+		}
+		value, err := validateMuteValue(deps, human, in.Body.Scope, in.Body.Value)
+		if err != nil {
+			return nil, err
+		}
+		duration := in.Body.DurationMin
+		if duration == 0 {
+			duration = muteDefaultDuration
+		}
+		now := time.Now().Unix()
+		entry := mute.Entry{
+			HumanID:    in.ID,
+			ScopeType:  in.Body.Scope,
+			ScopeValue: value,
+			ExpiresAt:  now + int64(duration)*60,
+		}
+		replaced := deps.Mutes.Add(entry)
+		out := &v2CreateMuteOutput{}
+		out.Body.Mute = muteEntryToItem(entry, now)
+		out.Body.Replaced = replaced
+		return out, nil
+	})
+}
+
+func registerV2MutesDelete(api huma.API, deps *TrackingDeps, tag []string, sec []map[string][]string) {
+	huma.Register(api, huma.Operation{
+		OperationID: "v2-delete-human-mutes", Method: "DELETE", Path: "/v2/humans/{id}/mutes",
+		Summary:     "Remove one mute or all mutes",
+		Description: "With ?scope= (and ?value= for every scope except 'everything'): removes that single mute, 404 when it does not exist. With no params: removes every mute the human has. Returns the removed entries.",
+		Tags:        tag, Security: sec, RejectUnknownQueryParameters: true,
+	}, func(_ context.Context, in *v2DeleteMutesInput) (*v2DeletedMutesOutput, error) {
+		if _, err := muteResolveHuman(deps, in.ID); err != nil {
+			return nil, err
+		}
+		now := time.Now().Unix()
+		out := &v2DeletedMutesOutput{}
+		out.Body.Deleted = make([]v2MuteItem, 0)
+
+		// Delete-all: no scope, no value.
+		if in.Scope == "" && in.Value == "" {
+			for _, e := range deps.Mutes.ListActive(in.ID, now) {
+				out.Body.Deleted = append(out.Body.Deleted, muteEntryToItem(e, now))
+			}
+			deps.Mutes.RemoveAll(in.ID)
+			return out, nil
+		}
+		if in.Scope == "" {
+			return nil, huma.Error422UnprocessableEntity("value requires scope")
+		}
+		if in.Scope == mute.ScopeEverything && in.Value != "" {
+			return nil, huma.Error422UnprocessableEntity("scope 'everything' takes no value")
+		}
+		if in.Scope != mute.ScopeEverything && in.Value == "" {
+			return nil, huma.Error422UnprocessableEntity("value is required for scope '" + in.Scope + "'")
+		}
+
+		// Snapshot the entry first so the response can carry it.
+		var found *mute.Entry
+		for _, e := range deps.Mutes.List(in.ID) {
+			if e.ScopeType == in.Scope && e.ScopeValue == in.Value {
+				cp := e
+				found = &cp
+				break
+			}
+		}
+		if found == nil || !deps.Mutes.Remove(in.ID, in.Scope, in.Value) {
+			return nil, huma.Error404NotFound("mute not found")
+		}
+		out.Body.Deleted = append(out.Body.Deleted, muteEntryToItem(*found, now))
+		return out, nil
+	})
+}

--- a/processor/internal/api/v2_mutes_test.go
+++ b/processor/internal/api/v2_mutes_test.go
@@ -1,0 +1,373 @@
+package api
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/pokemon/poracleng/processor/internal/bot"
+	"github.com/pokemon/poracleng/processor/internal/config"
+	"github.com/pokemon/poracleng/processor/internal/geofence"
+	"github.com/pokemon/poracleng/processor/internal/mute"
+	"github.com/pokemon/poracleng/processor/internal/state"
+	"github.com/pokemon/poracleng/processor/internal/store"
+)
+
+// newV2MutesTestAPI wires the strict v2 mutes endpoints against a mock human
+// store, a fresh in-memory mute store, and an AreaLogic with one fence
+// ("london") so area-name validation is exercised.
+func newV2MutesTestAPI(t *testing.T) (*gin.Engine, *mute.Store) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	humaAPI := NewHumaAPI(r, r.Group("/api"), "test")
+
+	humans := store.NewMockHumanStore()
+	humans.AddHuman(&store.Human{
+		ID: "u1", Type: "discord:user", Name: "User1", Enabled: true,
+		Language: "en", CurrentProfileNo: 1,
+	})
+
+	cfg := &config.Config{}
+	fences := []geofence.Fence{{Name: "london", UserSelectable: true}}
+	mutes := mute.NewStore()
+	deps := &TrackingDeps{
+		Humans:    humans,
+		Config:    cfg,
+		AreaLogic: bot.NewAreaLogic(fences, cfg),
+		Mutes:     mutes,
+	}
+
+	RegisterV2Mutes(humaAPI, deps)
+	return r, mutes
+}
+
+// --- create -------------------------------------------------------------------
+
+func TestV2Mutes_Create_Fresh(t *testing.T) {
+	r, mutes := newV2MutesTestAPI(t)
+	w := v2DoReq(t, r, http.MethodPost, "/api/v2/humans/u1/mutes",
+		`{"scope":"gym","value":"gym123","duration_min":120}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	body := v2DecodeBody(t, w)
+	if body["replaced"] != false {
+		t.Fatalf("expected replaced=false on fresh mute, got %v", body)
+	}
+	item, ok := body["mute"].(map[string]any)
+	if !ok {
+		t.Fatalf("missing mute item: %v", body)
+	}
+	if item["scope"] != "gym" || item["value"] != "gym123" {
+		t.Fatalf("unexpected item: %v", item)
+	}
+	now := time.Now().Unix()
+	exp, _ := item["expires_at"].(float64)
+	if int64(exp) < now+119*60 || int64(exp) > now+121*60 {
+		t.Fatalf("expires_at not ~120min out: %v (now %d)", item["expires_at"], now)
+	}
+	if rem, _ := item["remaining_secs"].(float64); rem <= 0 || rem > 120*60 {
+		t.Fatalf("remaining_secs out of range: %v", item["remaining_secs"])
+	}
+	// The store actually filters alerts for it.
+	if !mutes.Match("u1", mute.Event{GymID: "gym123"}, now) {
+		t.Fatalf("store does not match created mute")
+	}
+}
+
+func TestV2Mutes_Create_DefaultDuration(t *testing.T) {
+	r, _ := newV2MutesTestAPI(t)
+	w := v2DoReq(t, r, http.MethodPost, "/api/v2/humans/u1/mutes", `{"scope":"pokemon","value":"25"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	item := v2DecodeBody(t, w)["mute"].(map[string]any)
+	now := time.Now().Unix()
+	exp := int64(item["expires_at"].(float64))
+	if exp < now+59*60 || exp > now+61*60 {
+		t.Fatalf("default duration not ~60min: expires_at %d (now %d)", exp, now)
+	}
+}
+
+func TestV2Mutes_Create_Replace(t *testing.T) {
+	r, _ := newV2MutesTestAPI(t)
+	for range 2 {
+		w := v2DoReq(t, r, http.MethodPost, "/api/v2/humans/u1/mutes", `{"scope":"gym","value":"g1"}`)
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+	}
+	// Second create of the same (scope,value) reports replaced and does not duplicate.
+	w := v2DoReq(t, r, http.MethodPost, "/api/v2/humans/u1/mutes", `{"scope":"gym","value":"g1"}`)
+	if body := v2DecodeBody(t, w); body["replaced"] != true {
+		t.Fatalf("expected replaced=true, got %v", body)
+	}
+	lw := v2DoReq(t, r, http.MethodGet, "/api/v2/humans/u1/mutes", "")
+	if items := v2DecodeBody(t, lw)["mutes"].([]any); len(items) != 1 {
+		t.Fatalf("expected 1 entry after re-mute, got %d", len(items))
+	}
+}
+
+func TestV2Mutes_Create_Everything_NoValue(t *testing.T) {
+	r, mutes := newV2MutesTestAPI(t)
+	w := v2DoReq(t, r, http.MethodPost, "/api/v2/humans/u1/mutes", `{"scope":"everything"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	item := v2DecodeBody(t, w)["mute"].(map[string]any)
+	if v, present := item["value"]; !present || v != nil {
+		t.Fatalf("expected value present-but-null for everything, got %v", item)
+	}
+	if !mutes.Match("u1", mute.Event{GymID: "anything"}, time.Now().Unix()) {
+		t.Fatalf("everything mute does not match")
+	}
+}
+
+func TestV2Mutes_Create_Area_CanonicalisesName(t *testing.T) {
+	r, mutes := newV2MutesTestAPI(t)
+	w := v2DoReq(t, r, http.MethodPost, "/api/v2/humans/u1/mutes", `{"scope":"area","value":"LONDON"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if !mutes.Match("u1", mute.Event{Area: []string{"london"}}, time.Now().Unix()) {
+		t.Fatalf("area mute does not match canonical name")
+	}
+}
+
+func TestV2Mutes_Create_Validation(t *testing.T) {
+	r, _ := newV2MutesTestAPI(t)
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"bad scope", `{"scope":"weather","value":"x"}`},
+		{"missing value", `{"scope":"gym"}`},
+		{"everything with value", `{"scope":"everything","value":"x"}`},
+		{"pokemon non-numeric", `{"scope":"pokemon","value":"pikachu"}`},
+		{"tracking non-numeric", `{"scope":"tracking","value":"abc"}`},
+		{"unknown area", `{"scope":"area","value":"atlantis"}`},
+		{"duration too small", `{"scope":"gym","value":"g1","duration_min":0}`},
+		{"duration too large", `{"scope":"gym","value":"g1","duration_min":10081}`},
+		{"unknown field", `{"scope":"gym","value":"g1","bogus":1}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			w := v2DoReq(t, r, http.MethodPost, "/api/v2/humans/u1/mutes", tc.body)
+			if w.Code != http.StatusUnprocessableEntity {
+				t.Fatalf("expected 422, got %d: %s", w.Code, w.Body.String())
+			}
+		})
+	}
+}
+
+func TestV2Mutes_Create_UnknownHuman404(t *testing.T) {
+	r, _ := newV2MutesTestAPI(t)
+	w := v2DoReq(t, r, http.MethodPost, "/api/v2/humans/ghost/mutes", `{"scope":"gym","value":"g1"}`)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// --- list ---------------------------------------------------------------------
+
+func TestV2Mutes_List_FiltersExpired(t *testing.T) {
+	r, mutes := newV2MutesTestAPI(t)
+	now := time.Now().Unix()
+	mutes.Add(mute.Entry{HumanID: "u1", ScopeType: mute.ScopeGym, ScopeValue: "live", ExpiresAt: now + 600})
+	mutes.Add(mute.Entry{HumanID: "u1", ScopeType: mute.ScopeGym, ScopeValue: "dead", ExpiresAt: now - 600})
+
+	w := v2DoReq(t, r, http.MethodGet, "/api/v2/humans/u1/mutes", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	items := v2DecodeBody(t, w)["mutes"].([]any)
+	if len(items) != 1 {
+		t.Fatalf("expected 1 active mute, got %d: %v", len(items), items)
+	}
+	if items[0].(map[string]any)["value"] != "live" {
+		t.Fatalf("expected the live entry, got %v", items[0])
+	}
+}
+
+func TestV2Mutes_List_EmptyArray(t *testing.T) {
+	r, _ := newV2MutesTestAPI(t)
+	w := v2DoReq(t, r, http.MethodGet, "/api/v2/humans/u1/mutes", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if items, ok := v2DecodeBody(t, w)["mutes"].([]any); !ok || len(items) != 0 {
+		t.Fatalf("expected empty mutes array, got %s", w.Body.String())
+	}
+}
+
+func TestV2Mutes_List_UnknownHuman404(t *testing.T) {
+	r, _ := newV2MutesTestAPI(t)
+	w := v2DoReq(t, r, http.MethodGet, "/api/v2/humans/ghost/mutes", "")
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// --- delete -------------------------------------------------------------------
+
+func TestV2Mutes_DeleteOne(t *testing.T) {
+	r, mutes := newV2MutesTestAPI(t)
+	now := time.Now().Unix()
+	mutes.Add(mute.Entry{HumanID: "u1", ScopeType: mute.ScopeGym, ScopeValue: "g1", ExpiresAt: now + 600})
+	mutes.Add(mute.Entry{HumanID: "u1", ScopeType: mute.ScopePokemon, ScopeValue: "25", ExpiresAt: now + 600})
+
+	w := v2DoReq(t, r, http.MethodDelete, "/api/v2/humans/u1/mutes?scope=gym&value=g1", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	deleted := v2DecodeBody(t, w)["deleted"].([]any)
+	if len(deleted) != 1 || deleted[0].(map[string]any)["value"] != "g1" {
+		t.Fatalf("expected deleted gym g1, got %v", deleted)
+	}
+	if mutes.Match("u1", mute.Event{GymID: "g1"}, now) {
+		t.Fatalf("gym mute survived delete")
+	}
+	if !mutes.Match("u1", mute.Event{PokemonID: 25}, now) {
+		t.Fatalf("pokemon mute should be untouched")
+	}
+}
+
+func TestV2Mutes_DeleteEverythingScope_NoValue(t *testing.T) {
+	r, mutes := newV2MutesTestAPI(t)
+	mutes.Add(mute.Entry{HumanID: "u1", ScopeType: mute.ScopeEverything, ExpiresAt: time.Now().Unix() + 600})
+	w := v2DoReq(t, r, http.MethodDelete, "/api/v2/humans/u1/mutes?scope=everything", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestV2Mutes_DeleteAll(t *testing.T) {
+	r, mutes := newV2MutesTestAPI(t)
+	now := time.Now().Unix()
+	mutes.Add(mute.Entry{HumanID: "u1", ScopeType: mute.ScopeGym, ScopeValue: "g1", ExpiresAt: now + 600})
+	mutes.Add(mute.Entry{HumanID: "u1", ScopeType: mute.ScopePokemon, ScopeValue: "25", ExpiresAt: now + 600})
+
+	w := v2DoReq(t, r, http.MethodDelete, "/api/v2/humans/u1/mutes", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if deleted := v2DecodeBody(t, w)["deleted"].([]any); len(deleted) != 2 {
+		t.Fatalf("expected 2 deleted, got %v", deleted)
+	}
+	if len(mutes.List("u1")) != 0 {
+		t.Fatalf("entries survived delete-all")
+	}
+}
+
+func TestV2Mutes_DeleteAll_EmptyOK(t *testing.T) {
+	r, _ := newV2MutesTestAPI(t)
+	w := v2DoReq(t, r, http.MethodDelete, "/api/v2/humans/u1/mutes", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 for empty delete-all, got %d: %s", w.Code, w.Body.String())
+	}
+	if deleted := v2DecodeBody(t, w)["deleted"].([]any); len(deleted) != 0 {
+		t.Fatalf("expected empty deleted array, got %v", deleted)
+	}
+}
+
+func TestV2Mutes_Delete_Validation(t *testing.T) {
+	r, _ := newV2MutesTestAPI(t)
+	for _, q := range []string{
+		"?scope=gym",          // value required for gym
+		"?value=g1",           // value without scope
+		"?scope=weather&value=x", // unknown scope
+		"?scope=everything&value=x", // everything takes no value
+	} {
+		t.Run(q, func(t *testing.T) {
+			w := v2DoReq(t, r, http.MethodDelete, "/api/v2/humans/u1/mutes"+q, "")
+			if w.Code != http.StatusUnprocessableEntity {
+				t.Fatalf("expected 422 for %q, got %d: %s", q, w.Code, w.Body.String())
+			}
+		})
+	}
+}
+
+func TestV2Mutes_Delete_Miss404(t *testing.T) {
+	r, _ := newV2MutesTestAPI(t)
+	w := v2DoReq(t, r, http.MethodDelete, "/api/v2/humans/u1/mutes?scope=gym&value=nothere", "")
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for missing mute, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestV2Mutes_RejectUnknownQuery(t *testing.T) {
+	r, _ := newV2MutesTestAPI(t)
+	w := v2DoReq(t, r, http.MethodGet, "/api/v2/humans/u1/mutes?bogus=1", "")
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("expected 422 for unknown query param, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// --- snapshot inclusion ---------------------------------------------------------
+
+func TestV2Snapshot_IncludesMutes(t *testing.T) {
+	r, deps, restore := newV2SnapshotTestAPI(t)
+	defer restore()
+	deps.Mutes = mute.NewStore()
+	now := time.Now().Unix()
+	deps.Mutes.Add(mute.Entry{HumanID: "u1", ScopeType: mute.ScopeGym, ScopeValue: "g1", ExpiresAt: now + 600})
+	deps.Mutes.Add(mute.Entry{HumanID: "u1", ScopeType: mute.ScopeGym, ScopeValue: "dead", ExpiresAt: now - 600}) // expired
+
+	body := *mustOK(t, r, http.MethodGet, "/api/v2/humans/u1/tracking", "")
+	items, ok := body["mutes"].([]any)
+	if !ok {
+		t.Fatalf("snapshot missing mutes array: %v", body["mutes"])
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected 1 active mute in snapshot, got %d: %v", len(items), items)
+	}
+	if items[0].(map[string]any)["value"] != "g1" {
+		t.Fatalf("unexpected snapshot mute: %v", items[0])
+	}
+}
+
+func TestV2Snapshot_MutesEmptyArray(t *testing.T) {
+	r, _, restore := newV2SnapshotTestAPI(t)
+	defer restore()
+	body := *mustOK(t, r, http.MethodGet, "/api/v2/humans/u1/tracking", "")
+	if items, ok := body["mutes"].([]any); !ok || len(items) != 0 {
+		t.Fatalf("expected empty mutes array in snapshot, got %v", body["mutes"])
+	}
+}
+
+// --- area validation via StateMgr fallback --------------------------------------
+
+// Production wiring has no AreaLogic on TrackingDeps; area names must still be
+// validated (and canonicalised) against the live state's fences.
+func TestV2Mutes_Create_Area_StateMgrFallback(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	humaAPI := NewHumaAPI(r, r.Group("/api"), "test")
+
+	humans := store.NewMockHumanStore()
+	humans.AddHuman(&store.Human{ID: "u1", Type: "discord:user", Name: "User1", Enabled: true, CurrentProfileNo: 1})
+
+	mgr := state.NewManager()
+	mgr.Set(&state.State{Fences: []geofence.Fence{{Name: "london", UserSelectable: true}}})
+
+	mutes := mute.NewStore()
+	deps := &TrackingDeps{Humans: humans, Config: &config.Config{}, StateMgr: mgr, Mutes: mutes}
+	RegisterV2Mutes(humaAPI, deps)
+
+	// Unknown area rejected.
+	w := v2DoReq(t, r, http.MethodPost, "/api/v2/humans/u1/mutes", `{"scope":"area","value":"atlantis"}`)
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("expected 422 for unknown area, got %d: %s", w.Code, w.Body.String())
+	}
+	// Known area accepted, canonicalised case-insensitively.
+	w = v2DoReq(t, r, http.MethodPost, "/api/v2/humans/u1/mutes", `{"scope":"area","value":"LONDON"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 for known area, got %d: %s", w.Code, w.Body.String())
+	}
+	if !mutes.Match("u1", mute.Event{Area: []string{"london"}}, time.Now().Unix()) {
+		t.Fatalf("area mute does not match after StateMgr validation")
+	}
+}

--- a/processor/internal/api/v2_snapshot.go
+++ b/processor/internal/api/v2_snapshot.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"time"
 
 	"github.com/danielgtaylor/huma/v2"
 	log "github.com/sirupsen/logrus"
@@ -44,6 +45,7 @@ type v2SnapshotBody struct {
 	Profiles  []ProfileResponse            `json:"profiles"`
 	Locations locationsPayload             `json:"locations"`
 	Summaries []summaryScheduleResponse    `json:"summaries"`
+	Mutes     []v2MuteItem                 `json:"mutes" doc:"Active (non-expired) alert mutes — same items as GET …/mutes. Mutes are held in memory only and are cleared by a processor restart."`
 }
 
 type v2SnapshotOutput struct {
@@ -102,6 +104,7 @@ func RegisterV2TrackingSnapshot(api huma.API, deps *TrackingDeps) {
 		out.Body.Profiles = profilesToResponse(profiles)
 		out.Body.Locations = snapshotLocations(deps, human.ID, humanFull)
 		out.Body.Summaries = snapshotSummaries(deps, human.ID)
+		out.Body.Mutes = snapshotMutes(deps, human.ID)
 		return out, nil
 	})
 }
@@ -127,6 +130,20 @@ func snapshotLocations(deps *TrackingDeps, id string, humanFull *store.Human) lo
 			Latitude:  humanFull.Latitude,
 			Longitude: humanFull.Longitude,
 		}
+	}
+	return out
+}
+
+// snapshotMutes returns the human's active mutes via the same conversion the
+// mutes list endpoint uses. nil store ⇒ empty (tests and minimal harnesses).
+func snapshotMutes(deps *TrackingDeps, id string) []v2MuteItem {
+	out := []v2MuteItem{}
+	if deps.Mutes == nil {
+		return out
+	}
+	now := time.Now().Unix()
+	for _, e := range deps.Mutes.ListActive(id, now) {
+		out = append(out, muteEntryToItem(e, now))
 	}
 	return out
 }

--- a/processor/internal/mute/mute.go
+++ b/processor/internal/mute/mute.go
@@ -27,10 +27,10 @@ const (
 	ScopePokestop   = "pokestop"
 	ScopeStation    = "station"
 	ScopeEverything = "everything"
-	// ScopeTracking — reserved for tracking-UID mutes. The store accepts
-	// entries with this scope (see Add); enforcement in the matcher is a
-	// Phase 2.5 follow-up that requires MatchedUser to carry the rule UID.
-	// Until then, command parsers should not produce ScopeTracking entries.
+	// ScopeTracking mutes a single tracking rule by its database UID.
+	// matchScope compares Event.MatchedRuleUID (populated per matched user
+	// in cmd/processor/helpers.go) against the entry's value. Producers:
+	// `!mute id:N`, alert buttons, and the v2 mutes API.
 	ScopeTracking = "tracking"
 )
 
@@ -142,6 +142,24 @@ func (s *Store) List(humanID string) []Entry {
 	}
 	out := make([]Entry, len(src))
 	copy(out, src)
+	return out
+}
+
+// ListActive returns the user's entries that are still active at `now`,
+// filtering out expired-but-unswept ones. Like List, the result is a
+// snapshot — safe to mutate without affecting the store. Returns nil when
+// the user has no active entries. Used by the v2 mutes API and snapshot so
+// clients never see entries the sweeper hasn't reaped yet.
+func (s *Store) ListActive(humanID string, now int64) []Entry {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	var out []Entry
+	for _, e := range s.entries[humanID] {
+		if e.ExpiresAt > 0 && e.ExpiresAt <= now {
+			continue
+		}
+		out = append(out, e)
+	}
 	return out
 }
 

--- a/processor/internal/mute/mute_test.go
+++ b/processor/internal/mute/mute_test.go
@@ -229,3 +229,38 @@ func TestRemainingAt(t *testing.T) {
 		t.Errorf("RemainingAt for ExpiresAt=0: got %v, want 0", got)
 	}
 }
+
+func TestListActive(t *testing.T) {
+	s := NewStore()
+	now := time.Now().Unix()
+
+	// Empty store: nil.
+	if got := s.ListActive("u1", now); got != nil {
+		t.Fatalf("empty store: expected nil, got %v", got)
+	}
+
+	s.Add(Entry{HumanID: "u1", ScopeType: ScopeGym, ScopeValue: "gym1", ExpiresAt: now + 60})
+	s.Add(Entry{HumanID: "u1", ScopeType: ScopePokemon, ScopeValue: "25", ExpiresAt: now - 5}) // expired, unswept
+	s.Add(Entry{HumanID: "u1", ScopeType: ScopeEverything, ScopeValue: "", ExpiresAt: 0})      // never expires
+
+	got := s.ListActive("u1", now)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 active entries (expired filtered), got %d: %v", len(got), got)
+	}
+	for _, e := range got {
+		if e.ScopeType == ScopePokemon {
+			t.Fatalf("expired pokemon entry leaked into ListActive: %v", got)
+		}
+	}
+
+	// Snapshot semantics: mutating the result must not affect the store.
+	got[0].ScopeValue = "tampered"
+	if s.Match("u1", Event{GymID: "gym1"}, now) != true {
+		t.Fatalf("store affected by mutating ListActive result")
+	}
+
+	// Other users unaffected.
+	if got := s.ListActive("u2", now); got != nil {
+		t.Fatalf("u2: expected nil, got %v", got)
+	}
+}


### PR DESCRIPTION
Adds the HTTP surface for alert mutes (previously bot-command/button-only), per the approved design in `docs/superpowers/specs/2026-06-11-mute-api-design.md`.

## Endpoints
- `GET /api/v2/humans/{id}/mutes` — active (non-expired) mutes
- `POST /api/v2/humans/{id}/mutes` — `{scope, value?, duration_min?}` → `{mute, replaced}`; re-muting the same `(scope,value)` extends expiry
- `DELETE /api/v2/humans/{id}/mutes?scope=&value=` — remove one → `{deleted:[…]}` (404 on miss)
- `DELETE /api/v2/humans/{id}/mutes` — remove all → `{deleted:[…]}`
- `GET /api/v2/humans/{id}/tracking` snapshot now carries a `mutes` array

## Design points
- Strict v2 conventions: `additionalProperties:false`, unknown query rejection, problem+json, `{deleted:[…]}` delete shape mirroring v2 tracking, scope as string enum, value present-but-null for `everything`.
- Validation mirrors the bot parser (per-scope value rules, positive-int pokemon/tracking values, duration 1–10080 min, default 60). Area names canonicalise against `AreaLogic` when present, else the live `StateMgr` fences — the production path, reload-safe.
- Mutes stay **in-memory by design**; volatility is documented in every field description.
- New `mute.Store.ListActive` filters expired-but-unswept entries from list/snapshot reads.
- Stale `ScopeTracking` docs refreshed (tracking-UID mutes have been matcher-enforced since phase 3.5a).

## Testing
TDD throughout: 24 new tests (store, all endpoints, every validation rejection, snapshot inclusion, StateMgr fallback). Golden OpenAPI spec regenerated. Full build/vet/test/lint gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)