### PR TITLE
pvp: enable mega forms in cross-species evolution-direct tracking

### DIFF
--- a/processor/internal/matching/pokemon_test.go
+++ b/processor/internal/matching/pokemon_test.go
@@ -773,6 +773,54 @@ func TestPokemonMatchProfileFilter(t *testing.T) {
 
 // makePVPMonster returns a MonsterTracking for a PVP great-league rule with
 // permissive stat filters, suitable for evolution-filter tests.
+// TestPokemonMatchPVPEvolutionDirectMega proves cross-species evolution-direct
+// tracking now fires on mega forms: a Charmander (4) whose Mega Charizard (6,
+// evo 2) would be great-league top-rank matches a Charizard `mega` rule, while
+// the base Charizard rank is too poor to match on its own.
+func TestPokemonMatchPVPEvolutionDirectMega(t *testing.T) {
+	human := makeHuman("user1")
+
+	// Charizard (6) rule with worst rank 100. PVPRankingEvolution = 1 (any mega).
+	megaRule := makePVPMonster("user1", 6, 1)
+	megaRule.PVPRankingLeague = 1500
+	megaRule.PVPRankingWorst = 100
+
+	// EvoData[6] for the spawned Charmander: base Charizard rank 200 (>worst, no
+	// match) + Mega Charizard X (evo 2) rank 3 (<=worst, should match a mega rule).
+	pokemon := &ProcessedPokemon{
+		PokemonID: 4, Form: 0, IV: 100, CP: 400, Level: 20,
+		ATK: 15, DEF: 15, STA: 15, Weight: 1, Size: 1, RarityGroup: 1,
+		TTHSeconds: 600, Latitude: 51.0, Longitude: 0.0, Encountered: true,
+		PVPBestRank: map[int][]pvp.LeagueRank{},
+		PVPEvoData: map[int]map[int][]pvp.LeagueRank{
+			6: {1500: {
+				{Rank: 200, CP: 1500, Caps: []int{50}, Evolution: 0},
+				{Rank: 3, CP: 1480, Caps: []int{50}, Evolution: 2},
+			}},
+		},
+	}
+
+	st := makeTestState([]*db.MonsterTracking{megaRule}, map[string]*db.Human{"user1": human})
+	m := &PokemonMatcher{PVPQueryMaxRank: 100, PVPEvolutionDirectTracking: true}
+	matched, _ := m.Match(pokemon, st)
+	if len(matched) != 1 {
+		t.Fatalf("mega rule should match the Mega Charizard evolution entry; got %d", len(matched))
+	}
+
+	// A base Charizard rule (evo 0), no include_mega, must NOT match: its base
+	// evolution rank (200) is worse than worst, and the mega entry is filtered
+	// out for base rules.
+	baseRule := makePVPMonster("user1", 6, 0)
+	baseRule.PVPRankingLeague = 1500
+	baseRule.PVPRankingWorst = 100
+	stBase := makeTestState([]*db.MonsterTracking{baseRule}, map[string]*db.Human{"user1": human})
+	mBase := &PokemonMatcher{PVPQueryMaxRank: 100, PVPEvolutionDirectTracking: true, IncludeMegaEvolution: false}
+	matchedBase, _ := mBase.Match(pokemon, stBase)
+	if len(matchedBase) != 0 {
+		t.Fatalf("base rule (no include_mega) must not match the mega evolution entry; got %d", len(matchedBase))
+	}
+}
+
 func makePVPMonster(id string, pokemonID int, pvpEvolution int) *db.MonsterTracking {
 	return &db.MonsterTracking{
 		ID:                   id,

--- a/processor/internal/pvp/rankcalculator.go
+++ b/processor/internal/pvp/rankcalculator.go
@@ -136,8 +136,15 @@ func calculateLeague(league int, leagueData []webhook.PVPRankEntry, capsConsider
 			}
 		}
 
-		// Cross-species evolution direct tracking — unchanged (base entries only)
-		if stats.Evolution == 0 && cfg.PVPEvolutionDirectTracking && stats.Rank > 0 && stats.CP > 0 &&
+		// Cross-species evolution direct tracking. Each qualifying entry for a
+		// DIFFERENT pokemon (stats.Pokemon != pokemonID) is recorded under that
+		// evolved species so a rule on it can fire on this pre-evolution. Mega /
+		// temporary-evolution entries are INCLUDED, tagged with their Evolution,
+		// so a `mega` rule on the evolved species (e.g. track Mega Charizard, get
+		// Charmander alerts) matches via the matcher's evolution discriminator;
+		// base rules still only see base (evolution 0) entries unless the server
+		// include_mega_evolution default is on.
+		if cfg.PVPEvolutionDirectTracking && stats.Rank > 0 && stats.CP > 0 &&
 			stats.Pokemon != pokemonID && stats.Rank <= cfg.PVPFilterMaxRank && stats.CP >= minCP {
 			var evoCaps []int
 			if stats.Capped {
@@ -153,7 +160,7 @@ func calculateLeague(league int, leagueData []webhook.PVPRankEntry, capsConsider
 					}
 				}
 			}
-			evoRank := LeagueRank{Rank: stats.Rank, CP: stats.CP, Caps: evoCaps, Form: stats.Form}
+			evoRank := LeagueRank{Rank: stats.Rank, CP: stats.CP, Caps: evoCaps, Form: stats.Form, Evolution: stats.Evolution}
 			if _, ok := evoData[stats.Pokemon]; !ok {
 				evoData[stats.Pokemon] = make(map[int][]LeagueRank)
 			}

--- a/processor/internal/pvp/rankcalculator_test.go
+++ b/processor/internal/pvp/rankcalculator_test.go
@@ -63,6 +63,38 @@ func TestCalculateBasic(t *testing.T) {
 	}
 }
 
+// TestCalculate_EvolutionDataIncludesMega ensures cross-species evolution
+// direct tracking captures mega/temporary-evolution entries (tagged with their
+// Evolution), so a `mega` rule on the evolved species can fire on a
+// pre-evolution. A Charmander (4) spawns; its great-league PVP lists the evolved
+// Charizard (6) as base (evo 0) and Mega X (evo 2).
+func TestCalculate_EvolutionDataIncludesMega(t *testing.T) {
+	pokemon := &webhook.PokemonWebhook{
+		PokemonID: 4,
+		Form:      0,
+		PVP: map[string][]webhook.PVPRankEntry{
+			"great": {
+				{Pokemon: 6, Form: 178, Rank: 50, CP: 1500, Cap: 50, Capped: true, Evolution: 0}, // base Charizard
+				{Pokemon: 6, Form: 178, Rank: 3, CP: 1480, Cap: 50, Capped: true, Evolution: 2},  // Mega Charizard X
+			},
+		},
+	}
+	cfg := &Config{LevelCaps: []int{50}, PVPFilterMaxRank: 100, PVPEvolutionDirectTracking: true}
+	result := Calculate(pokemon, cfg)
+
+	evo := result.EvolutionData[6][1500]
+	got := map[int]int{} // evolution -> rank
+	for _, r := range evo {
+		got[r.Evolution] = r.Rank
+	}
+	if got[0] != 50 {
+		t.Errorf("expected base Charizard (evo 0) rank 50 in EvolutionData[6]; got %#v", got)
+	}
+	if got[2] != 3 {
+		t.Errorf("expected Mega Charizard X (evo 2) rank 3 in EvolutionData[6]; got %#v", got)
+	}
+}
+
 func TestCalculateMultipleCaps(t *testing.T) {
 	pokemon := &webhook.PokemonWebhook{
 		PokemonID: 25,


### PR DESCRIPTION
## Report

> It's the evolution tracking for mega. I could get notified of charmanders that can evolve into a mega Charizard but now it's not working. Non-mega evolution tracking seems ok.

## Investigation

Reproduced the full pipeline (`ProcessPokemonWebhook` → `Match`) and traced it. The cross-species evolution-direct path (`pvp.Calculate`'s `evoData` block) is gated by `stats.Evolution == 0`, so it only records the **base** form of an evolved species. For a Charmander spawn, `EvolutionData[6]` contained only base Charizard — the Mega Charizard entry (evolution 2) was dropped before it reached the matcher. So `!track charizard … mega` (or any mega evolution-direct match) could never fire.

Findings:
- **Non-mega evolution-direct works** (base entries aren't excluded) — matches the "non-mega ok" report.
- **Mega cross-species never worked** — the guard predates the mega feature and **PoracleJS has the identical guard** (`!stats.evolution`, monster.js:338). So strictly it's a long-standing gap, but the new `mega` keyword (#136) makes `!track charizard great5 mega` a natural way to ask for it, and it did nothing.
- (Same-id mega tracking — tracking the spawn itself — already works with `include_mega_evolution = true` or a `mega` rule; verified separately.)

## Fix

Drop the `stats.Evolution == 0` restriction in the `evoData` block and tag each entry with its `Evolution`. The matcher's existing evolution discriminator (added in #136) then routes them correctly:

| rule | mega evo entry (evo 2) | base evo entry (evo 0) |
|---|---|---|
| base (evo 0), include_mega off | skipped | matched |
| base (evo 0), include_mega on | matched | matched |
| `mega` (evo 1) | matched | skipped |
| `mega:x` (evo 2) | matched | skipped |

So **non-mega evolution tracking is unchanged**, and mega evolution tracking now works. Only cross-species entries (`stats.Pokemon != pokemonID`) are affected; the spawn's own mega is still handled by the regular best-rank path.

## Tests

- `pvp`: `EvolutionData[6]` now contains both base (evo 0) and Mega X (evo 2), tagged.
- `matching`: a Charizard `mega` rule fires on a Charmander via the mega entry; a base rule (no include_mega) does not. Existing non-mega evolution-direct tests (Eevee→Sylveon, etc.) still pass.

Full gate green (build/vet/test/lint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)