### PR TITLE
geocoding: cached GeoNames intersection lookups ({{intersection}}) — takeover of #151

### DIFF
--- a/DTS.md
+++ b/DTS.md
@@ -210,6 +210,7 @@ These fields are available in every template:
 | `neighbourhood` | string | Neighbourhood name |
 | `suburb` | string | Suburb name |
 | `flag` | string | Country flag emoji |
+| `intersection` | string | Nearest street intersection (`Street1 & Street2`) from GeoNames; empty when disabled (`[geocoding] intersection_users`) or none nearby |
 | `staticMap` | string | Static map tile image URL |
 | `staticmap` | string | *Deprecated* — alias for `staticMap` |
 | `imgUrl` | string | Primary icon URL |

--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -413,6 +413,12 @@ provider_url = ""                               # nominatim or photon URL, e.g. 
 # own template like "{{{streetName}}} {{streetNumber}}, {{{city}}}".
 forward_only = false                     # when true, disable reverse geocoding lookup
 cache_detail = 3                         # decimal places of lon/lat for caching (3 or 4 for 100x more detail)
+# intersection_users - list of GeoNames usernames (https://www.geonames.org)
+#   used to populate the {{intersection}} DTS field with the nearest street
+#   intersection. One is picked at random per uncached lookup to spread credit
+#   usage. Empty disables the feature. Results share the geocoding cache above,
+#   but each uncached lookup spends a GeoNames credit, so caching/credits apply.
+intersection_users = []
 # Styles for different times of day using tileservercache
 # Use style: "#(style)" in templates to utilize these
 day_style = ""

--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -418,6 +418,10 @@ cache_detail = 3                         # decimal places of lon/lat for caching
 #   intersection. One is picked at random per uncached lookup to spread credit
 #   usage. Empty disables the feature. Results share the geocoding cache above,
 #   but each uncached lookup spends a GeoNames credit, so caching/credits apply.
+#   GeoNames is a separate service from the reverse-geocode provider, so it gets
+#   its own concurrency limiter and circuit breaker (both sized from the
+#   [tuning] geocoding_* values). Peak outbound to external geo services can
+#   therefore reach 2x geocoding_concurrency when both are busy.
 intersection_users = []
 # Styles for different times of day using tileservercache
 # Use style: "#(style)" in templates to utilize these

--- a/processor/cmd/processor/main.go
+++ b/processor/cmd/processor/main.go
@@ -1505,6 +1505,25 @@ func NewProcessorService(cfg *config.Config, stateMgr *state.Manager, database *
 		}
 	}
 
+	// Nearest-street-intersection lookups (GeoNames). Shares the reverse-
+	// geocoder's pogreb cache when one exists, so intersection results live in
+	// the same on-disk DB (separate key namespace) and repeat sightings at a
+	// fixed stop don't re-hit GeoNames.
+	if len(cfg.Geocoding.IntersectionUsers) > 0 {
+		var sharedCache *geocoding.Cache
+		if geocoder != nil {
+			sharedCache = geocoder.Cache()
+		}
+		enricher.Intersection = geocoding.NewIntersection(geocoding.IntersectionConfig{
+			Usernames:   cfg.Geocoding.IntersectionUsers,
+			Cache:       sharedCache,
+			CacheDetail: cfg.Geocoding.CacheDetail,
+			TimeoutMs:   cfg.Tuning.GeocodingTimeout,
+			Concurrency: cfg.Tuning.GeocodingConcurrency,
+		})
+		log.Infof("GeoNames intersection lookups enabled (%d user(s), cache shared=%t)", len(cfg.Geocoding.IntersectionUsers), sharedCache != nil)
+	}
+
 	// Stats tracker (rarity + shiny, shared rolling window)
 	statsTracker := tracker.NewStatsTracker(tracker.StatsConfig{
 		MinSampleSize:       cfg.Stats.MinSampleSize,

--- a/processor/cmd/processor/main.go
+++ b/processor/cmd/processor/main.go
@@ -1515,11 +1515,13 @@ func NewProcessorService(cfg *config.Config, stateMgr *state.Manager, database *
 			sharedCache = geocoder.Cache()
 		}
 		enricher.Intersection = geocoding.NewIntersection(geocoding.IntersectionConfig{
-			Usernames:   cfg.Geocoding.IntersectionUsers,
-			Cache:       sharedCache,
-			CacheDetail: cfg.Geocoding.CacheDetail,
-			TimeoutMs:   cfg.Tuning.GeocodingTimeout,
-			Concurrency: cfg.Tuning.GeocodingConcurrency,
+			Usernames:        cfg.Geocoding.IntersectionUsers,
+			Cache:            sharedCache,
+			CacheDetail:      cfg.Geocoding.CacheDetail,
+			TimeoutMs:        cfg.Tuning.GeocodingTimeout,
+			Concurrency:      cfg.Tuning.GeocodingConcurrency,
+			FailureThreshold: cfg.Tuning.GeocodingFailureThreshold,
+			CooldownMs:       cfg.Tuning.GeocodingCooldownMs,
 		})
 		log.Infof("GeoNames intersection lookups enabled (%d user(s), cache shared=%t)", len(cfg.Geocoding.IntersectionUsers), sharedCache != nil)
 	}

--- a/processor/internal/api/config_schema.go
+++ b/processor/internal/api/config_schema.go
@@ -316,7 +316,7 @@ var configSchema = []ConfigSection{
 			{Name: "provider_url", Type: "string", Default: "", Description: "Nominatim instance URL for address lookups", DependsOn: &ConfigDependency{Field: "provider", Value: "nominatim"}},
 			{Name: "geocoding_key", Type: "string[]", Default: []string{}, Description: "Google Geocoding API keys (rotated through array)", Sensitive: true, HotReload: true, DependsOn: &ConfigDependency{Field: "provider", Value: "google"}},
 			{Name: "cache_detail", Type: "int", Default: 3, Description: "Decimal places of lat/lon for geocoding cache key rounding (3 or 4 for 100x more detail)"},
-			{Name: "intersection_users", Type: "string[]", Default: []string{}, Description: "GeoNames usernames for the {{intersection}} field (nearest street intersection). Empty disables it. Shares the geocoding cache; uses GeoNames credits per uncached lookup", HotReload: true},
+			{Name: "intersection_users", Type: "string[]", Default: []string{}, Description: "GeoNames usernames for the {{intersection}} field (nearest street intersection). Empty disables it. Shares the geocoding cache; uses GeoNames credits per uncached lookup. Requires a restart to take effect", HotReload: false},
 			{Name: "forward_only", Type: "bool", Default: false, Description: "Disable reverse geocoding — only forward lookups will be performed"},
 			{Name: "static_provider", Type: "select", Default: "none", Description: "Static map tile provider for generating map images in alerts", Options: []ConfigSelectOption{
 				{Value: "none", Label: "None", Description: "Disable static map tiles"},

--- a/processor/internal/api/config_schema.go
+++ b/processor/internal/api/config_schema.go
@@ -316,6 +316,7 @@ var configSchema = []ConfigSection{
 			{Name: "provider_url", Type: "string", Default: "", Description: "Nominatim instance URL for address lookups", DependsOn: &ConfigDependency{Field: "provider", Value: "nominatim"}},
 			{Name: "geocoding_key", Type: "string[]", Default: []string{}, Description: "Google Geocoding API keys (rotated through array)", Sensitive: true, HotReload: true, DependsOn: &ConfigDependency{Field: "provider", Value: "google"}},
 			{Name: "cache_detail", Type: "int", Default: 3, Description: "Decimal places of lat/lon for geocoding cache key rounding (3 or 4 for 100x more detail)"},
+			{Name: "intersection_users", Type: "string[]", Default: []string{}, Description: "GeoNames usernames for the {{intersection}} field (nearest street intersection). Empty disables it. Shares the geocoding cache; uses GeoNames credits per uncached lookup", HotReload: true},
 			{Name: "forward_only", Type: "bool", Default: false, Description: "Disable reverse geocoding — only forward lookups will be performed"},
 			{Name: "static_provider", Type: "select", Default: "none", Description: "Static map tile provider for generating map images in alerts", Options: []ConfigSelectOption{
 				{Value: "none", Label: "None", Description: "Disable static map tiles"},

--- a/processor/internal/api/dts_fields.go
+++ b/processor/internal/api/dts_fields.go
@@ -36,6 +36,7 @@ var commonFields = []FieldDef{
 	{Name: "country", Type: "string", Description: "Country name", Category: "location"},
 	{Name: "countryCode", Type: "string", Description: "Country code", Category: "location"},
 	{Name: "flag", Type: "string", Description: "Country flag emoji", Category: "location"},
+	{Name: "intersection", Type: "string", Description: "Nearest street intersection (\"Street1 & Street2\") from GeoNames; empty when disabled or none nearby", Category: "location"},
 	{Name: "areas", Type: "string", Description: "Comma-separated matched areas", Category: "location"},
 	{Name: "areasList", Type: "array", Description: "Matched areas as array", Category: "location"},
 	{Name: "distance", Type: "number", Description: "Distance from user location", Category: "location"},

--- a/processor/internal/config/config.go
+++ b/processor/internal/config/config.go
@@ -643,6 +643,10 @@ type GeocodingConfig struct {
 	GeocodingKey []string `toml:"geocoding_key"` // google API keys
 	CacheDetail  int      `toml:"cache_detail"`  // decimal places for cache key rounding (default 3)
 	ForwardOnly  bool     `toml:"forward_only"`  // if true, skip reverse geocoding
+	// IntersectionUsers is a pool of GeoNames usernames for nearest-street-
+	// intersection lookups (the {{intersection}} DTS field). Empty disables
+	// the feature. Results share the reverse-geocode pogreb cache.
+	IntersectionUsers []string `toml:"intersection_users"`
 
 	// Static map tile provider
 	StaticProvider    string `toml:"static_provider"`

--- a/processor/internal/enrichment/enrichment.go
+++ b/processor/internal/enrichment/enrichment.go
@@ -224,6 +224,16 @@ func (e *Enricher) addIntersection(m map[string]any, lat, lon float64) {
 	m["intersection"] = e.Intersection.GetIntersection(lat, lon)
 }
 
+// addLocationFields populates the geocoding-derived location fields (reverse-
+// geocoded address + nearest street intersection) for a coordinate. Every
+// webhook type funnels through here, so adding a future location field — or
+// adding a new enrichment type — only touches one place instead of every
+// call site. Both sub-steps are no-ops when their provider is disabled.
+func (e *Enricher) addLocationFields(m map[string]any, lat, lon float64) {
+	e.addGeoResult(m, lat, lon)
+	e.addIntersection(m, lat, lon)
+}
+
 // Tile mode constants. Defined here to avoid import cycles with cmd/processor.
 const (
 	TileModeSkip         = 0 // no template uses staticMap → don't generate tile

--- a/processor/internal/enrichment/enrichment.go
+++ b/processor/internal/enrichment/enrichment.go
@@ -67,18 +67,19 @@ type Enricher struct {
 	ForecastProvider   ForecastProvider  // optional; triggers AccuWeather fetch
 	ShinyProvider      ShinyRateProvider // optional; provides shiny rates
 	EventChecker       *PogoEventChecker
-	GameData           *gamedata.GameData  // game master data for enrichment
-	Translations       *i18n.Bundle        // translations for per-language enrichment
-	MapConfig          *MapConfig          // map URL configuration
-	IvColors           []string            // Discord IV color hex strings (6 thresholds)
-	PVPDisplay         *PVPDisplayConfig   // PVP display filtering config
-	ImgUicons          *uicons.Uicons      // Primary icon resolver
-	ImgUiconsAlt       *uicons.Uicons      // Alternative icon resolver
-	StickerUicons      *uicons.Uicons      // Sticker icon resolver (webp)
-	DefaultLocale      string              // Fallback locale when user has no language set
-	RequestShinyImages bool                // Whether to request shiny icon variants
-	StaticMap          *staticmap.Resolver // Static map tile resolver (nil = disabled)
-	Geocoder           *geocoding.Geocoder // Reverse geocoder (nil = disabled)
+	GameData           *gamedata.GameData      // game master data for enrichment
+	Translations       *i18n.Bundle            // translations for per-language enrichment
+	MapConfig          *MapConfig              // map URL configuration
+	IvColors           []string                // Discord IV color hex strings (6 thresholds)
+	PVPDisplay         *PVPDisplayConfig       // PVP display filtering config
+	ImgUicons          *uicons.Uicons          // Primary icon resolver
+	ImgUiconsAlt       *uicons.Uicons          // Alternative icon resolver
+	StickerUicons      *uicons.Uicons          // Sticker icon resolver (webp)
+	DefaultLocale      string                  // Fallback locale when user has no language set
+	RequestShinyImages bool                    // Whether to request shiny icon variants
+	StaticMap          *staticmap.Resolver     // Static map tile resolver (nil = disabled)
+	Geocoder           *geocoding.Geocoder     // Reverse geocoder (nil = disabled)
+	Intersection       *geocoding.Intersection // Nearest street intersection lookup (nil = disabled)
 
 	// Fallback icon URLs when uicons are not configured or fail
 	FallbackImgURL      string
@@ -210,6 +211,17 @@ func (e *Enricher) addAddressFields(m map[string]any, addr *geocoding.Address) {
 	m["neighbourhood"] = addr.Neighbourhood
 	m["suburb"] = addr.Suburb
 	m["formattedAddress"] = addr.FormattedAddress
+}
+
+// addIntersection populates the {{intersection}} field with the nearest street
+// intersection ("Street1 & Street2"), or "" when unavailable. No-op when the
+// feature is disabled. Results are cache-backed (shared geocoder pogreb DB),
+// so repeat sightings at a fixed stop don't re-hit GeoNames.
+func (e *Enricher) addIntersection(m map[string]any, lat, lon float64) {
+	if e.Intersection == nil {
+		return
+	}
+	m["intersection"] = e.Intersection.GetIntersection(lat, lon)
 }
 
 // Tile mode constants. Defined here to avoid import cycles with cmd/processor.

--- a/processor/internal/enrichment/fort.go
+++ b/processor/internal/enrichment/fort.go
@@ -177,6 +177,7 @@ func (e *Enricher) FortUpdate(lat, lon float64, fortID string, fort *webhook.For
 
 	// Reverse geocoding
 	e.addGeoResult(m, lat, lon)
+	e.addIntersection(m, lat, lon)
 
 	// Static map tile — use autopositioned center if available, else original coords
 	mapLat, mapLon := lat, lon

--- a/processor/internal/enrichment/fort.go
+++ b/processor/internal/enrichment/fort.go
@@ -176,8 +176,7 @@ func (e *Enricher) FortUpdate(lat, lon float64, fortID string, fort *webhook.For
 	}
 
 	// Reverse geocoding
-	e.addGeoResult(m, lat, lon)
-	e.addIntersection(m, lat, lon)
+	e.addLocationFields(m, lat, lon)
 
 	// Static map tile — use autopositioned center if available, else original coords
 	mapLat, mapLon := lat, lon

--- a/processor/internal/enrichment/gym.go
+++ b/processor/internal/enrichment/gym.go
@@ -43,8 +43,7 @@ func (e *Enricher) Gym(lat, lon float64, teamID, oldTeamID, slotsAvailable, oldS
 	e.addMapURLs(m, lat, lon, "gyms", gymID)
 
 	// Reverse geocoding
-	e.addGeoResult(m, lat, lon)
-	e.addIntersection(m, lat, lon)
+	e.addLocationFields(m, lat, lon)
 
 	// Static map tile
 	pending := e.addStaticMap(m, "gym", lat, lon, map[string]any{

--- a/processor/internal/enrichment/gym.go
+++ b/processor/internal/enrichment/gym.go
@@ -44,6 +44,7 @@ func (e *Enricher) Gym(lat, lon float64, teamID, oldTeamID, slotsAvailable, oldS
 
 	// Reverse geocoding
 	e.addGeoResult(m, lat, lon)
+	e.addIntersection(m, lat, lon)
 
 	// Static map tile
 	pending := e.addStaticMap(m, "gym", lat, lon, map[string]any{

--- a/processor/internal/enrichment/invasion.go
+++ b/processor/internal/enrichment/invasion.go
@@ -92,6 +92,7 @@ func (e *Enricher) Invasion(lat, lon float64, expiration int64, pokestopID, poke
 
 	// Reverse geocoding
 	e.addGeoResult(m, lat, lon)
+	e.addIntersection(m, lat, lon)
 
 	// Grunt and display type IDs for DTS templates
 	m["gruntTypeId"] = gruntTypeID

--- a/processor/internal/enrichment/invasion.go
+++ b/processor/internal/enrichment/invasion.go
@@ -91,8 +91,7 @@ func (e *Enricher) Invasion(lat, lon float64, expiration int64, pokestopID, poke
 	e.addMapURLs(m, lat, lon, "pokestops", pokestopID)
 
 	// Reverse geocoding
-	e.addGeoResult(m, lat, lon)
-	e.addIntersection(m, lat, lon)
+	e.addLocationFields(m, lat, lon)
 
 	// Grunt and display type IDs for DTS templates
 	m["gruntTypeId"] = gruntTypeID

--- a/processor/internal/enrichment/lure.go
+++ b/processor/internal/enrichment/lure.go
@@ -45,8 +45,7 @@ func (e *Enricher) Lure(lure *webhook.LureWebhook, tileMode int) (map[string]any
 	e.addMapURLs(m, lure.Latitude, lure.Longitude, "pokestops", lure.PokestopID)
 
 	// Reverse geocoding
-	e.addGeoResult(m, lure.Latitude, lure.Longitude)
-	e.addIntersection(m, lure.Latitude, lure.Longitude)
+	e.addLocationFields(m, lure.Latitude, lure.Longitude)
 
 	// Static map tile — only pass non-zero lureTypeId so tileserver template nil checks work
 	var tileFields map[string]any

--- a/processor/internal/enrichment/lure.go
+++ b/processor/internal/enrichment/lure.go
@@ -46,6 +46,7 @@ func (e *Enricher) Lure(lure *webhook.LureWebhook, tileMode int) (map[string]any
 
 	// Reverse geocoding
 	e.addGeoResult(m, lure.Latitude, lure.Longitude)
+	e.addIntersection(m, lure.Latitude, lure.Longitude)
 
 	// Static map tile — only pass non-zero lureTypeId so tileserver template nil checks work
 	var tileFields map[string]any

--- a/processor/internal/enrichment/maxbattle.go
+++ b/processor/internal/enrichment/maxbattle.go
@@ -82,6 +82,7 @@ func (e *Enricher) Maxbattle(lat, lon float64, battleEnd int64, mb *webhook.Maxb
 
 	if mb == nil {
 		e.addGeoResult(m, lat, lon)
+		e.addIntersection(m, lat, lon)
 		return m, nil
 	}
 
@@ -90,6 +91,7 @@ func (e *Enricher) Maxbattle(lat, lon float64, battleEnd int64, mb *webhook.Maxb
 
 	// Reverse geocoding
 	e.addGeoResult(m, lat, lon)
+	e.addIntersection(m, lat, lon)
 
 	// Static map tile
 	pending := e.addStaticMap(m, "maxbattle", lat, lon, map[string]any{

--- a/processor/internal/enrichment/maxbattle.go
+++ b/processor/internal/enrichment/maxbattle.go
@@ -81,8 +81,7 @@ func (e *Enricher) Maxbattle(lat, lon float64, battleEnd int64, mb *webhook.Maxb
 	}
 
 	if mb == nil {
-		e.addGeoResult(m, lat, lon)
-		e.addIntersection(m, lat, lon)
+		e.addLocationFields(m, lat, lon)
 		return m, nil
 	}
 
@@ -90,8 +89,7 @@ func (e *Enricher) Maxbattle(lat, lon float64, battleEnd int64, mb *webhook.Maxb
 	e.addMapURLs(m, lat, lon, "stations", mb.ID)
 
 	// Reverse geocoding
-	e.addGeoResult(m, lat, lon)
-	e.addIntersection(m, lat, lon)
+	e.addLocationFields(m, lat, lon)
 
 	// Static map tile
 	pending := e.addStaticMap(m, "maxbattle", lat, lon, map[string]any{

--- a/processor/internal/enrichment/nest.go
+++ b/processor/internal/enrichment/nest.go
@@ -81,6 +81,7 @@ func (e *Enricher) Nest(nest *webhook.NestWebhook, tileMode int) (map[string]any
 
 	// Reverse geocoding
 	e.addGeoResult(m, nest.Lat, nest.Lon)
+	e.addIntersection(m, nest.Lat, nest.Lon)
 
 	// Static map tile — use autopositioned center if available, else original coords
 	mapLat, mapLon := nest.Lat, nest.Lon

--- a/processor/internal/enrichment/nest.go
+++ b/processor/internal/enrichment/nest.go
@@ -80,8 +80,7 @@ func (e *Enricher) Nest(nest *webhook.NestWebhook, tileMode int) (map[string]any
 	e.addMapURLs(m, nest.Lat, nest.Lon, "nests", strconv.FormatInt(nest.NestID, 10))
 
 	// Reverse geocoding
-	e.addGeoResult(m, nest.Lat, nest.Lon)
-	e.addIntersection(m, nest.Lat, nest.Lon)
+	e.addLocationFields(m, nest.Lat, nest.Lon)
 
 	// Static map tile — use autopositioned center if available, else original coords
 	mapLat, mapLon := nest.Lat, nest.Lon

--- a/processor/internal/enrichment/pokemon.go
+++ b/processor/internal/enrichment/pokemon.go
@@ -186,6 +186,7 @@ func (e *Enricher) Pokemon(pokemon *webhook.PokemonWebhook, processed *matching.
 
 	// Reverse geocoding
 	e.addGeoResult(m, pokemon.Latitude, pokemon.Longitude)
+	e.addIntersection(m, pokemon.Latitude, pokemon.Longitude)
 
 	// Static map tile
 	weather := pokemon.BoostedWeather

--- a/processor/internal/enrichment/pokemon.go
+++ b/processor/internal/enrichment/pokemon.go
@@ -185,8 +185,7 @@ func (e *Enricher) Pokemon(pokemon *webhook.PokemonWebhook, processed *matching.
 	}
 
 	// Reverse geocoding
-	e.addGeoResult(m, pokemon.Latitude, pokemon.Longitude)
-	e.addIntersection(m, pokemon.Latitude, pokemon.Longitude)
+	e.addLocationFields(m, pokemon.Latitude, pokemon.Longitude)
 
 	// Static map tile
 	weather := pokemon.BoostedWeather

--- a/processor/internal/enrichment/quest.go
+++ b/processor/internal/enrichment/quest.go
@@ -72,8 +72,7 @@ func (e *Enricher) Quest(lat, lon float64, pokestopID, pokestopURL string, rewar
 	e.addQuestIconURLs(m, rewards)
 
 	// Reverse geocoding
-	e.addGeoResult(m, lat, lon)
-	e.addIntersection(m, lat, lon)
+	e.addLocationFields(m, lat, lon)
 
 	// Static map tile
 	pending := e.addStaticMap(m, "quest", lat, lon, nil, tileMode, pokestopID)

--- a/processor/internal/enrichment/quest.go
+++ b/processor/internal/enrichment/quest.go
@@ -73,6 +73,7 @@ func (e *Enricher) Quest(lat, lon float64, pokestopID, pokestopURL string, rewar
 
 	// Reverse geocoding
 	e.addGeoResult(m, lat, lon)
+	e.addIntersection(m, lat, lon)
 
 	// Static map tile
 	pending := e.addStaticMap(m, "quest", lat, lon, nil, tileMode, pokestopID)

--- a/processor/internal/enrichment/raid.go
+++ b/processor/internal/enrichment/raid.go
@@ -118,6 +118,7 @@ func (e *Enricher) Raid(raid *webhook.RaidWebhook, firstNotification bool, tileM
 
 	// Reverse geocoding
 	e.addGeoResult(m, raid.Latitude, raid.Longitude)
+	e.addIntersection(m, raid.Latitude, raid.Longitude)
 
 	// Static map tile
 	pending := e.addStaticMap(m, "raid", raid.Latitude, raid.Longitude, map[string]any{

--- a/processor/internal/enrichment/raid.go
+++ b/processor/internal/enrichment/raid.go
@@ -117,8 +117,7 @@ func (e *Enricher) Raid(raid *webhook.RaidWebhook, firstNotification bool, tileM
 	m["campfireUrl"] = CampfireURL(raid.Latitude, raid.Longitude, raid.GymID, raid.GymName, raid.GymURL)
 
 	// Reverse geocoding
-	e.addGeoResult(m, raid.Latitude, raid.Longitude)
-	e.addIntersection(m, raid.Latitude, raid.Longitude)
+	e.addLocationFields(m, raid.Latitude, raid.Longitude)
 
 	// Static map tile
 	pending := e.addStaticMap(m, "raid", raid.Latitude, raid.Longitude, map[string]any{

--- a/processor/internal/enrichment/weather.go
+++ b/processor/internal/enrichment/weather.go
@@ -40,6 +40,7 @@ func (e *Enricher) Weather(lat, lon float64, gameplayCondition int, coords [][2]
 
 	// Reverse geocoding
 	e.addGeoResult(m, lat, lon)
+	e.addIntersection(m, lat, lon)
 
 	// Generate base weather tile (used when showAlteredPokemonStaticMap is false)
 	var pending *staticmap.TilePending

--- a/processor/internal/enrichment/weather.go
+++ b/processor/internal/enrichment/weather.go
@@ -39,8 +39,7 @@ func (e *Enricher) Weather(lat, lon float64, gameplayCondition int, coords [][2]
 	}
 
 	// Reverse geocoding
-	e.addGeoResult(m, lat, lon)
-	e.addIntersection(m, lat, lon)
+	e.addLocationFields(m, lat, lon)
 
 	// Generate base weather tile (used when showAlteredPokemonStaticMap is false)
 	var pending *staticmap.TilePending

--- a/processor/internal/geocoding/cache.go
+++ b/processor/internal/geocoding/cache.go
@@ -31,15 +31,25 @@ type Cache struct {
 	hitsMemory atomic.Uint64
 	hitsDisk   atomic.Uint64
 	misses     atomic.Uint64
+
+	// Intersection-layer counters are kept separate so they don't pollute the
+	// reverse-geocode cache-hit metrics operators tune cache_detail against.
+	isectHitsMemory atomic.Uint64
+	isectHitsDisk   atomic.Uint64
+	isectMisses     atomic.Uint64
 }
 
 // CacheStats is a point-in-time snapshot of geocoder cache health.
 type CacheStats struct {
 	MemoryEntries int    // entries currently in the in-memory layer
-	DiskEntries   int    // entries in the on-disk pogreb layer
-	HitsMemory    uint64 // total memory-layer hits since process start
-	HitsDisk      uint64 // total disk-layer hits since process start
-	Misses        uint64 // total misses since process start
+	DiskEntries   int    // entries in the on-disk pogreb layer (address + intersection share one DB)
+	HitsMemory    uint64 // total address memory-layer hits since process start
+	HitsDisk      uint64 // total address disk-layer hits since process start
+	Misses        uint64 // total address misses since process start
+
+	IsectHitsMemory uint64 // intersection memory-layer hits since process start
+	IsectHitsDisk   uint64 // intersection disk-layer hits since process start
+	IsectMisses     uint64 // intersection misses since process start
 }
 
 // NewCache opens or creates a two-layer cache.
@@ -140,19 +150,24 @@ func (c *Cache) Get(key string) (*Address, bool) {
 // Stats returns a point-in-time snapshot of cache health metrics.
 func (c *Cache) Stats() CacheStats {
 	return CacheStats{
-		MemoryEntries: c.mem.Len(),
-		DiskEntries:   int(c.disk.Count()),
-		HitsMemory:    c.hitsMemory.Load(),
-		HitsDisk:      c.hitsDisk.Load(),
-		Misses:        c.misses.Load(),
+		MemoryEntries:   c.mem.Len() + c.memISect.Len(),
+		DiskEntries:     int(c.disk.Count()),
+		HitsMemory:      c.hitsMemory.Load(),
+		HitsDisk:        c.hitsDisk.Load(),
+		Misses:          c.misses.Load(),
+		IsectHitsMemory: c.isectHitsMemory.Load(),
+		IsectHitsDisk:   c.isectHitsDisk.Load(),
+		IsectMisses:     c.isectMisses.Load(),
 	}
 }
 
-// ClearMemory drops all entries from the in-memory layer. The disk layer is
-// left untouched. Returns the number of entries that were removed.
+// ClearMemory drops all entries from both in-memory layers (address +
+// intersection). The disk layer is left untouched. Returns the number of
+// entries that were removed.
 func (c *Cache) ClearMemory() int {
-	n := c.mem.Len()
+	n := c.mem.Len() + c.memISect.Len()
 	c.mem.DeleteAll()
+	c.memISect.DeleteAll()
 	return n
 }
 
@@ -175,13 +190,13 @@ func (c *Cache) Set(key string, addr *Address) {
 // here") and is returned as ("", true), distinct from a never-stored miss.
 func (c *Cache) GetIntersection(key string) (string, bool) {
 	if item := c.memISect.Get(key); item != nil {
-		c.hitsMemory.Add(1)
+		c.isectHitsMemory.Add(1)
 		return item.Value(), true
 	}
 
 	data, err := c.disk.Get([]byte(key))
 	if err != nil || data == nil {
-		c.misses.Add(1)
+		c.isectMisses.Add(1)
 		return "", false
 	}
 
@@ -190,11 +205,11 @@ func (c *Cache) GetIntersection(key string) (string, bool) {
 	// from "missing".
 	var val string
 	if err := json.Unmarshal(data, &val); err != nil {
-		c.misses.Add(1)
+		c.isectMisses.Add(1)
 		return "", false
 	}
 
-	c.hitsDisk.Add(1)
+	c.isectHitsDisk.Add(1)
 	c.memISect.Set(key, val, ttlcache.DefaultTTL)
 	return val, true
 }

--- a/processor/internal/geocoding/cache.go
+++ b/processor/internal/geocoding/cache.go
@@ -20,6 +20,14 @@ type Cache struct {
 	mem  *ttlcache.Cache[string, *Address]
 	disk *pogreb.DB
 
+	// memISect is a second in-memory layer for intersection strings. pogreb
+	// is a single key-value store with no notion of tables, so intersections
+	// share the same on-disk DB as addresses but under a distinct key
+	// namespace (see IntersectionCacheKey) — effectively a second logical
+	// table in one file. A separate mem layer keeps the address layer's
+	// *Address typing clean.
+	memISect *ttlcache.Cache[string, string]
+
 	hitsMemory atomic.Uint64
 	hitsDisk   atomic.Uint64
 	misses     atomic.Uint64
@@ -57,10 +65,29 @@ func NewCache(diskPath string, memTTL time.Duration, memMaxSize int) (*Cache, er
 	mem := ttlcache.New(opts...)
 	go mem.Start() // start eviction goroutine
 
+	isectOpts := []ttlcache.Option[string, string]{ttlcache.WithTTL[string, string](memTTL)}
+	if memMaxSize > 0 {
+		isectOpts = append(isectOpts, ttlcache.WithCapacity[string, string](uint64(memMaxSize)))
+	}
+	memISect := ttlcache.New(isectOpts...)
+	go memISect.Start()
+
 	return &Cache{
-		mem:  mem,
-		disk: disk,
+		mem:      mem,
+		memISect: memISect,
+		disk:     disk,
 	}, nil
+}
+
+// intersectionKeyPrefix namespaces intersection entries within the shared
+// pogreb DB so they never collide with reverse-geocode address keys.
+const intersectionKeyPrefix = "isect:"
+
+// IntersectionCacheKey builds an intersection cache key from lat/lon rounded
+// to the given number of decimal places. Intersections are coordinate-only
+// (no language), prefixed to stay isolated from address keys in the shared DB.
+func IntersectionCacheKey(lat, lon float64, detail int) string {
+	return intersectionKeyPrefix + CacheKey(lat, lon, detail)
 }
 
 // CacheKey builds a cache key from lat/lon rounded to the given number of
@@ -142,8 +169,53 @@ func (c *Cache) Set(key string, addr *Address) {
 	}
 }
 
-// Close stops the memory cache eviction loop and closes the disk database.
+// GetIntersection looks up a cached intersection string by key (built with
+// IntersectionCacheKey). Memory first, then disk; a disk hit is promoted to
+// memory. A cached empty string is a HIT (negative cache for "no intersection
+// here") and is returned as ("", true), distinct from a never-stored miss.
+func (c *Cache) GetIntersection(key string) (string, bool) {
+	if item := c.memISect.Get(key); item != nil {
+		c.hitsMemory.Add(1)
+		return item.Value(), true
+	}
+
+	data, err := c.disk.Get([]byte(key))
+	if err != nil || data == nil {
+		c.misses.Add(1)
+		return "", false
+	}
+
+	// Values are JSON-encoded strings so an empty intersection serializes as
+	// `""` (2 bytes) — never a zero-length value pogreb can't distinguish
+	// from "missing".
+	var val string
+	if err := json.Unmarshal(data, &val); err != nil {
+		c.misses.Add(1)
+		return "", false
+	}
+
+	c.hitsDisk.Add(1)
+	c.memISect.Set(key, val, ttlcache.DefaultTTL)
+	return val, true
+}
+
+// SetIntersection writes an intersection string to both memory and the shared
+// disk DB. An empty value is stored deliberately (negative cache).
+func (c *Cache) SetIntersection(key, value string) {
+	c.memISect.Set(key, value, ttlcache.DefaultTTL)
+
+	data, err := json.Marshal(value)
+	if err != nil {
+		return
+	}
+	if err := c.disk.Put([]byte(key), data); err != nil {
+		log.Debugf("geocache: intersection disk write failed for %s: %s", key, err)
+	}
+}
+
+// Close stops the memory cache eviction loops and closes the disk database.
 func (c *Cache) Close() error {
 	c.mem.Stop()
+	c.memISect.Stop()
 	return c.disk.Close()
 }

--- a/processor/internal/geocoding/cache_test.go
+++ b/processor/internal/geocoding/cache_test.go
@@ -126,6 +126,61 @@ func TestCacheStats_DiskHitIncrements(t *testing.T) {
 	}
 }
 
+func TestCache_Intersection_RoundTrip(t *testing.T) {
+	c := newTestCache(t)
+	key := IntersectionCacheKey(52.5, 13.4, 4)
+
+	// Miss before anything is stored.
+	if _, ok := c.GetIntersection(key); ok {
+		t.Fatal("expected intersection miss on fresh cache")
+	}
+
+	c.SetIntersection(key, "Main St & 2nd Ave")
+	got, ok := c.GetIntersection(key)
+	if !ok || got != "Main St & 2nd Ave" {
+		t.Fatalf("GetIntersection after Set: got (%q, %v), want (%q, true)", got, ok, "Main St & 2nd Ave")
+	}
+}
+
+// A negative result ("no intersection here") is a stable fact and must be
+// cached so we don't re-query GeoNames forever for rural stops. The empty
+// string must round-trip as a HIT, distinct from a never-stored MISS.
+func TestCache_Intersection_NegativeCaches(t *testing.T) {
+	c := newTestCache(t)
+	key := IntersectionCacheKey(0, 0, 4)
+
+	c.SetIntersection(key, "")
+	got, ok := c.GetIntersection(key)
+	if !ok {
+		t.Fatal("cached empty intersection should be a HIT, not a miss")
+	}
+	if got != "" {
+		t.Fatalf("GetIntersection: got %q, want empty string", got)
+	}
+}
+
+// Intersection entries share the pogreb DB with addresses but live under a
+// distinct key namespace, so an address key and an intersection key derived
+// from the same coordinates never collide.
+func TestCache_Intersection_NamespaceIsolation(t *testing.T) {
+	c := newTestCache(t)
+	addrKey := CacheKey(52.5, 13.4, 4)
+	isectKey := IntersectionCacheKey(52.5, 13.4, 4)
+	if addrKey == isectKey {
+		t.Fatalf("intersection key %q must differ from address key %q", isectKey, addrKey)
+	}
+
+	c.Set(addrKey, testAddr)
+	c.SetIntersection(isectKey, "A & B")
+
+	if _, ok := c.GetIntersection(addrKey); ok {
+		t.Error("address key should not resolve as an intersection")
+	}
+	if a, ok := c.Get(addrKey); !ok || a.City != "Berlin" {
+		t.Error("address lookup broken by intersection write")
+	}
+}
+
 func TestCache_ClearMemory_Empties(t *testing.T) {
 	c := newTestCache(t)
 

--- a/processor/internal/geocoding/geocoder.go
+++ b/processor/internal/geocoding/geocoder.go
@@ -258,6 +258,13 @@ func (g *Geocoder) CacheStats() CacheStats {
 	return g.cache.Stats()
 }
 
+// Cache returns the geocoder's two-layer cache so other geocoding features
+// (e.g. intersection lookups) can share the same pogreb DB. Returns nil when
+// no cache is configured.
+func (g *Geocoder) Cache() *Cache {
+	return g.cache
+}
+
 // ClearCache drops all entries from the in-memory cache layer.
 // Returns the number of entries cleared. Safe to call when no cache is configured.
 func (g *Geocoder) ClearCache() int {

--- a/processor/internal/geocoding/intersection.go
+++ b/processor/internal/geocoding/intersection.go
@@ -1,0 +1,171 @@
+package geocoding
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// defaultIntersectionBaseURL is the GeoNames OSM intersection endpoint. The
+// OSM variant (vs the US-only findNearestIntersectionJSON used by PoracleJS)
+// gives worldwide coverage.
+const defaultIntersectionBaseURL = "https://api.geonames.org/findNearestIntersectionOSMJSON"
+
+// IntersectionConfig configures intersection lookups.
+type IntersectionConfig struct {
+	// Usernames is the pool of GeoNames usernames; one is picked at random
+	// per uncached lookup to spread credit usage. Empty disables lookups.
+	Usernames []string
+	// Cache, when non-nil, is shared with the reverse geocoder so intersection
+	// results live in the same pogreb DB (under a separate key namespace).
+	// When nil, lookups run uncached.
+	Cache *Cache
+	// CacheDetail is the lat/lon rounding (decimal places) for cache keys.
+	// Defaults to 3 when <= 0.
+	CacheDetail int
+	// TimeoutMs is the per-request HTTP timeout. Defaults to 5000.
+	TimeoutMs int
+	// Concurrency bounds simultaneous outbound GeoNames requests so a cold
+	// cache can't tie up the whole webhook worker pool. Defaults to 5.
+	Concurrency int
+}
+
+// Intersection fetches the nearest street intersection for a coordinate from
+// GeoNames, with optional shared-cache backing. Reuses a single HTTP client
+// and bounds concurrency.
+type Intersection struct {
+	usernames   []string
+	cache       *Cache
+	cacheDetail int
+	client      *http.Client
+	sem         chan struct{}
+	baseURL     string // overridable in tests
+}
+
+// NewIntersection builds an Intersection from config. Returns a usable (no-op
+// on empty usernames) instance.
+func NewIntersection(cfg IntersectionConfig) *Intersection {
+	detail := cfg.CacheDetail
+	if detail <= 0 {
+		detail = 3
+	}
+	timeout := cfg.TimeoutMs
+	if timeout <= 0 {
+		timeout = 5000
+	}
+	conc := cfg.Concurrency
+	if conc <= 0 {
+		conc = 5
+	}
+	return &Intersection{
+		usernames:   cfg.Usernames,
+		cache:       cfg.Cache,
+		cacheDetail: detail,
+		client:      &http.Client{Timeout: time.Duration(timeout) * time.Millisecond},
+		sem:         make(chan struct{}, conc),
+		baseURL:     defaultIntersectionBaseURL,
+	}
+}
+
+// geonamesResponse models the fields we read from the GeoNames reply. Over-quota
+// and other API-level errors arrive as HTTP 200 with a populated Status object.
+type geonamesResponse struct {
+	Intersection struct {
+		Street1 string `json:"street1"`
+		Street2 string `json:"street2"`
+	} `json:"intersection"`
+	Status *struct {
+		Message string `json:"message"`
+		Value   int    `json:"value"`
+	} `json:"status"`
+}
+
+// GetIntersection returns "<street1> & <street2>" for the nearest intersection,
+// or "" when none is found, lookups are disabled, or the request fails. A
+// successful result (including a stable "no intersection here") is cached;
+// transient failures are not, so they retry on the next sighting.
+func (i *Intersection) GetIntersection(lat, lon float64) string {
+	if len(i.usernames) == 0 {
+		return ""
+	}
+
+	var cacheKey string
+	if i.cache != nil {
+		cacheKey = IntersectionCacheKey(lat, lon, i.cacheDetail)
+		if v, ok := i.cache.GetIntersection(cacheKey); ok {
+			return v
+		}
+	}
+
+	result, ok := i.fetch(lat, lon)
+	if !ok {
+		// Transient failure — don't cache, so a later sighting retries.
+		return ""
+	}
+	if i.cache != nil {
+		i.cache.SetIntersection(cacheKey, result)
+	}
+	return result
+}
+
+// fetch performs one GeoNames request. The bool reports whether the call
+// produced a usable answer (true even when the answer is "no intersection",
+// which is a cacheable fact); false means a transient error not worth caching.
+func (i *Intersection) fetch(lat, lon float64) (string, bool) {
+	i.sem <- struct{}{}
+	defer func() { <-i.sem }()
+
+	username := i.usernames[rand.Intn(len(i.usernames))] //nolint:gosec // username pick, not security-sensitive
+
+	q := url.Values{}
+	q.Set("lat", strconv.FormatFloat(lat, 'f', -1, 64))
+	q.Set("lng", strconv.FormatFloat(lon, 'f', -1, 64))
+	q.Set("username", username)
+	reqURL := i.baseURL + "?" + q.Encode()
+
+	ctx, cancel := context.WithTimeout(context.Background(), i.client.Timeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		log.Debugf("GeoNames intersection: build request: %v", err)
+		return "", false
+	}
+
+	resp, err := i.client.Do(req)
+	if err != nil {
+		log.Warnf("GeoNames intersection request failed for %f,%f: %v", lat, lon, err)
+		return "", false
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		log.Warnf("GeoNames intersection: HTTP %d for %f,%f", resp.StatusCode, lat, lon)
+		return "", false
+	}
+
+	var result geonamesResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		log.Warnf("GeoNames intersection: decode response: %v", err)
+		return "", false
+	}
+
+	// API-level error (e.g. credit exhaustion) — surface it and don't cache.
+	if result.Status != nil {
+		log.Warnf("GeoNames intersection: API error %d for %f,%f: %s", result.Status.Value, lat, lon, result.Status.Message)
+		return "", false
+	}
+
+	if result.Intersection.Street1 != "" && result.Intersection.Street2 != "" {
+		return fmt.Sprintf("%s & %s", result.Intersection.Street1, result.Intersection.Street2), true
+	}
+
+	// Successful call, genuinely no intersection nearby — cacheable.
+	return "", true
+}

--- a/processor/internal/geocoding/intersection.go
+++ b/processor/internal/geocoding/intersection.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"net/http"
 	"net/url"
 	"strconv"
+	"sync"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -33,13 +34,22 @@ type IntersectionConfig struct {
 	// TimeoutMs is the per-request HTTP timeout. Defaults to 5000.
 	TimeoutMs int
 	// Concurrency bounds simultaneous outbound GeoNames requests so a cold
-	// cache can't tie up the whole webhook worker pool. Defaults to 5.
+	// cache can't tie up the whole webhook worker pool. Defaults to 5. This is
+	// independent of the reverse geocoder's limiter — GeoNames is a separate
+	// service with its own credit pool.
 	Concurrency int
+	// FailureThreshold is the number of consecutive failures before the circuit
+	// opens (stops calling GeoNames). Defaults to 5.
+	FailureThreshold int
+	// CooldownMs is how long the circuit stays open before a half-open probe.
+	// Defaults to 30000.
+	CooldownMs int
 }
 
 // Intersection fetches the nearest street intersection for a coordinate from
-// GeoNames, with optional shared-cache backing. Reuses a single HTTP client
-// and bounds concurrency.
+// GeoNames, with optional shared-cache backing. Reuses a single HTTP client,
+// bounds concurrency, and trips a circuit breaker so a GeoNames outage can't
+// park webhook workers on doomed requests.
 type Intersection struct {
 	usernames   []string
 	cache       *Cache
@@ -47,6 +57,15 @@ type Intersection struct {
 	client      *http.Client
 	sem         chan struct{}
 	baseURL     string // overridable in tests
+
+	// Circuit breaker (mirrors Geocoder): after failureThreshold consecutive
+	// failures the circuit opens for cooldown, then allows one half-open probe.
+	failureThreshold    int
+	cooldown            time.Duration
+	mu                  sync.Mutex
+	consecutiveErrors   int
+	circuitOpenSince    time.Time
+	halfOpenProbeActive bool
 }
 
 // NewIntersection builds an Intersection from config. Returns a usable (no-op
@@ -64,13 +83,23 @@ func NewIntersection(cfg IntersectionConfig) *Intersection {
 	if conc <= 0 {
 		conc = 5
 	}
+	threshold := cfg.FailureThreshold
+	if threshold <= 0 {
+		threshold = 5
+	}
+	cooldownMs := cfg.CooldownMs
+	if cooldownMs <= 0 {
+		cooldownMs = 30000
+	}
 	return &Intersection{
-		usernames:   cfg.Usernames,
-		cache:       cfg.Cache,
-		cacheDetail: detail,
-		client:      &http.Client{Timeout: time.Duration(timeout) * time.Millisecond},
-		sem:         make(chan struct{}, conc),
-		baseURL:     defaultIntersectionBaseURL,
+		usernames:        cfg.Usernames,
+		cache:            cfg.Cache,
+		cacheDetail:      detail,
+		client:           &http.Client{Timeout: time.Duration(timeout) * time.Millisecond},
+		sem:              make(chan struct{}, conc),
+		baseURL:          defaultIntersectionBaseURL,
+		failureThreshold: threshold,
+		cooldown:         time.Duration(cooldownMs) * time.Millisecond,
 	}
 }
 
@@ -90,7 +119,7 @@ type geonamesResponse struct {
 // GetIntersection returns "<street1> & <street2>" for the nearest intersection,
 // or "" when none is found, lookups are disabled, or the request fails. A
 // successful result (including a stable "no intersection here") is cached;
-// transient failures are not, so they retry on the next sighting.
+// transient failures and circuit-open skips are not, so they retry later.
 func (i *Intersection) GetIntersection(lat, lon float64) string {
 	if len(i.usernames) == 0 {
 		return ""
@@ -106,7 +135,8 @@ func (i *Intersection) GetIntersection(lat, lon float64) string {
 
 	result, ok := i.fetch(lat, lon)
 	if !ok {
-		// Transient failure — don't cache, so a later sighting retries.
+		// Transient failure or open circuit — don't cache, so a later sighting
+		// retries once the service recovers.
 		return ""
 	}
 	if i.cache != nil {
@@ -115,14 +145,69 @@ func (i *Intersection) GetIntersection(lat, lon float64) string {
 	return result
 }
 
-// fetch performs one GeoNames request. The bool reports whether the call
-// produced a usable answer (true even when the answer is "no intersection",
-// which is a cacheable fact); false means a transient error not worth caching.
+// circuitAllows reports whether a request may proceed. When the circuit is
+// open and still within cooldown, it denies; after cooldown it lets exactly
+// one half-open probe through.
+func (i *Intersection) circuitAllows() bool {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	if i.consecutiveErrors < i.failureThreshold {
+		return true
+	}
+	if time.Since(i.circuitOpenSince) < i.cooldown {
+		return false
+	}
+	if i.halfOpenProbeActive {
+		return false
+	}
+	i.halfOpenProbeActive = true
+	return true
+}
+
+// recordSuccess closes the circuit after a healthy response.
+func (i *Intersection) recordSuccess() {
+	i.mu.Lock()
+	i.consecutiveErrors = 0
+	i.halfOpenProbeActive = false
+	i.mu.Unlock()
+}
+
+// recordFailure advances the failure count and opens the circuit at the
+// threshold.
+func (i *Intersection) recordFailure() {
+	i.mu.Lock()
+	i.consecutiveErrors++
+	i.halfOpenProbeActive = false
+	if i.consecutiveErrors >= i.failureThreshold {
+		i.circuitOpenSince = time.Now()
+	}
+	i.mu.Unlock()
+}
+
+// fetch performs one GeoNames request, gated by the circuit breaker and
+// concurrency limiter. The bool reports whether the call produced a usable
+// answer (true even when the answer is "no intersection", which is a cacheable
+// fact); false means a transient error or open circuit not worth caching.
 func (i *Intersection) fetch(lat, lon float64) (string, bool) {
+	if !i.circuitAllows() {
+		log.Debugf("GeoNames intersection: circuit open, skipping %f,%f", lat, lon)
+		return "", false
+	}
+
 	i.sem <- struct{}{}
 	defer func() { <-i.sem }()
 
-	username := i.usernames[rand.Intn(len(i.usernames))] //nolint:gosec // username pick, not security-sensitive
+	// Classify the outcome for the circuit breaker exactly once on return.
+	healthy := false
+	defer func() {
+		if healthy {
+			i.recordSuccess()
+		} else {
+			i.recordFailure()
+		}
+	}()
+
+	username := i.usernames[rand.IntN(len(i.usernames))]
 
 	q := url.Values{}
 	q.Set("lat", strconv.FormatFloat(lat, 'f', -1, 64))
@@ -156,12 +241,13 @@ func (i *Intersection) fetch(lat, lon float64) (string, bool) {
 		return "", false
 	}
 
-	// API-level error (e.g. credit exhaustion) — surface it and don't cache.
+	// API-level error (e.g. credit exhaustion) — surface it and trip the breaker.
 	if result.Status != nil {
 		log.Warnf("GeoNames intersection: API error %d for %f,%f: %s", result.Status.Value, lat, lon, result.Status.Message)
 		return "", false
 	}
 
+	healthy = true
 	if result.Intersection.Street1 != "" && result.Intersection.Street2 != "" {
 		return fmt.Sprintf("%s & %s", result.Intersection.Street1, result.Intersection.Street2), true
 	}

--- a/processor/internal/geocoding/intersection.go
+++ b/processor/internal/geocoding/intersection.go
@@ -16,8 +16,9 @@ import (
 
 // defaultIntersectionBaseURL is the GeoNames OSM intersection endpoint. The
 // OSM variant (vs the US-only findNearestIntersectionJSON used by PoracleJS)
-// gives worldwide coverage.
-const defaultIntersectionBaseURL = "https://api.geonames.org/findNearestIntersectionOSMJSON"
+// gives worldwide coverage. HTTPS is served from the secure.geonames.org host —
+// api.geonames.org does not answer over TLS.
+const defaultIntersectionBaseURL = "https://secure.geonames.org/findNearestIntersectionOSMJSON"
 
 // IntersectionConfig configures intersection lookups.
 type IntersectionConfig struct {

--- a/processor/internal/geocoding/intersection_test.go
+++ b/processor/internal/geocoding/intersection_test.go
@@ -1,0 +1,137 @@
+package geocoding
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// newIntersectionWithBase builds an Intersection pointing at a test server
+// by overriding the base URL. Cache is optional.
+func newIntersectionWithServer(t *testing.T, handler http.HandlerFunc, cache *Cache) *Intersection {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	i := NewIntersection(IntersectionConfig{
+		Usernames:   []string{"demo"},
+		Cache:       cache,
+		CacheDetail: 4,
+		TimeoutMs:   2000,
+	})
+	i.baseURL = srv.URL
+	return i
+}
+
+func TestIntersection_ParsesStreets(t *testing.T) {
+	i := newIntersectionWithServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Write([]byte(`{"intersection":{"street1":"Main St","street2":"2nd Ave"}}`))
+	}, nil)
+
+	if got := i.GetIntersection(40.0, -73.0); got != "Main St & 2nd Ave" {
+		t.Errorf("got %q, want %q", got, "Main St & 2nd Ave")
+	}
+}
+
+func TestIntersection_EmptyOnNoStreets(t *testing.T) {
+	i := newIntersectionWithServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Write([]byte(`{"intersection":{}}`))
+	}, nil)
+
+	if got := i.GetIntersection(40.0, -73.0); got != "" {
+		t.Errorf("got %q, want empty string", got)
+	}
+}
+
+func TestIntersection_EmptyOnGeoNamesError(t *testing.T) {
+	// GeoNames signals over-quota with HTTP 200 + a status object.
+	i := newIntersectionWithServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Write([]byte(`{"status":{"message":"the hourly limit of 1000 credits has been exceeded","value":19}}`))
+	}, nil)
+
+	if got := i.GetIntersection(40.0, -73.0); got != "" {
+		t.Errorf("got %q, want empty string on GeoNames error", got)
+	}
+}
+
+func TestIntersection_EmptyOnHTTP500(t *testing.T) {
+	i := newIntersectionWithServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}, nil)
+
+	if got := i.GetIntersection(40.0, -73.0); got != "" {
+		t.Errorf("got %q, want empty string on HTTP 500", got)
+	}
+}
+
+// A successful lookup is cached so the second call makes no HTTP request.
+func TestIntersection_CachesSuccess(t *testing.T) {
+	cache := newTestCache(t)
+	var calls atomic.Int32
+	i := newIntersectionWithServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		w.Write([]byte(`{"intersection":{"street1":"A","street2":"B"}}`))
+	}, cache)
+
+	if got := i.GetIntersection(1.23456, 2.34567); got != "A & B" {
+		t.Fatalf("first call got %q", got)
+	}
+	if got := i.GetIntersection(1.23456, 2.34567); got != "A & B" {
+		t.Fatalf("second call got %q", got)
+	}
+	if n := calls.Load(); n != 1 {
+		t.Errorf("expected 1 HTTP call (second served from cache), got %d", n)
+	}
+}
+
+// A stable "no intersection" result is negative-cached: no repeat HTTP call.
+func TestIntersection_NegativeCaches(t *testing.T) {
+	cache := newTestCache(t)
+	var calls atomic.Int32
+	i := newIntersectionWithServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		w.Write([]byte(`{"intersection":{}}`))
+	}, cache)
+
+	i.GetIntersection(5.5, 6.6)
+	i.GetIntersection(5.5, 6.6)
+	if n := calls.Load(); n != 1 {
+		t.Errorf("expected 1 HTTP call (empty result negative-cached), got %d", n)
+	}
+}
+
+// A transient failure (HTTP 500) must NOT be cached — it should retry.
+func TestIntersection_DoesNotCacheFailure(t *testing.T) {
+	cache := newTestCache(t)
+	var calls atomic.Int32
+	i := newIntersectionWithServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}, cache)
+
+	i.GetIntersection(7.7, 8.8)
+	i.GetIntersection(7.7, 8.8)
+	if n := calls.Load(); n != 2 {
+		t.Errorf("expected 2 HTTP calls (failures not cached), got %d", n)
+	}
+}
+
+func TestIntersection_NoUsernamesReturnsEmpty(t *testing.T) {
+	i := NewIntersection(IntersectionConfig{Usernames: nil})
+	if got := i.GetIntersection(1, 2); got != "" {
+		t.Errorf("got %q, want empty with no usernames", got)
+	}
+}
+
+func TestIntersection_RespectsTimeout(t *testing.T) {
+	i := newIntersectionWithServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(200 * time.Millisecond)
+		w.Write([]byte(`{"intersection":{"street1":"A","street2":"B"}}`))
+	}, nil)
+	i.client.Timeout = 50 * time.Millisecond
+
+	if got := i.GetIntersection(1, 2); got != "" {
+		t.Errorf("got %q, want empty on timeout", got)
+	}
+}

--- a/processor/internal/geocoding/intersection_test.go
+++ b/processor/internal/geocoding/intersection_test.go
@@ -124,6 +124,79 @@ func TestIntersection_NoUsernamesReturnsEmpty(t *testing.T) {
 	}
 }
 
+// After FailureThreshold consecutive failures the circuit opens and further
+// lookups return immediately without hitting GeoNames (until cooldown).
+func TestIntersection_CircuitBreakerOpensAfterFailures(t *testing.T) {
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+
+	i := NewIntersection(IntersectionConfig{
+		Usernames:        []string{"demo"},
+		TimeoutMs:        2000,
+		FailureThreshold: 3,
+		CooldownMs:       60000, // long cooldown so the circuit stays open in-test
+	})
+	i.baseURL = srv.URL
+
+	// First 3 calls hit the server and fail, tripping the breaker.
+	for n := 0; n < 3; n++ {
+		if got := i.GetIntersection(float64(n), 0); got != "" {
+			t.Fatalf("call %d: got %q, want empty", n, got)
+		}
+	}
+	// Subsequent calls are short-circuited — no further HTTP.
+	for n := 0; n < 5; n++ {
+		i.GetIntersection(float64(100+n), 0)
+	}
+	if c := calls.Load(); c != 3 {
+		t.Errorf("expected 3 HTTP calls before the circuit opened, got %d", c)
+	}
+}
+
+// A success after failures resets the breaker.
+func TestIntersection_CircuitBreakerResetsOnSuccess(t *testing.T) {
+	var fail atomic.Bool
+	fail.Store(true)
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		if fail.Load() {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.Write([]byte(`{"intersection":{"street1":"A","street2":"B"}}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	i := NewIntersection(IntersectionConfig{
+		Usernames:        []string{"demo"},
+		TimeoutMs:        2000,
+		FailureThreshold: 5,
+	})
+	i.baseURL = srv.URL
+
+	// 2 failures (below threshold), then a success resets the counter.
+	i.GetIntersection(1, 0)
+	i.GetIntersection(2, 0)
+	fail.Store(false)
+	if got := i.GetIntersection(3, 0); got != "A & B" {
+		t.Fatalf("recovery call got %q", got)
+	}
+	// Breaker reset: 4 more failures shouldn't open it (counter started over).
+	fail.Store(true)
+	before := calls.Load()
+	for n := 0; n < 4; n++ {
+		i.GetIntersection(float64(10+n), 0)
+	}
+	if c := calls.Load() - before; c != 4 {
+		t.Errorf("expected 4 HTTP calls after reset (circuit still closed), got %d", c)
+	}
+}
+
 func TestIntersection_RespectsTimeout(t *testing.T) {
 	i := newIntersectionWithServer(t, func(w http.ResponseWriter, _ *http.Request) {
 		time.Sleep(200 * time.Millisecond)


### PR DESCRIPTION
Takes over #151 (thanks @auisgold for the original port) and addresses the review feedback there. Keeps the OSM endpoint change (worldwide coverage) as agreed.

## What this adds
A `{{intersection}}` DTS field populated from GeoNames `findNearestIntersectionOSM` — the nearest street intersection (`"Street1 & Street2"`) for an alert's coordinates. Registered as a **common** field, so it's available on every DTS type.

## The headline fix: caching, shared with the geocoder
The original port did an **uncached, blocking** GeoNames request on the enrichment hot path for every webhook. This now shares the reverse-geocoder's pogreb cache.

pogreb is a single key-value store with no notion of tables, so the answer to "can it have more than one table?" is: **namespace the keys in the same DB**. Intersection entries live in the same on-disk pogreb file as addresses but under an `"isect:"` key prefix (`IntersectionCacheKey`), with their own in-memory layer — effectively a second logical table in one file. Pokestops/gyms are fixed coordinates, so the coord-rounded cache reaches near-100% hit rate after warm-up.

- **Negative caching:** a stable "no intersection here" is cached (so rural stops don't re-query forever); transient failures are **not** cached, so they retry on the next sighting.
- **Sharing:** when a reverse-geocode provider is configured, the cache is shared automatically. If geocoding is `none` there's no geocache to share, so intersection runs uncached (still concurrency-bounded) — `intersection_users` without a geocoder is the only uncached path.

## Other review corrections
- Reuse one `http.Client`; bound outbound calls with a semaphore so a cold cache can't exhaust the webhook worker pool (Go blocks a goroutine where PoracleJS's `await` yielded the event loop).
- Global `rand` instead of a per-call time-seeded source.
- HTTPS + `context`-with-timeout instead of a bare `http.Get`.
- Decode GeoNames' HTTP-200 error body (e.g. credit exhaustion) and log at **Warn** with the reason, instead of silently degrading to a sentinel.
- Return `""` consistently on every failure/empty path so templates can do `{{#if intersection}}`. **Note:** this diverges from PoracleJS, which returned the literal `"No Intersection"`; chose `""` to match this codebase's empty-on-failure geocoding convention.

## Plumbing the original PR was missing
- `intersection` in `commonFields` (`internal/api/dts_fields.go`) → advertised for every type by `/api/dts/fields/{type}`
- `DTS.md` location-fields table
- `[geocoding] intersection_users` in `config.example.toml`
- geocoding section of the online config-editor schema (`internal/api/config_schema.go`)

## Tests
- `cache_test.go`: intersection round-trip, negative cache (empty = hit), address/intersection namespace isolation
- `intersection_test.go` (httptest): street parsing, empty-on-no-streets, GeoNames error body, HTTP 500, success caching (1 HTTP call), negative caching, failures-not-cached, no-usernames no-op, timeout

Full gate green: `go build ./... && go vet ./... && go test -count=1 ./... && golangci-lint run ./...`

Closes #151.

🤖 Generated with [Claude Code](https://claude.com/claude-code)