### PR TITLE
discordbot: clean up threads under a dead master channel instead of warning daily

### DIFF
--- a/processor/internal/discordbot/autocreate_sync.go
+++ b/processor/internal/discordbot/autocreate_sync.go
@@ -262,6 +262,55 @@ func (as *autocreateSyncer) ruleLock(name string) *sync.Mutex {
 	return m
 }
 
+// purgeThreadsUnderParent removes every cached thread whose host channel is
+// parentID from every rule/fence in the cache, persisting the result to
+// cachePath. Returns the number of thread entries removed. Used by the
+// thread keep-alive sweeper when a parent channel is confirmed gone in
+// Discord — the threads under it can never be revived, so leaving their
+// stale cache entries would keep the sweeper walking a dead parent (and
+// re-warning) every pass. A thread's host channel is fs.ChannelIDs[name],
+// falling back to fs.ChannelID for legacy single-channel caches — the same
+// resolution the sweeper uses when building its parent map.
+func (as *autocreateSyncer) purgeThreadsUnderParent(parentID, cachePath string) (int, error) {
+	if parentID == "" {
+		return 0, nil
+	}
+	as.mu.Lock()
+	defer as.mu.Unlock()
+	removed := 0
+	for _, ruleState := range as.cache {
+		if ruleState == nil {
+			continue
+		}
+		for _, fs := range ruleState.Fences {
+			if fs == nil || len(fs.ThreadIDs) == 0 {
+				continue
+			}
+			for chName, labelMap := range fs.ThreadIDs {
+				host := fs.ChannelIDs[chName]
+				if host == "" {
+					host = fs.ChannelID
+				}
+				if host != parentID {
+					continue
+				}
+				removed += len(labelMap)
+				delete(fs.ThreadIDs, chName)
+			}
+			if len(fs.ThreadIDs) == 0 {
+				fs.ThreadIDs = nil
+			}
+		}
+	}
+	if removed == 0 {
+		return 0, nil
+	}
+	if err := saveAutocreateCache(cachePath, as.cache); err != nil {
+		return removed, err
+	}
+	return removed, nil
+}
+
 // loadCache reads the on-disk cache into as.cache. Missing file is benign.
 // Must be called with as.mu held.
 func (as *autocreateSyncer) loadCache(baseDir string) error {

--- a/processor/internal/discordbot/autocreate_threads.go
+++ b/processor/internal/discordbot/autocreate_threads.go
@@ -202,6 +202,20 @@ func (c *threadCache) removeThreadByLabel(masterID, label string) string {
 	return ""
 }
 
+// removeMaster drops the entire cache section for masterID — used when the
+// master channel is confirmed gone in Discord (HTTP 404), so every thread
+// under it is dead and can never be revived. Returns true if a section was
+// removed (so the caller knows whether a save() is worthwhile).
+func (c *threadCache) removeMaster(masterID string) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if _, ok := c.masters[masterID]; !ok {
+		return false
+	}
+	delete(c.masters, masterID)
+	return true
+}
+
 func (c *threadCache) master(masterID string) (*threadCacheMaster, bool) {
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/processor/internal/discordbot/threadkeepalive.go
+++ b/processor/internal/discordbot/threadkeepalive.go
@@ -177,13 +177,13 @@ func (k *threadKeepAlive) revivePrivateArchived(ctx context.Context, parentID st
 		page, err := k.bot.session.ThreadsPrivateArchived(parentID, before, pageLimit)
 		if err != nil {
 			// Parent gone? Discord returns 404 (Unknown Channel, code 10003).
-			// Disable every managed thread under this parent so we stop
-			// trying to deliver to them, and post an admin notice so the
-			// operator knows. Reconciliation will eventually clean up the
-			// rows; the immediate disable just stops alert delivery NOW.
+			// A 404 here is permanent — the threads under this parent can
+			// never be revived — so delete the orphaned thread rows and
+			// purge them from both caches. Leaving them would make the
+			// sweeper re-walk this dead parent (and re-warn) every pass.
 			if restErr, ok := err.(*discordgo.RESTError); ok && restErr.Response != nil && restErr.Response.StatusCode == 404 {
-				k.disableThreadsUnder(parentID, parents, managed)
-				log.Warnf("thread keep-alive: parent channel %s is gone (HTTP 404); disabled affected threads", parentID)
+				k.cleanupDeadThreadsUnder(parentID, parents, managed)
+				log.Warnf("thread keep-alive: parent channel %s is gone (HTTP 404); cleaned up affected threads", parentID)
 				return
 			}
 			log.Warnf("thread keep-alive: ThreadsPrivateArchived(%s): %v", parentID, err)
@@ -213,26 +213,55 @@ func (k *threadKeepAlive) revivePrivateArchived(ctx context.Context, parentID st
 	}
 }
 
-// disableThreadsUnder finds every managed thread whose recorded parent
-// is parentID, sets admin_disable on its humans row so the matcher /
-// dispatcher stop targeting it, and posts an admin notice listing the
-// affected threads.
-func (k *threadKeepAlive) disableThreadsUnder(parentID string, parents map[string]string, managed map[string]bool) {
-	var disabled []string
+// cleanupDeadThreadsUnder finds every managed thread whose recorded parent
+// is parentID — a channel confirmed gone in Discord (HTTP 404) — deletes
+// its humans row and tracking, purges it from both in-process caches, and
+// posts an admin notice listing what was removed.
+//
+// A 404 (Unknown Channel) is permanent: the parent is gone, so its threads
+// can never be revived. The previous behaviour only set admin_disable and
+// deferred cleanup to "reconciliation next pass", but reconciliation only
+// scans enabled discord:channel rows — it never saw the disabled
+// discord:thread rows, so the rows lingered forever and the sweeper
+// re-warned every interval. Deleting here makes the cleanup actually happen
+// and stops the recurring notice (the rows and cache entries are gone, so
+// the dead parent is no longer walked on subsequent sweeps).
+func (k *threadKeepAlive) cleanupDeadThreadsUnder(parentID string, parents map[string]string, managed map[string]bool) {
+	var deleted []string
 	for tid, pid := range parents {
 		if pid != parentID || !managed[tid] {
 			continue
 		}
-		if err := k.bot.Humans.SetAdminDisable(tid, true); err != nil {
-			log.Warnf("thread keep-alive: SetAdminDisable(%s): %v", tid, err)
+		if err := k.bot.Humans.Delete(tid); err != nil {
+			log.Warnf("thread keep-alive: delete dead thread %s: %v", tid, err)
 			continue
 		}
-		disabled = append(disabled, tid)
+		deleted = append(deleted, tid)
 	}
-	if len(disabled) > 0 {
-		k.bot.PostAdminNotice(fmt.Sprintf(
-			":warning: Thread keep-alive: master channel `%s` is gone in Discord (HTTP 404). Disabled %d managed thread(s) under it: `%s`. Reconciliation will tidy up the rows next pass.",
-			parentID, len(disabled), strings.Join(disabled, "`, `"),
-		))
+	if len(deleted) == 0 {
+		return
 	}
+
+	// Purge the dead threads from both caches so the next sweep doesn't
+	// resurrect the parent walk and the on-disk cache files reflect reality.
+	// threadCache keys threads under the master channel (== parentID in the
+	// picker flow); the autocreate-sync cache keys them under their host
+	// channel. Each purge is a no-op for threads it doesn't own.
+	if k.bot.threadCache != nil && k.bot.threadCache.removeMaster(parentID) {
+		if err := k.bot.threadCache.save(); err != nil {
+			log.Warnf("thread keep-alive: save thread cache after purge: %v", err)
+		}
+	}
+	if k.bot.autocreateSync != nil {
+		if n, err := k.bot.autocreateSync.purgeThreadsUnderParent(parentID, syncCachePath(k.bot.Cfg.BaseDir)); err != nil {
+			log.Warnf("thread keep-alive: purge autocreate cache for parent %s: %v", parentID, err)
+		} else if n > 0 {
+			log.Infof("thread keep-alive: purged %d autocreate-cache thread(s) under dead parent %s", n, parentID)
+		}
+	}
+
+	k.bot.PostAdminNotice(fmt.Sprintf(
+		":wastebasket: Thread keep-alive: master channel `%s` is gone in Discord (HTTP 404). Deleted %d orphaned managed thread(s) and their tracking: `%s`.",
+		parentID, len(deleted), strings.Join(deleted, "`, `"),
+	))
 }

--- a/processor/internal/discordbot/threadkeepalive_test.go
+++ b/processor/internal/discordbot/threadkeepalive_test.go
@@ -1,9 +1,89 @@
 package discordbot
 
 import (
+	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/pokemon/poracleng/processor/internal/bot"
+	"github.com/pokemon/poracleng/processor/internal/config"
+	"github.com/pokemon/poracleng/processor/internal/store"
 )
+
+// TestCleanupDeadThreadsUnder verifies that when a master/parent channel is
+// confirmed gone in Discord, the keep-alive sweeper deletes the orphaned
+// thread humans rows AND purges them from both in-process caches — so the
+// next sweep no longer walks the dead parent and the warning stops firing.
+func TestCleanupDeadThreadsUnder(t *testing.T) {
+	const deadMaster = "deadMaster"
+	const liveMaster = "liveMaster"
+
+	humans := store.NewMockHumanStore()
+	for _, id := range []string{"t1", "t2", "t3", "t4"} {
+		humans.AddHuman(&store.Human{ID: id, Type: bot.TypeDiscordThread})
+	}
+
+	tmpDir := t.TempDir()
+
+	// threadCache: t1, t2 live under the dead master; t3 under a live master.
+	tc := newThreadCache(filepath.Join(tmpDir, "config", ".cache", "autocreate-threads.json"))
+	tc.ensureMaster("g1", deadMaster)
+	tc.upsertThread(deadMaster, threadCacheEntry{ThreadID: "t1", Label: "a"})
+	tc.upsertThread(deadMaster, threadCacheEntry{ThreadID: "t2", Label: "b"})
+	tc.ensureMaster("g1", liveMaster)
+	tc.upsertThread(liveMaster, threadCacheEntry{ThreadID: "t3", Label: "c"})
+
+	// autocreate-sync cache: t4 hosted under a channel whose ID is the dead master.
+	as := newAutocreateSyncer()
+	as.cache = autocreateCache{
+		"rule1": &autocreateRuleState{
+			Fences: map[string]*autocreateFenceState{
+				"fence1": {
+					ChannelID:  deadMaster,
+					ChannelIDs: map[string]string{"chan": deadMaster},
+					ThreadIDs:  map[string]map[string]string{"chan": {"d": "t4"}},
+				},
+			},
+		},
+	}
+
+	b := &Bot{
+		BotDeps:        bot.BotDeps{Humans: humans, Cfg: &config.Config{BaseDir: tmpDir}},
+		threadCache:    tc,
+		autocreateSync: as,
+	}
+	k := &threadKeepAlive{bot: b}
+
+	parents := map[string]string{
+		"t1": deadMaster, "t2": deadMaster, "t4": deadMaster, "t3": liveMaster,
+	}
+	managed := map[string]bool{"t1": true, "t2": true, "t3": true, "t4": true}
+
+	k.cleanupDeadThreadsUnder(deadMaster, parents, managed)
+
+	// Rows under the dead master are deleted; the live-master row survives.
+	for _, id := range []string{"t1", "t2", "t4"} {
+		if h, _ := humans.Get(id); h != nil {
+			t.Errorf("thread %s should have been deleted but still exists", id)
+		}
+	}
+	if h, _ := humans.Get("t3"); h == nil {
+		t.Errorf("thread t3 under live master should not have been deleted")
+	}
+
+	// threadCache: dead master section removed, live master untouched.
+	if _, ok := tc.master(deadMaster); ok {
+		t.Errorf("threadCache still has dead master %s", deadMaster)
+	}
+	if _, ok := tc.master(liveMaster); !ok {
+		t.Errorf("threadCache lost live master %s", liveMaster)
+	}
+
+	// autocreate-sync cache: the thread under the dead channel is purged.
+	if fs := as.cache["rule1"].Fences["fence1"]; len(fs.ThreadIDs) != 0 {
+		t.Errorf("autocreate cache still has threads under dead parent: %v", fs.ThreadIDs)
+	}
+}
 
 func TestThreadKeepAliveDuration_RespectsConfig(t *testing.T) {
 	if d := keepAliveTickerDuration(0); d != 0 {


### PR DESCRIPTION
## Problem

Operators see a recurring (≈daily) admin-channel warning like:

> :warning: Thread keep-alive: master channel `1501554163337920676` is gone in Discord (HTTP 404). Disabled 4 managed thread(s) under it: … Reconciliation will tidy up the rows next pass.

The reconciliation pass never tidies the rows, so the same warning fires on every keep-alive sweep forever. These are typically leftover `!autocreate` test threads whose master channel was deleted in Discord.

## Root cause

The message comes from the **thread keep-alive sweeper** (`internal/discordbot/threadkeepalive.go`), not reconciliation. Two compounding bugs:

1. **The notice was not idempotent.** On a 404, `disableThreadsUnder` called `SetAdminDisable(tid, true)` for every managed thread under the parent. That `UPDATE` returns nil even when the row is *already* `admin_disable=1`, so the warning re-fired every sweep. The threads stayed in `ListByType` (which does not filter `admin_disable`) and in the autocreate caches, so the dead parent kept being walked.

2. **The promised cleanup never ran.** `runReconciliation` → `SyncDiscordChannels` only scans `ListByTypeEnabled("discord:channel")` — the wrong type (`channel`, not `thread`) **and** it excludes `admin_disable=1` rows. So the disabled `discord:thread` rows were invisible to it. No code path ever deleted them or purged the cache entries.

## Fix

A 404 (Unknown Channel) is permanent — the parent is gone, so its threads can never be revived. The sweeper now performs the cleanup it used to defer:

- **`cleanupDeadThreadsUnder`** (replaces `disableThreadsUnder`): deletes each orphaned thread's `humans` row + tracking via `store.Delete` (full cascade), then purges them from both caches:
  - **`threadCache.removeMaster`** (new) — drops the dead master section, saves `autocreate-threads.json`.
  - **`autocreateSyncer.purgeThreadsUnderParent`** (new) — drops threads whose host channel is the dead parent, rewrites the sync cache.
- The admin notice now reports what was **deleted**, dropping the false "reconciliation next pass" promise.

With the rows and cache entries gone, the next sweep no longer finds those threads, doesn't walk the dead parent, and the message stops. Existing leftover rows are cleaned up automatically on the next sweep that hits each dead master (or at startup, since the sweeper runs once on boot).

## Testing

- New `TestCleanupDeadThreadsUnder` verifies rows under the dead master are deleted (live-master rows untouched), and both caches are purged.
- Full gate passes: `go build ./... && go vet ./... && go test -count=1 ./... && golangci-lint run ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)