### PR TITLE
quest: support `all pokemon` / `all items` wildcards and fix reward=0 matching

### DIFF
--- a/processor/internal/bot/argmatch.go
+++ b/processor/internal/bot/argmatch.go
@@ -317,6 +317,7 @@ var knownPrefixKeys = []string{
 // knownKeywordKeys lists all arg.* keyword keys used by any command.
 var knownKeywordKeys = []string{
 	"arg.remove", "arg.everything", "arg.individually",
+	"arg.all_pokemon", "arg.all_items",
 	"arg.clean", "arg.edit", "arg.summary", "arg.shiny", "arg.ex",
 	"arg.rsvp", "arg.no_rsvp", "arg.rsvp_only",
 	"arg.gmax", "arg.mega",

--- a/processor/internal/bot/commands/quest.go
+++ b/processor/internal/bot/commands/quest.go
@@ -78,6 +78,8 @@ var questParams = []bot.ParamDef{
 	{Type: bot.ParamPrefixStringList, Key: "arg.prefix.area"},
 	{Type: bot.ParamKeyword, Key: "arg.remove"},
 	{Type: bot.ParamKeyword, Key: "arg.everything"},
+	{Type: bot.ParamKeyword, Key: "arg.all_pokemon"}, // all pokemon (reward_type 7, wildcard reward=0)
+	{Type: bot.ParamKeyword, Key: "arg.all_items"},   // all items (reward_type 2, wildcard reward=0)
 	{Type: bot.ParamKeyword, Key: "arg.clean"},
 	{Type: bot.ParamKeyword, Key: "arg.summary"},
 	{Type: bot.ParamKeyword, Key: "arg.shiny"},
@@ -153,6 +155,23 @@ func (c *QuestCommand) Run(ctx *bot.CommandContext, args []string) []bot.Reply {
 	amountVal := 0
 	if amountSet {
 		amountVal = questParseInt(amountStr)
+	}
+
+	// Bulk wildcard keywords (everything / all pokemon / all items) are
+	// gated behind everything_flag_permissions for non-admins, mirroring
+	// PoracleJS. "all pokemon" → reward_type 7 wildcard (reward=0);
+	// "all items" → reward_type 2 wildcard (reward=0). Both combine with
+	// each other and with the reward-specific keywords below.
+	wantsAllPokemon := parsed.HasKeyword("arg.all_pokemon")
+	wantsAllItems := parsed.HasKeyword("arg.all_items")
+	if (wantsAllPokemon || wantsAllItems || parsed.HasKeyword("arg.everything")) && !questBulkAllowed(ctx) {
+		return []bot.Reply{{React: "🙅", Text: tr.T("msg.quest.bulk_not_permitted")}}
+	}
+	if wantsAllPokemon {
+		insert = append(insert, c.makeQuest(ctx, common, override, shiny, pings, 7, 0, 0, 0))
+	}
+	if wantsAllItems {
+		insert = append(insert, c.makeQuest(ctx, common, override, shiny, pings, 2, 0, 0, amountVal))
 	}
 
 	if stardustVal, ok := parsed.Strings["stardust"]; ok {
@@ -247,7 +266,9 @@ func (c *QuestCommand) Run(ctx *bot.CommandContext, args []string) []bot.Reply {
 		// Consume matched item tokens from Unrecognized
 		parsed.Unrecognized = nil
 		insert = append(insert, c.makeQuest(ctx, common, override, shiny, pings, 2, itemID, 0, amountVal))
-	} else {
+	} else if len(insert) == 0 {
+		// No reward-specific branch matched and no bulk wildcard was
+		// pre-appended above — nothing to track.
 		return []bot.Reply{{React: "🙅", Text: tr.T("msg.no_quest_type")}}
 	}
 
@@ -334,6 +355,16 @@ func (c *QuestCommand) resolveMonsters(ctx *bot.CommandContext, parsed *bot.Pars
 	return applyFormFilter(ctx, parsed.Pokemon, parsed)
 }
 
+// questBulkAllowed reports whether the user may use bulk wildcard keywords
+// (everything / all pokemon / all items). Mirrors PoracleJS: gated behind
+// everything_flag_permissions for non-admins, always allowed for admins.
+func questBulkAllowed(ctx *bot.CommandContext) bool {
+	if ctx.IsAdmin {
+		return true
+	}
+	return strings.ToLower(ctx.Config.Tracking.EverythingFlagPermissions) != "deny"
+}
+
 // handleRemove handles !quest remove variants. Must be called before reward type detection.
 func (c *QuestCommand) handleRemove(ctx *bot.CommandContext, parsed *bot.ParsedArgs, common *commonTrackFields, shiny bool, pings string) []bot.Reply {
 	if len(parsed.RemoveUIDs) > 0 {
@@ -351,6 +382,14 @@ func (c *QuestCommand) handleRemove(ctx *bot.CommandContext, parsed *bot.ParsedA
 		// remove everything — match all reward types
 		for _, rt := range []int{7, 3, 12, 4, 2} {
 			targets = append(targets, c.makeQuest(ctx, common, noOverride, shiny, pings, rt, 0, 0, 0))
+		}
+	} else if parsed.HasKeyword("arg.all_pokemon") || parsed.HasKeyword("arg.all_items") {
+		// remove the "all pokemon" / "all items" wildcard rows (reward=0)
+		if parsed.HasKeyword("arg.all_pokemon") {
+			targets = append(targets, c.makeQuest(ctx, common, noOverride, shiny, pings, 7, 0, 0, 0))
+		}
+		if parsed.HasKeyword("arg.all_items") {
+			targets = append(targets, c.makeQuest(ctx, common, noOverride, shiny, pings, 2, 0, 0, 0))
 		}
 	} else if stardustVal, ok := parsed.Strings["stardust"]; ok {
 		amount := questParseInt(stardustVal)

--- a/processor/internal/bot/commands/quest_test.go
+++ b/processor/internal/bot/commands/quest_test.go
@@ -157,6 +157,53 @@ func TestQuest_Everything(t *testing.T) {
 	assert.Len(t, rows, 5, "everything should create 5 reward types")
 }
 
+// !quest all_pokemon → single "all pokemon" token after underscore
+// replacement → wildcard pokemon rule (reward_type 7, reward 0).
+func TestQuest_AllPokemon(t *testing.T) {
+	ctx := questCtx(t)
+	cmd := &QuestCommand{}
+	replies := cmd.Run(ctx, []string{"all pokemon"})
+
+	require.NotEmpty(t, replies)
+	assert.Equal(t, "✅", replies[0].React, "reply: %s", replies[0].Text)
+
+	rows, _ := ctx.Tracking.Quests.SelectByIDProfile("user1", 1)
+	require.Len(t, rows, 1)
+	assert.Equal(t, 7, rows[0].RewardType, "pokemon quest reward type")
+	assert.Equal(t, 0, rows[0].Reward, "all pokemon = wildcard reward 0")
+}
+
+// !quest all_items → wildcard item rule (reward_type 2, reward 0).
+func TestQuest_AllItems(t *testing.T) {
+	ctx := questCtx(t)
+	cmd := &QuestCommand{}
+	replies := cmd.Run(ctx, []string{"all items"})
+
+	require.NotEmpty(t, replies)
+	assert.Equal(t, "✅", replies[0].React, "reply: %s", replies[0].Text)
+
+	rows, _ := ctx.Tracking.Quests.SelectByIDProfile("user1", 1)
+	require.Len(t, rows, 1)
+	assert.Equal(t, 2, rows[0].RewardType, "item quest reward type")
+	assert.Equal(t, 0, rows[0].Reward, "all items = wildcard reward 0")
+}
+
+// Non-admins are blocked from bulk wildcards when everything_flag_permissions
+// is "deny".
+func TestQuest_AllPokemon_DeniedForNonAdmin(t *testing.T) {
+	ctx := questCtx(t)
+	ctx.Config.Tracking.EverythingFlagPermissions = "deny"
+	ctx.IsAdmin = false
+	cmd := &QuestCommand{}
+	replies := cmd.Run(ctx, []string{"all pokemon"})
+
+	require.NotEmpty(t, replies)
+	assert.Equal(t, "🙅", replies[0].React)
+
+	rows, _ := ctx.Tracking.Quests.SelectByIDProfile("user1", 1)
+	assert.Empty(t, rows, "denied bulk wildcard should track nothing")
+}
+
 func TestQuest_SummaryKeyword(t *testing.T) {
 	ctx := questCtx(t)
 	replies := runQuest(t, ctx, "25 summary")

--- a/processor/internal/i18n/locale/en.json
+++ b/processor/internal/i18n/locale/en.json
@@ -96,6 +96,8 @@
   "tracking.reward_mega_energy_fmt": "mega energy {0}",
   "tracking.reward_candy": "candy",
   "tracking.reward_candy_fmt": "candy {0}",
+  "tracking.reward_any_pokemon": "any pokemon",
+  "tracking.reward_any_item": "any item",
   "tracking.reward_min_fmt": "minimum {0}",
   "tracking.grunt_type_fmt": "Grunt type: **{0}**",
   "tracking.min_avg_spawn": "Min avg. spawn {0}/hour",
@@ -240,6 +242,8 @@
 
   "arg.remove": "remove",
   "arg.everything": "everything",
+  "arg.all_pokemon": "all pokemon",
+  "arg.all_items": "all items",
   "arg.any": "any",
   "arg.clean": "clean",
   "arg.edit": "edit",
@@ -419,6 +423,7 @@
   "msg.no_lure_type": "No lure type specified",
   "msg.no_quest_type": "No quest type specified",
   "msg.quest.amount_not_applicable": "`amount:N` doesn't apply to pokemon quests — pokemon rewards have no minimum amount.",
+  "msg.quest.bulk_not_permitted": "You do not have permission to track all pokemon or items at once. Track specific rewards instead.",
   "msg.removed_n": "Removed {0} tracking rules",
 
   "msg.egg.usage": "Valid commands are e.g. `{0}egg level:5`, `{0}egg legendary`, `{0}egg remove everything`",

--- a/processor/internal/matching/quest.go
+++ b/processor/internal/matching/quest.go
@@ -120,7 +120,9 @@ func singleRewardMatches(q *db.QuestTracking, r *QuestRewardData) bool {
 
 	switch r.Type {
 	case 7: // pokemon
-		if q.Reward != r.PokemonID {
+		// reward==0 is the "all pokemon" wildcard (e.g. !quest all pokemon,
+		// !quest everything) — match any pokemon reward.
+		if q.Reward != 0 && q.Reward != r.PokemonID {
 			return false
 		}
 		if q.Form != 0 && q.Form != r.FormID {
@@ -132,7 +134,9 @@ func singleRewardMatches(q *db.QuestTracking, r *QuestRewardData) bool {
 		return true
 
 	case 2: // item
-		if q.Reward != r.ItemID {
+		// reward==0 is the "all items" wildcard (e.g. !quest all items,
+		// !quest everything) — match any item reward.
+		if q.Reward != 0 && q.Reward != r.ItemID {
 			return false
 		}
 		if q.Amount > 0 && r.Amount < q.Amount {

--- a/processor/internal/matching/quest_test.go
+++ b/processor/internal/matching/quest_test.go
@@ -94,6 +94,24 @@ func TestSingleRewardMatchesPokemon(t *testing.T) {
 			&QuestRewardData{Type: 7, PokemonID: 25, Shiny: true},
 			true,
 		},
+		{
+			"all pokemon wildcard (reward=0) matches any pokemon",
+			&db.QuestTracking{RewardType: 7, Reward: 0},
+			&QuestRewardData{Type: 7, PokemonID: 25},
+			true,
+		},
+		{
+			"all pokemon wildcard (reward=0) matches a different pokemon",
+			&db.QuestTracking{RewardType: 7, Reward: 0},
+			&QuestRewardData{Type: 7, PokemonID: 566},
+			true,
+		},
+		{
+			"all pokemon wildcard still honours shiny filter",
+			&db.QuestTracking{RewardType: 7, Reward: 0, Shiny: true},
+			&QuestRewardData{Type: 7, PokemonID: 25, Shiny: false},
+			false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -156,6 +174,18 @@ func TestSingleRewardMatchesItem(t *testing.T) {
 			&db.QuestTracking{RewardType: 2, Reward: 701},
 			&QuestRewardData{Type: 2, ItemID: 701, Amount: 3},
 			true,
+		},
+		{
+			"all items wildcard (reward=0) matches any item",
+			&db.QuestTracking{RewardType: 2, Reward: 0},
+			&QuestRewardData{Type: 2, ItemID: 701, Amount: 3},
+			true,
+		},
+		{
+			"all items wildcard still honours amount filter",
+			&db.QuestTracking{RewardType: 2, Reward: 0, Amount: 5},
+			&QuestRewardData{Type: 2, ItemID: 701, Amount: 3},
+			false,
 		},
 	}
 

--- a/processor/internal/rowtext/quest.go
+++ b/processor/internal/rowtext/quest.go
@@ -14,7 +14,11 @@ func (g *Generator) QuestRowText(tr *i18n.Translator, quest *db.QuestTracking) s
 
 	switch quest.RewardType {
 	case 7:
-		// Pokemon reward
+		// Pokemon reward (reward==0 is the "all pokemon" wildcard)
+		if quest.Reward == 0 {
+			rewardThing = tr.T("tracking.reward_any_pokemon")
+			break
+		}
 		mon := g.GD.GetMonster(quest.Reward, quest.Form)
 		if mon != nil {
 			rewardThing = tr.T(gamedata.PokemonTranslationKey(quest.Reward))
@@ -37,7 +41,11 @@ func (g *Generator) QuestRowText(tr *i18n.Translator, quest *db.QuestTracking) s
 		}
 
 	case 2:
-		// Item reward
+		// Item reward (reward==0 is the "all items" wildcard)
+		if quest.Reward == 0 {
+			rewardThing = tr.T("tracking.reward_any_item")
+			break
+		}
 		item := g.GD.GetItem(quest.Reward)
 		if item != nil {
 			rewardThing = tr.T(gamedata.ItemTranslationKey(quest.Reward))


### PR DESCRIPTION
## Problem

A user reported `!quest all_pokemon` returning **"No quest type specified"**.

Root cause was two distinct issues, both unique to the quest path (the other tracking commands — raid, egg, invasion, lure, gym, nest, fort, maxbattle, track — already have their PoracleJS wildcards):

1. **Parser gap** — PoracleJS supports the `all pokemon` and `all items` quest wildcards (`quest.js:84-95`). PoracleNG had no keyword for either, so `all_pokemon` (which becomes the single token `all pokemon` after underscore replacement) fell through to the error.

2. **Latent matcher bug** — the matcher only honored `reward=0` as a wildcard for mega-energy (type 12) and candy (type 4), **not** pokemon (type 7) or item (type 2). So the *existing* `!quest everything` keyword — which inserts type 7/2 rows with `reward=0` — silently never matched any pokemon or item quest.

## Changes

- **`matching/quest.go`** — `reward=0` now matches any pokemon (type 7) / any item (type 2), consistent with types 12/4. Fixes `everything` and enables the new wildcards. (+ matcher tests)
- **`bot/commands/quest.go`** — added `all_pokemon` / `all_items` keywords (insert a `reward=0` wildcard row, combine with other reward keywords). Remove-path handles them so `!quest remove all pokemon` removes all pokemon-reward rules (PoracleJS semantics). Bulk wildcards (`everything`/`all pokemon`/`all items`) gated behind `everything_flag_permissions` for non-admins, matching PoracleJS and `track`. (+ command tests)
- **`bot/argmatch.go`** — registered the two new keys in `knownKeywordKeys`.
- **`rowtext/quest.go`** — `reward=0` rows display as "any pokemon" / "any item" in `!tracked`.
- **`i18n/locale/en.json`** — new keyword + display + permission-denial strings (per-key English fallback covers other locales).

## Behavior note

Newly honoring `everything_flag_permissions` for quest only affects operators who explicitly set `deny` (default is empty → allowed, same as `track`), so default deployments see no change for `!quest everything`.

## Verification

Pre-commit gate green:

```
go build ./...   ✓
go vet ./...     ✓
go test ./...    ✓
golangci-lint    ✓ (0 issues)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)