### PR TITLE
breaker: shared circuit-breaker wrapper (gobreaker) + cover AccuWeather & Shlink

### DIFF
--- a/processor/go.mod
+++ b/processor/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/prometheus/client_model v0.6.2
 	github.com/ringsaturn/tzf v1.2.1
 	github.com/sirupsen/logrus v1.9.4
+	github.com/sony/gobreaker/v2 v2.4.0
 	github.com/stretchr/testify v1.11.1
 	github.com/tidwall/rtree v1.10.0
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1

--- a/processor/go.sum
+++ b/processor/go.sum
@@ -168,6 +168,8 @@ github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0t
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/sirupsen/logrus v1.9.4 h1:TsZE7l11zFCLZnZ+teH4Umoq5BhEIfIzfRDZ1Uzql2w=
 github.com/sirupsen/logrus v1.9.4/go.mod h1:ftWc9WdOfJ0a92nsE2jF5u5ZwH8Bv2zdeOC42RjbV2g=
+github.com/sony/gobreaker/v2 v2.4.0 h1:g2KJRW1Ubty3+ZOcSEUN7K+REQJdN6yo6XvaML+jptg=
+github.com/sony/gobreaker/v2 v2.4.0/go.mod h1:pTyFJgcZ3h2tdQVLZZruK2C0eoFL1fb/G83wK1ZQl+s=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=

--- a/processor/internal/breaker/breaker.go
+++ b/processor/internal/breaker/breaker.go
@@ -1,0 +1,156 @@
+// Package breaker wraps github.com/sony/gobreaker with this project's
+// conventions: a consecutive-failure circuit breaker (default 5 failures /
+// 30s cooldown / single half-open probe), an optional concurrency limiter,
+// and a health-gauge hook. It is the shared replacement for the per-component
+// hand-rolled breakers that previously lived in geocoder, staticmap, and
+// intersection — one tested implementation instead of three copies.
+package breaker
+
+import (
+	"errors"
+	"time"
+
+	"github.com/sony/gobreaker/v2"
+)
+
+// Defaults match the previous hand-rolled breakers so behaviour is unchanged
+// across the migration.
+const (
+	DefaultFailureThreshold = 5
+	DefaultCooldown         = 30 * time.Second
+)
+
+// ErrOpen is returned by Do when the breaker rejects a call without running it
+// (the circuit is open, or the half-open probe budget is spent). Callers use
+// errors.Is(err, ErrOpen) to count "circuit break" events separately from real
+// call failures.
+var ErrOpen = errors.New("circuit breaker open")
+
+// Config configures a Breaker.
+type Config struct {
+	// Name identifies the breaker in logs/metrics.
+	Name string
+	// FailureThreshold is the number of consecutive failures that opens the
+	// circuit. <= 0 uses DefaultFailureThreshold.
+	FailureThreshold int
+	// Cooldown is how long the circuit stays open before allowing a single
+	// half-open probe. <= 0 uses DefaultCooldown.
+	Cooldown time.Duration
+	// Concurrency bounds simultaneous in-flight calls. <= 0 means unlimited.
+	Concurrency int
+	// OnHealthChange fires on state transitions: false when the circuit opens,
+	// true when it closes. Drives a health gauge. Nil disables.
+	OnHealthChange func(healthy bool)
+	// IsSuccessful classifies a call's returned error; return true to count it
+	// as a success that won't trip the breaker. Nil treats any non-nil error
+	// as a failure.
+	IsSuccessful func(err error) bool
+}
+
+// Breaker guards calls to an external dependency that returns a T.
+type Breaker[T any] struct {
+	cb  *gobreaker.CircuitBreaker[T]
+	sem chan struct{}
+}
+
+// New builds a Breaker from cfg.
+func New[T any](cfg Config) *Breaker[T] {
+	threshold := cfg.FailureThreshold
+	if threshold <= 0 {
+		threshold = DefaultFailureThreshold
+	}
+	cooldown := cfg.Cooldown
+	if cooldown <= 0 {
+		cooldown = DefaultCooldown
+	}
+
+	st := gobreaker.Settings{
+		Name:        cfg.Name,
+		MaxRequests: 1, // single half-open probe, matching the old breakers
+		Timeout:     cooldown,
+		ReadyToTrip: func(c gobreaker.Counts) bool {
+			return c.ConsecutiveFailures >= uint32(threshold)
+		},
+		IsSuccessful: cfg.IsSuccessful,
+	}
+	if cfg.OnHealthChange != nil {
+		onHealth := cfg.OnHealthChange
+		st.OnStateChange = func(_ string, _, to gobreaker.State) {
+			switch to {
+			case gobreaker.StateClosed:
+				onHealth(true)
+			case gobreaker.StateOpen:
+				onHealth(false)
+			}
+		}
+	}
+
+	var sem chan struct{}
+	if cfg.Concurrency > 0 {
+		sem = make(chan struct{}, cfg.Concurrency)
+	}
+
+	return &Breaker[T]{
+		cb:  gobreaker.NewCircuitBreaker[T](st),
+		sem: sem,
+	}
+}
+
+// Do runs fn if the breaker permits it, honouring the concurrency limit. When
+// the circuit is open (or the half-open probe budget is spent) fn is NOT run
+// and Do returns the zero T and ErrOpen. Otherwise it returns fn's result; a
+// non-nil error from fn counts toward tripping the breaker unless IsSuccessful
+// classifies it as a success.
+//
+// The concurrency limiter sits inside the breaker gate, so a rejected call
+// never acquires a slot.
+func (b *Breaker[T]) Do(fn func() (T, error)) (T, error) {
+	res, err := b.cb.Execute(func() (T, error) {
+		if b.sem != nil {
+			b.sem <- struct{}{}
+			defer func() { <-b.sem }()
+		}
+		return fn()
+	})
+	if err != nil && (errors.Is(err, gobreaker.ErrOpenState) || errors.Is(err, gobreaker.ErrTooManyRequests)) {
+		var zero T
+		return zero, ErrOpen
+	}
+	return res, err
+}
+
+// State returns the current breaker state ("closed", "half-open", or "open")
+// for diagnostics.
+func (b *Breaker[T]) State() string {
+	return b.cb.State().String()
+}
+
+// Gate is a circuit breaker for calls whose result the caller handles itself
+// (typically via a closure), so only success/failure matters to the breaker.
+// It's the right choice when one breaker guards several call sites with
+// different return types — e.g. a tile server that both pregenerates a URL and
+// fetches bytes. Build with NewGate.
+type Gate struct {
+	b *Breaker[struct{}]
+}
+
+// NewGate builds a Gate from cfg.
+func NewGate(cfg Config) *Gate {
+	return &Gate{b: New[struct{}](cfg)}
+}
+
+// Do runs fn if the breaker permits it (honouring the concurrency limit) and
+// returns fn's error. When the circuit is open it returns ErrOpen without
+// running fn. A non-nil error from fn counts toward tripping the breaker
+// unless IsSuccessful classifies it as a success.
+func (g *Gate) Do(fn func() error) error {
+	_, err := g.b.Do(func() (struct{}, error) {
+		return struct{}{}, fn()
+	})
+	return err
+}
+
+// State returns the current breaker state for diagnostics.
+func (g *Gate) State() string {
+	return g.b.State()
+}

--- a/processor/internal/breaker/breaker.go
+++ b/processor/internal/breaker/breaker.go
@@ -41,10 +41,6 @@ type Config struct {
 	// OnHealthChange fires on state transitions: false when the circuit opens,
 	// true when it closes. Drives a health gauge. Nil disables.
 	OnHealthChange func(healthy bool)
-	// IsSuccessful classifies a call's returned error; return true to count it
-	// as a success that won't trip the breaker. Nil treats any non-nil error
-	// as a failure.
-	IsSuccessful func(err error) bool
 }
 
 // Breaker guards calls to an external dependency that returns a T.
@@ -71,7 +67,6 @@ func New[T any](cfg Config) *Breaker[T] {
 		ReadyToTrip: func(c gobreaker.Counts) bool {
 			return c.ConsecutiveFailures >= uint32(threshold)
 		},
-		IsSuccessful: cfg.IsSuccessful,
 	}
 	if cfg.OnHealthChange != nil {
 		onHealth := cfg.OnHealthChange
@@ -125,6 +120,13 @@ func (b *Breaker[T]) State() string {
 	return b.cb.State().String()
 }
 
+// IsOpen reports whether the circuit is fully open, so callers can cheaply
+// skip expensive request preparation (marshaling, key selection) that Do would
+// then throw away. Half-open returns false so the single probe still proceeds.
+func (b *Breaker[T]) IsOpen() bool {
+	return b.cb.State() == gobreaker.StateOpen
+}
+
 // Gate is a circuit breaker for calls whose result the caller handles itself
 // (typically via a closure), so only success/failure matters to the breaker.
 // It's the right choice when one breaker guards several call sites with
@@ -153,4 +155,9 @@ func (g *Gate) Do(fn func() error) error {
 // State returns the current breaker state for diagnostics.
 func (g *Gate) State() string {
 	return g.b.State()
+}
+
+// IsOpen reports whether the circuit is fully open (see Breaker.IsOpen).
+func (g *Gate) IsOpen() bool {
+	return g.b.IsOpen()
 }

--- a/processor/internal/breaker/breaker_test.go
+++ b/processor/internal/breaker/breaker_test.go
@@ -151,16 +151,14 @@ func TestGate_ResultViaClosure(t *testing.T) {
 	}
 }
 
-func TestBreaker_IsSuccessfulSuppressesTrip(t *testing.T) {
-	// An error classified as "successful" must not trip the breaker.
-	b := New[int](Config{
-		Name: "t", FailureThreshold: 2, Cooldown: time.Minute,
-		IsSuccessful: func(err error) bool { return errors.Is(err, errBoom) },
-	})
-	for n := 0; n < 5; n++ {
-		_, err := b.Do(func() (int, error) { return 0, errBoom })
-		if errors.Is(err, ErrOpen) {
-			t.Fatalf("call %d ErrOpen — errBoom should be treated as success", n)
-		}
+func TestBreaker_IsOpenReflectsState(t *testing.T) {
+	b := New[int](Config{Name: "t", FailureThreshold: 2, Cooldown: time.Minute})
+	if b.IsOpen() {
+		t.Fatal("fresh breaker should not be open")
+	}
+	b.Do(func() (int, error) { return 0, errBoom })
+	b.Do(func() (int, error) { return 0, errBoom })
+	if !b.IsOpen() {
+		t.Fatal("breaker should be open after threshold failures")
 	}
 }

--- a/processor/internal/breaker/breaker_test.go
+++ b/processor/internal/breaker/breaker_test.go
@@ -1,0 +1,166 @@
+package breaker
+
+import (
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+var errBoom = errors.New("boom")
+
+func TestBreaker_RunsAndReturns(t *testing.T) {
+	b := New[int](Config{Name: "t"})
+	got, err := b.Do(func() (int, error) { return 42, nil })
+	if err != nil || got != 42 {
+		t.Fatalf("Do = (%d, %v), want (42, nil)", got, err)
+	}
+}
+
+func TestBreaker_OpensAfterThreshold(t *testing.T) {
+	var calls atomic.Int32
+	b := New[int](Config{Name: "t", FailureThreshold: 3, Cooldown: time.Minute})
+
+	for n := 0; n < 3; n++ {
+		_, err := b.Do(func() (int, error) { calls.Add(1); return 0, errBoom })
+		if !errors.Is(err, errBoom) {
+			t.Fatalf("call %d: err = %v, want errBoom", n, err)
+		}
+	}
+	// Circuit now open: fn must NOT run, ErrOpen returned.
+	_, err := b.Do(func() (int, error) { calls.Add(1); return 0, errBoom })
+	if !errors.Is(err, ErrOpen) {
+		t.Fatalf("after threshold: err = %v, want ErrOpen", err)
+	}
+	if c := calls.Load(); c != 3 {
+		t.Errorf("fn ran %d times, want 3 (open circuit skips fn)", c)
+	}
+}
+
+func TestBreaker_SuccessResetsConsecutive(t *testing.T) {
+	b := New[int](Config{Name: "t", FailureThreshold: 3, Cooldown: time.Minute})
+	// 2 failures, a success, then 2 more failures — should NOT open (consecutive reset).
+	b.Do(func() (int, error) { return 0, errBoom })
+	b.Do(func() (int, error) { return 0, errBoom })
+	b.Do(func() (int, error) { return 1, nil })
+	var ran int
+	for n := 0; n < 2; n++ {
+		_, err := b.Do(func() (int, error) { ran++; return 0, errBoom })
+		if errors.Is(err, ErrOpen) {
+			t.Fatalf("call %d unexpectedly ErrOpen — consecutive count not reset", n)
+		}
+	}
+	if ran != 2 {
+		t.Errorf("fn ran %d times, want 2", ran)
+	}
+}
+
+func TestBreaker_HalfOpenRecovers(t *testing.T) {
+	b := New[int](Config{Name: "t", FailureThreshold: 2, Cooldown: 40 * time.Millisecond})
+	b.Do(func() (int, error) { return 0, errBoom })
+	b.Do(func() (int, error) { return 0, errBoom })
+	if _, err := b.Do(func() (int, error) { return 0, nil }); !errors.Is(err, ErrOpen) {
+		t.Fatalf("expected ErrOpen while open, got %v", err)
+	}
+	time.Sleep(60 * time.Millisecond) // let it move to half-open
+	got, err := b.Do(func() (int, error) { return 7, nil })
+	if err != nil || got != 7 {
+		t.Fatalf("half-open probe = (%d, %v), want (7, nil)", got, err)
+	}
+	// Closed again.
+	if got, err := b.Do(func() (int, error) { return 9, nil }); err != nil || got != 9 {
+		t.Fatalf("after recovery = (%d, %v), want (9, nil)", got, err)
+	}
+}
+
+func TestBreaker_OnHealthChange(t *testing.T) {
+	var mu sync.Mutex
+	var transitions []bool
+	b := New[int](Config{
+		Name: "t", FailureThreshold: 2, Cooldown: 40 * time.Millisecond,
+		OnHealthChange: func(healthy bool) {
+			mu.Lock()
+			transitions = append(transitions, healthy)
+			mu.Unlock()
+		},
+	})
+	b.Do(func() (int, error) { return 0, errBoom })
+	b.Do(func() (int, error) { return 0, errBoom }) // opens → healthy=false
+	time.Sleep(60 * time.Millisecond)
+	b.Do(func() (int, error) { return 1, nil }) // half-open probe succeeds → closed → healthy=true
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(transitions) < 2 || transitions[0] != false || transitions[len(transitions)-1] != true {
+		t.Errorf("transitions = %v, want first=false (open) then ...true (closed)", transitions)
+	}
+}
+
+func TestBreaker_ConcurrencyLimits(t *testing.T) {
+	const limit = 2
+	b := New[int](Config{Name: "t", Concurrency: limit})
+	var inFlight, maxSeen atomic.Int32
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			b.Do(func() (int, error) {
+				n := inFlight.Add(1)
+				for {
+					m := maxSeen.Load()
+					if n <= m || maxSeen.CompareAndSwap(m, n) {
+						break
+					}
+				}
+				time.Sleep(10 * time.Millisecond)
+				inFlight.Add(-1)
+				return 0, nil
+			})
+		}()
+	}
+	wg.Wait()
+	if m := maxSeen.Load(); m > limit {
+		t.Errorf("max concurrent fn = %d, want <= %d", m, limit)
+	}
+}
+
+func TestGate_OpensAndReturnsErrOpen(t *testing.T) {
+	var calls atomic.Int32
+	g := NewGate(Config{Name: "g", FailureThreshold: 2, Cooldown: time.Minute})
+	for n := 0; n < 2; n++ {
+		if err := g.Do(func() error { calls.Add(1); return errBoom }); !errors.Is(err, errBoom) {
+			t.Fatalf("call %d err = %v, want errBoom", n, err)
+		}
+	}
+	if err := g.Do(func() error { calls.Add(1); return errBoom }); !errors.Is(err, ErrOpen) {
+		t.Fatalf("after threshold err = %v, want ErrOpen", err)
+	}
+	if c := calls.Load(); c != 2 {
+		t.Errorf("fn ran %d times, want 2 (open circuit skips fn)", c)
+	}
+}
+
+func TestGate_ResultViaClosure(t *testing.T) {
+	g := NewGate(Config{Name: "g"})
+	var captured string
+	err := g.Do(func() error { captured = "ok"; return nil })
+	if err != nil || captured != "ok" {
+		t.Fatalf("Do = %v, captured=%q; want nil, ok", err, captured)
+	}
+}
+
+func TestBreaker_IsSuccessfulSuppressesTrip(t *testing.T) {
+	// An error classified as "successful" must not trip the breaker.
+	b := New[int](Config{
+		Name: "t", FailureThreshold: 2, Cooldown: time.Minute,
+		IsSuccessful: func(err error) bool { return errors.Is(err, errBoom) },
+	})
+	for n := 0; n < 5; n++ {
+		_, err := b.Do(func() (int, error) { return 0, errBoom })
+		if errors.Is(err, ErrOpen) {
+			t.Fatalf("call %d ErrOpen — errBoom should be treated as success", n)
+		}
+	}
+}

--- a/processor/internal/dts/shlink.go
+++ b/processor/internal/dts/shlink.go
@@ -57,6 +57,13 @@ func (s *ShlinkShortener) Shorten(longURL string) string {
 		metrics.ShlinkTotal.WithLabelValues("disabled").Inc()
 		return longURL
 	}
+
+	// Open circuit: skip the marshal/request build entirely and fall back to the
+	// long URL. (Half-open returns false so the single probe still runs.)
+	if s.breaker.IsOpen() {
+		metrics.ShlinkTotal.WithLabelValues("circuit_break").Inc()
+		return longURL
+	}
 	start := time.Now()
 
 	reqBody := shlinkRequest{
@@ -104,23 +111,27 @@ func (s *ShlinkShortener) Shorten(longURL string) string {
 			return fmt.Errorf("shlink: status %d", resp.StatusCode)
 		}
 
+		// Past this point Shlink responded with a 2xx — it is reachable. A bad
+		// body just means we fall back to the long URL for this call; it is NOT
+		// a connectivity failure, so return nil and don't let it trip the
+		// breaker (which would suppress shortening globally for 30s).
 		respBytes, err := io.ReadAll(resp.Body)
 		if err != nil {
 			log.Warnf("shlink: read response: %v", err)
 			metrics.ShlinkTotal.WithLabelValues("error").Inc()
-			return err
+			return nil
 		}
 
 		var result shlinkResponse
 		if err := json.Unmarshal(respBytes, &result); err != nil {
 			log.Warnf("shlink: parse response: %v", err)
 			metrics.ShlinkTotal.WithLabelValues("error").Inc()
-			return err
+			return nil
 		}
 
 		if result.ShortURL == "" {
 			metrics.ShlinkTotal.WithLabelValues("error").Inc()
-			return fmt.Errorf("shlink: empty short url")
+			return nil
 		}
 		metrics.ShlinkTotal.WithLabelValues("ok").Inc()
 		short = result.ShortURL

--- a/processor/internal/dts/shlink.go
+++ b/processor/internal/dts/shlink.go
@@ -3,6 +3,8 @@ package dts
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"regexp"
@@ -11,25 +13,28 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
+	"github.com/pokemon/poracleng/processor/internal/breaker"
 	"github.com/pokemon/poracleng/processor/internal/metrics"
 )
 
 // ShlinkShortener shortens URLs via a Shlink (https://shlink.io/) instance.
 type ShlinkShortener struct {
-	url    string
-	apiKey string
-	domain string
-	client *http.Client
+	url     string
+	apiKey  string
+	domain  string
+	client  *http.Client
+	breaker *breaker.Gate
 }
 
 // NewShlinkShortener creates a ShlinkShortener pointing at the given Shlink server.
 // If url or apiKey is empty, Shorten will always return the original URL.
 func NewShlinkShortener(url, apiKey, domain string) *ShlinkShortener {
 	return &ShlinkShortener{
-		url:    url,
-		apiKey: apiKey,
-		domain: domain,
-		client: &http.Client{Timeout: 10 * time.Second},
+		url:     url,
+		apiKey:  apiKey,
+		domain:  domain,
+		client:  &http.Client{Timeout: 10 * time.Second},
+		breaker: breaker.NewGate(breaker.Config{Name: "shlink"}),
 	}
 }
 
@@ -77,43 +82,54 @@ func (s *ShlinkShortener) Shorten(longURL string) string {
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-Api-Key", s.apiKey)
 
-	resp, err := s.client.Do(req)
-	if err != nil {
-		log.Warnf("shlink: request failed: %v", err)
-		metrics.ShlinkTotal.WithLabelValues("error").Inc()
+	// Guard the Shlink call with a circuit breaker so an outage doesn't make
+	// every rendered message wait out the 10s timeout. The original URL is the
+	// safe fallback for both an open circuit and any call failure.
+	short := longURL
+	berr := s.breaker.Do(func() error {
+		resp, err := s.client.Do(req)
+		if err != nil {
+			log.Warnf("shlink: request failed: %v", err)
+			metrics.ShlinkTotal.WithLabelValues("error").Inc()
+			metrics.ShlinkDuration.Observe(time.Since(start).Seconds())
+			return err
+		}
+		defer resp.Body.Close()
+
 		metrics.ShlinkDuration.Observe(time.Since(start).Seconds())
-		return longURL
-	}
-	defer resp.Body.Close()
 
-	metrics.ShlinkDuration.Observe(time.Since(start).Seconds())
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			log.Warnf("shlink: unexpected status %d for %s", resp.StatusCode, longURL)
+			metrics.ShlinkTotal.WithLabelValues("error").Inc()
+			return fmt.Errorf("shlink: status %d", resp.StatusCode)
+		}
 
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		log.Warnf("shlink: unexpected status %d for %s", resp.StatusCode, longURL)
-		metrics.ShlinkTotal.WithLabelValues("error").Inc()
-		return longURL
-	}
+		respBytes, err := io.ReadAll(resp.Body)
+		if err != nil {
+			log.Warnf("shlink: read response: %v", err)
+			metrics.ShlinkTotal.WithLabelValues("error").Inc()
+			return err
+		}
 
-	respBytes, err := io.ReadAll(resp.Body)
-	if err != nil {
-		log.Warnf("shlink: read response: %v", err)
-		metrics.ShlinkTotal.WithLabelValues("error").Inc()
-		return longURL
-	}
+		var result shlinkResponse
+		if err := json.Unmarshal(respBytes, &result); err != nil {
+			log.Warnf("shlink: parse response: %v", err)
+			metrics.ShlinkTotal.WithLabelValues("error").Inc()
+			return err
+		}
 
-	var result shlinkResponse
-	if err := json.Unmarshal(respBytes, &result); err != nil {
-		log.Warnf("shlink: parse response: %v", err)
-		metrics.ShlinkTotal.WithLabelValues("error").Inc()
-		return longURL
+		if result.ShortURL == "" {
+			metrics.ShlinkTotal.WithLabelValues("error").Inc()
+			return fmt.Errorf("shlink: empty short url")
+		}
+		metrics.ShlinkTotal.WithLabelValues("ok").Inc()
+		short = result.ShortURL
+		return nil
+	})
+	if errors.Is(berr, breaker.ErrOpen) {
+		metrics.ShlinkTotal.WithLabelValues("circuit_break").Inc()
 	}
-
-	if result.ShortURL == "" {
-		metrics.ShlinkTotal.WithLabelValues("error").Inc()
-		return longURL
-	}
-	metrics.ShlinkTotal.WithLabelValues("ok").Inc()
-	return result.ShortURL
+	return short
 }
 
 // shortenMarkerRe matches <S< ... >S> markers wrapping URLs to be shortened.

--- a/processor/internal/dts/shlink_test.go
+++ b/processor/internal/dts/shlink_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -106,6 +107,61 @@ func TestShortenInvalidResponse(t *testing.T) {
 	s := NewShlinkShortener(server.URL, "key", "")
 	result := s.Shorten("https://example.com/original")
 	assert.Equal(t, "https://example.com/original", result)
+}
+
+// A reachable Shlink returning 2xx with a body we can't use (bad JSON, empty
+// short URL) must NOT trip the breaker — it's responding, just unhelpfully, so
+// every call should keep hitting it and falling back per-call.
+func TestShortenBadBodyDoesNotTripBreaker(t *testing.T) {
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte("not json"))
+	}))
+	defer server.Close()
+
+	s := NewShlinkShortener(server.URL, "key", "")
+	for i := 0; i < 8; i++ {
+		if got := s.Shorten("https://example.com/original"); got != "https://example.com/original" {
+			t.Fatalf("call %d: got %q, want fallback", i, got)
+		}
+	}
+	if s.breaker.IsOpen() {
+		t.Error("breaker opened on reachable bad-body responses; it should stay closed")
+	}
+	if c := calls.Load(); c != 8 {
+		t.Errorf("server hit %d times, want 8 (breaker must not short-circuit)", c)
+	}
+}
+
+// A genuinely failing Shlink (5xx) SHOULD trip the breaker and stop the calls.
+func TestShortenServerErrorTripsBreaker(t *testing.T) {
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	s := NewShlinkShortener(server.URL, "key", "")
+	// Default threshold is 5 consecutive failures.
+	for i := 0; i < 5; i++ {
+		s.Shorten("https://example.com/original")
+	}
+	if !s.breaker.IsOpen() {
+		t.Fatal("breaker should be open after 5 server errors")
+	}
+	hits := calls.Load()
+	// Further calls short-circuit — server not contacted.
+	for i := 0; i < 3; i++ {
+		if got := s.Shorten("https://example.com/original"); got != "https://example.com/original" {
+			t.Fatalf("expected fallback during circuit break, got %q", got)
+		}
+	}
+	if extra := calls.Load() - hits; extra != 0 {
+		t.Errorf("circuit open but server hit %d more times", extra)
+	}
 }
 
 func TestShortenEmptyShortURL(t *testing.T) {

--- a/processor/internal/geocoding/geocoder.go
+++ b/processor/internal/geocoding/geocoder.go
@@ -172,10 +172,15 @@ func (g *Geocoder) GetAddressForLanguage(lat, lon float64, language string) *Add
 		if rerr != nil || a == nil {
 			g.statErrors.Add(1)
 			metrics.GeocodeTotal.WithLabelValues("error").Inc()
-			if rerr == nil {
+			// Log only a genuine provider error; a (nil, nil) "no address found"
+			// was silent before the refactor — keep it silent to avoid flooding
+			// the warn log in high-volume unresolvable areas. It still trips the
+			// breaker (parity with the old recordError path) via errNilAddress.
+			if rerr != nil {
+				log.Warnf("Geocode %f,%f failed: %s", lat, lon, rerr)
+			} else {
 				rerr = errNilAddress
 			}
-			log.Warnf("Geocode %f,%f failed: %s", lat, lon, rerr)
 			return nil, rerr
 		}
 

--- a/processor/internal/geocoding/geocoder.go
+++ b/processor/internal/geocoding/geocoder.go
@@ -1,13 +1,14 @@
 package geocoding
 
 import (
+	"errors"
 	"strings"
-	"sync"
 	"sync/atomic"
 	"time"
 
 	log "github.com/sirupsen/logrus"
 
+	"github.com/pokemon/poracleng/processor/internal/breaker"
 	"github.com/pokemon/poracleng/processor/internal/metrics"
 )
 
@@ -41,14 +42,8 @@ type Geocoder struct {
 	provider Provider
 	cache    *Cache
 	config   Config
-	addrTmpl *AddressTemplate // compiled once from config.AddressFormat
-	sem      chan struct{}    // concurrency limiter
-
-	// Circuit breaker state
-	consecutiveErrors   int
-	circuitOpenSince    time.Time
-	halfOpenProbeActive bool
-	mu                  sync.Mutex
+	addrTmpl *AddressTemplate           // compiled once from config.AddressFormat
+	breaker  *breaker.Breaker[*Address] // circuit breaker + concurrency limiter
 
 	// Stats counters for periodic logging
 	statCalls         atomic.Int64
@@ -57,6 +52,10 @@ type Geocoder struct {
 	statHits          atomic.Int64
 	statCircuitBreaks atomic.Int64
 }
+
+// errNilAddress marks a provider returning (nil, nil) — treated as a failure
+// so it counts toward the circuit breaker.
+var errNilAddress = errors.New("geocode: provider returned nil address")
 
 // New creates a new Geocoder from the given config.
 func New(config Config) (*Geocoder, error) {
@@ -103,13 +102,27 @@ func New(config Config) (*Geocoder, error) {
 		log.Warnf("Geocoder: %s — falling back to formattedAddress", err)
 	}
 
-	return &Geocoder{
+	g := &Geocoder{
 		provider: provider,
 		cache:    cache,
 		config:   config,
 		addrTmpl: addrTmpl,
-		sem:      make(chan struct{}, config.Concurrency),
-	}, nil
+	}
+	g.breaker = breaker.New[*Address](breaker.Config{
+		Name:             "geocoder-" + config.Provider,
+		FailureThreshold: config.FailureThreshold,
+		Cooldown:         time.Duration(config.CooldownMs) * time.Millisecond,
+		Concurrency:      config.Concurrency,
+		OnHealthChange: func(healthy bool) {
+			if healthy {
+				metrics.GeocodeCircuitHealthy.Set(1)
+			} else {
+				metrics.GeocodeCircuitHealthy.Set(0)
+			}
+		},
+	})
+	metrics.GeocodeCircuitHealthy.Set(1) // start healthy (gobreaker fires OnStateChange only on transition)
+	return g, nil
 }
 
 // unknownAddress returns a minimal Address for error/skip cases.
@@ -145,68 +158,50 @@ func (g *Geocoder) GetAddressForLanguage(lat, lon float64, language string) *Add
 		}
 	}
 
-	// Circuit breaker check
-	g.mu.Lock()
-	if g.consecutiveErrors >= g.config.FailureThreshold {
-		cooldown := time.Duration(g.config.CooldownMs) * time.Millisecond
-		if time.Since(g.circuitOpenSince) < cooldown {
-			g.mu.Unlock()
-			g.statCircuitBreaks.Add(1)
-			metrics.GeocodeTotal.WithLabelValues("circuit_break").Inc()
-			return unknownAddress()
+	// Reverse geocode behind the circuit breaker (which also bounds
+	// concurrency). The breaker trips on consecutive provider failures.
+	addr, err := g.breaker.Do(func() (*Address, error) {
+		metrics.GeocodeInFlight.Inc()
+		defer metrics.GeocodeInFlight.Dec()
+
+		start := time.Now()
+		a, rerr := g.provider.Reverse(lat, lon, language)
+		duration := time.Since(start)
+		metrics.GeocodeDuration.Observe(duration.Seconds())
+
+		if rerr != nil || a == nil {
+			g.statErrors.Add(1)
+			metrics.GeocodeTotal.WithLabelValues("error").Inc()
+			if rerr == nil {
+				rerr = errNilAddress
+			}
+			log.Warnf("Geocode %f,%f failed: %s", lat, lon, rerr)
+			return nil, rerr
 		}
-		// Half-open: allow exactly one probe request
-		if g.halfOpenProbeActive {
-			g.mu.Unlock()
-			g.statCircuitBreaks.Add(1)
-			metrics.GeocodeTotal.WithLabelValues("circuit_break").Inc()
-			return unknownAddress()
-		}
-		g.halfOpenProbeActive = true
-	}
-	g.mu.Unlock()
 
-	// Acquire concurrency slot
-	g.sem <- struct{}{}
-	defer func() { <-g.sem }()
+		g.statCalls.Add(1)
+		g.statTotalMs.Add(duration.Milliseconds())
+		metrics.GeocodeTotal.WithLabelValues("success").Inc()
+		return a, nil
+	})
 
-	metrics.GeocodeInFlight.Inc()
-	defer metrics.GeocodeInFlight.Dec()
-
-	start := time.Now()
-	addr, err := g.provider.Reverse(lat, lon, language)
-	duration := time.Since(start)
-
-	metrics.GeocodeDuration.Observe(duration.Seconds())
-
-	if err != nil || addr == nil {
-		g.statErrors.Add(1)
-		metrics.GeocodeTotal.WithLabelValues("error").Inc()
-		g.recordError()
-		if err != nil {
-			log.Warnf("Geocode %f,%f failed: %s", lat, lon, err)
-		}
+	if errors.Is(err, breaker.ErrOpen) {
+		g.statCircuitBreaks.Add(1)
+		metrics.GeocodeTotal.WithLabelValues("circuit_break").Inc()
 		return unknownAddress()
 	}
-
-	// Success — reset circuit breaker
-	g.mu.Lock()
-	g.consecutiveErrors = 0
-	g.halfOpenProbeActive = false
-	g.mu.Unlock()
-	metrics.GeocodeCircuitHealthy.Set(1)
-
-	g.statCalls.Add(1)
-	g.statTotalMs.Add(duration.Milliseconds())
-	metrics.GeocodeTotal.WithLabelValues("success").Inc()
+	if err != nil {
+		// Provider error — already counted and logged inside the breaker fn.
+		return unknownAddress()
+	}
 
 	// Add flag and formatted address (template rendered via raymond so
 	// operators get {{#if}}/{{#unless}}/helpers for conditional layout).
 	addr.Flag = CountryFlag(addr.CountryCode)
 	addr.Addr = g.addrTmpl.Render(*addr)
 
-	log.Debugf("Geocode %.4f,%.4f → street=%q number=%q city=%q addr=%q (%dms)",
-		lat, lon, addr.StreetName, addr.StreetNumber, addr.City, addr.Addr, duration.Milliseconds())
+	log.Debugf("Geocode %.4f,%.4f → street=%q number=%q city=%q addr=%q",
+		lat, lon, addr.StreetName, addr.StreetNumber, addr.City, addr.Addr)
 
 	// Escape special characters
 	EscapeAddress(addr)
@@ -216,7 +211,7 @@ func (g *Geocoder) GetAddressForLanguage(lat, lon float64, language string) *Add
 		g.cache.Set(cacheKey, addr)
 	}
 
-	log.Debugf("Geocode %f,%f → %s (%dms)", lat, lon, addr.Addr, duration.Milliseconds())
+	log.Debugf("Geocode %f,%f → %s", lat, lon, addr.Addr)
 	return addr
 }
 
@@ -280,17 +275,4 @@ func (g *Geocoder) Close() error {
 		return g.cache.Close()
 	}
 	return nil
-}
-
-// recordError increments the consecutive error counter and opens the circuit
-// if the threshold is reached.
-func (g *Geocoder) recordError() {
-	g.mu.Lock()
-	defer g.mu.Unlock()
-	g.consecutiveErrors++
-	g.halfOpenProbeActive = false
-	if g.consecutiveErrors >= g.config.FailureThreshold {
-		g.circuitOpenSince = time.Now()
-		metrics.GeocodeCircuitHealthy.Set(0)
-	}
 }

--- a/processor/internal/geocoding/geocoder_test.go
+++ b/processor/internal/geocoding/geocoder_test.go
@@ -4,6 +4,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/pokemon/poracleng/processor/internal/breaker"
 )
 
 type languageProvider struct {
@@ -49,7 +51,7 @@ func TestGeocoderLanguageAffectsProviderAndCacheKey(t *testing.T) {
 			CooldownMs:       1,
 		},
 		addrTmpl: addrTmpl,
-		sem:      make(chan struct{}, 1),
+		breaker:  breaker.New[*Address](breaker.Config{Name: "test", Concurrency: 1}),
 	}
 
 	if got := g.GetAddressForLanguage(52.517, 13.389, "DE"); got.City != "de" {

--- a/processor/internal/geocoding/intersection.go
+++ b/processor/internal/geocoding/intersection.go
@@ -8,10 +8,11 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
-	"sync"
 	"time"
 
 	log "github.com/sirupsen/logrus"
+
+	"github.com/pokemon/poracleng/processor/internal/breaker"
 )
 
 // defaultIntersectionBaseURL is the GeoNames OSM intersection endpoint. The
@@ -48,25 +49,17 @@ type IntersectionConfig struct {
 }
 
 // Intersection fetches the nearest street intersection for a coordinate from
-// GeoNames, with optional shared-cache backing. Reuses a single HTTP client,
-// bounds concurrency, and trips a circuit breaker so a GeoNames outage can't
-// park webhook workers on doomed requests.
+// GeoNames, with optional shared-cache backing. Reuses a single HTTP client
+// and routes every lookup through a shared circuit breaker (which also bounds
+// concurrency), so a GeoNames outage can't park webhook workers on doomed
+// requests.
 type Intersection struct {
 	usernames   []string
 	cache       *Cache
 	cacheDetail int
 	client      *http.Client
-	sem         chan struct{}
+	breaker     *breaker.Breaker[string]
 	baseURL     string // overridable in tests
-
-	// Circuit breaker (mirrors Geocoder): after failureThreshold consecutive
-	// failures the circuit opens for cooldown, then allows one half-open probe.
-	failureThreshold    int
-	cooldown            time.Duration
-	mu                  sync.Mutex
-	consecutiveErrors   int
-	circuitOpenSince    time.Time
-	halfOpenProbeActive bool
 }
 
 // NewIntersection builds an Intersection from config. Returns a usable (no-op
@@ -84,23 +77,18 @@ func NewIntersection(cfg IntersectionConfig) *Intersection {
 	if conc <= 0 {
 		conc = 5
 	}
-	threshold := cfg.FailureThreshold
-	if threshold <= 0 {
-		threshold = 5
-	}
-	cooldownMs := cfg.CooldownMs
-	if cooldownMs <= 0 {
-		cooldownMs = 30000
-	}
 	return &Intersection{
-		usernames:        cfg.Usernames,
-		cache:            cfg.Cache,
-		cacheDetail:      detail,
-		client:           &http.Client{Timeout: time.Duration(timeout) * time.Millisecond},
-		sem:              make(chan struct{}, conc),
-		baseURL:          defaultIntersectionBaseURL,
-		failureThreshold: threshold,
-		cooldown:         time.Duration(cooldownMs) * time.Millisecond,
+		usernames:   cfg.Usernames,
+		cache:       cfg.Cache,
+		cacheDetail: detail,
+		client:      &http.Client{Timeout: time.Duration(timeout) * time.Millisecond},
+		breaker: breaker.New[string](breaker.Config{
+			Name:             "geonames-intersection",
+			FailureThreshold: cfg.FailureThreshold,
+			Cooldown:         time.Duration(cfg.CooldownMs) * time.Millisecond,
+			Concurrency:      conc,
+		}),
+		baseURL: defaultIntersectionBaseURL,
 	}
 }
 
@@ -134,8 +122,10 @@ func (i *Intersection) GetIntersection(lat, lon float64) string {
 		}
 	}
 
-	result, ok := i.fetch(lat, lon)
-	if !ok {
+	result, err := i.breaker.Do(func() (string, error) {
+		return i.fetch(lat, lon)
+	})
+	if err != nil {
 		// Transient failure or open circuit — don't cache, so a later sighting
 		// retries once the service recovers.
 		return ""
@@ -146,68 +136,10 @@ func (i *Intersection) GetIntersection(lat, lon float64) string {
 	return result
 }
 
-// circuitAllows reports whether a request may proceed. When the circuit is
-// open and still within cooldown, it denies; after cooldown it lets exactly
-// one half-open probe through.
-func (i *Intersection) circuitAllows() bool {
-	i.mu.Lock()
-	defer i.mu.Unlock()
-	if i.consecutiveErrors < i.failureThreshold {
-		return true
-	}
-	if time.Since(i.circuitOpenSince) < i.cooldown {
-		return false
-	}
-	if i.halfOpenProbeActive {
-		return false
-	}
-	i.halfOpenProbeActive = true
-	return true
-}
-
-// recordSuccess closes the circuit after a healthy response.
-func (i *Intersection) recordSuccess() {
-	i.mu.Lock()
-	i.consecutiveErrors = 0
-	i.halfOpenProbeActive = false
-	i.mu.Unlock()
-}
-
-// recordFailure advances the failure count and opens the circuit at the
-// threshold.
-func (i *Intersection) recordFailure() {
-	i.mu.Lock()
-	i.consecutiveErrors++
-	i.halfOpenProbeActive = false
-	if i.consecutiveErrors >= i.failureThreshold {
-		i.circuitOpenSince = time.Now()
-	}
-	i.mu.Unlock()
-}
-
-// fetch performs one GeoNames request, gated by the circuit breaker and
-// concurrency limiter. The bool reports whether the call produced a usable
-// answer (true even when the answer is "no intersection", which is a cacheable
-// fact); false means a transient error or open circuit not worth caching.
-func (i *Intersection) fetch(lat, lon float64) (string, bool) {
-	if !i.circuitAllows() {
-		log.Debugf("GeoNames intersection: circuit open, skipping %f,%f", lat, lon)
-		return "", false
-	}
-
-	i.sem <- struct{}{}
-	defer func() { <-i.sem }()
-
-	// Classify the outcome for the circuit breaker exactly once on return.
-	healthy := false
-	defer func() {
-		if healthy {
-			i.recordSuccess()
-		} else {
-			i.recordFailure()
-		}
-	}()
-
+// fetch performs one GeoNames request. A nil error means a usable answer
+// (including "no intersection nearby", returned as "" — a cacheable fact); a
+// non-nil error is a transient failure that counts toward tripping the breaker.
+func (i *Intersection) fetch(lat, lon float64) (string, error) {
 	username := i.usernames[rand.IntN(len(i.usernames))]
 
 	q := url.Values{}
@@ -221,38 +153,37 @@ func (i *Intersection) fetch(lat, lon float64) (string, bool) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
 	if err != nil {
 		log.Debugf("GeoNames intersection: build request: %v", err)
-		return "", false
+		return "", err
 	}
 
 	resp, err := i.client.Do(req)
 	if err != nil {
 		log.Warnf("GeoNames intersection request failed for %f,%f: %v", lat, lon, err)
-		return "", false
+		return "", err
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		log.Warnf("GeoNames intersection: HTTP %d for %f,%f", resp.StatusCode, lat, lon)
-		return "", false
+		return "", fmt.Errorf("geonames: http %d", resp.StatusCode)
 	}
 
 	var result geonamesResponse
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
 		log.Warnf("GeoNames intersection: decode response: %v", err)
-		return "", false
+		return "", err
 	}
 
 	// API-level error (e.g. credit exhaustion) — surface it and trip the breaker.
 	if result.Status != nil {
 		log.Warnf("GeoNames intersection: API error %d for %f,%f: %s", result.Status.Value, lat, lon, result.Status.Message)
-		return "", false
+		return "", fmt.Errorf("geonames: api error %d: %s", result.Status.Value, result.Status.Message)
 	}
 
-	healthy = true
 	if result.Intersection.Street1 != "" && result.Intersection.Street2 != "" {
-		return fmt.Sprintf("%s & %s", result.Intersection.Street1, result.Intersection.Street2), true
+		return fmt.Sprintf("%s & %s", result.Intersection.Street1, result.Intersection.Street2), nil
 	}
 
 	// Successful call, genuinely no intersection nearby — cacheable.
-	return "", true
+	return "", nil
 }

--- a/processor/internal/staticmap/staticmap.go
+++ b/processor/internal/staticmap/staticmap.go
@@ -7,6 +7,7 @@ package staticmap
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -20,6 +21,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
+	"github.com/pokemon/poracleng/processor/internal/breaker"
 	"github.com/pokemon/poracleng/processor/internal/logref"
 	"github.com/pokemon/poracleng/processor/internal/metrics"
 	"github.com/pokemon/poracleng/processor/internal/scanner"
@@ -188,11 +190,10 @@ type Resolver struct {
 	done      chan struct{}    // signals tile workers to stop
 	wg        sync.WaitGroup   // tracks tile worker goroutines
 
-	// Circuit breaker state
-	consecutiveErrors   int
-	circuitOpenSince    time.Time
-	halfOpenProbeActive bool // true when a half-open probe request is in flight
-	mu                  sync.Mutex
+	// breaker guards tileserver POSTs (pregenerate + inline). Concurrency is
+	// already bounded by the tile worker pool, so the breaker itself is
+	// unlimited.
+	breaker *breaker.Gate
 
 	// Stats counters for periodic logging
 	statCalls   atomic.Int64
@@ -293,6 +294,19 @@ func New(config Config) *Resolver {
 		tileQueue: make(chan tileRequest, config.TileQueueSize),
 		done:      make(chan struct{}),
 	}
+	r.breaker = breaker.NewGate(breaker.Config{
+		Name:             "tileserver",
+		FailureThreshold: config.TileserverFailureThreshold,
+		Cooldown:         time.Duration(config.TileserverCooldownMs) * time.Millisecond,
+		OnHealthChange: func(healthy bool) {
+			if healthy {
+				metrics.TileCircuitHealthy.Set(1)
+			} else {
+				metrics.TileCircuitHealthy.Set(0)
+			}
+		},
+	})
+	metrics.TileCircuitHealthy.Set(1) // start healthy (gobreaker fires OnStateChange only on transition)
 
 	// Start tile worker goroutines
 	for range config.TileserverConcurrency {
@@ -759,30 +773,6 @@ func (r *Resolver) GetPregeneratedTileURL(maptype string, data map[string]any, s
 // Returns "", "" on any error (circuit-breaker, HTTP failure, invalid response).
 func (r *Resolver) pregenerateID(maptype string, data map[string]any, staticMapType, ref string) (result, mapPath string) {
 	l := reflog(ref)
-	// Circuit breaker check
-	r.mu.Lock()
-	if r.consecutiveErrors >= r.config.TileserverFailureThreshold {
-		elapsed := time.Since(r.circuitOpenSince)
-		cooldown := time.Duration(r.config.TileserverCooldownMs) * time.Millisecond
-		if elapsed < cooldown {
-			r.mu.Unlock()
-			metrics.TileTotal.WithLabelValues("circuit_break").Inc()
-			l.Debugf("staticmap: circuit breaker open for %s, skipping tile", maptype)
-			return "", ""
-		}
-		// Half-open: allow exactly one probe request
-		if r.halfOpenProbeActive {
-			r.mu.Unlock()
-			metrics.TileTotal.WithLabelValues("circuit_break").Inc()
-			return "", ""
-		}
-		r.halfOpenProbeActive = true
-	}
-	r.mu.Unlock()
-
-	metrics.TileInFlight.Inc()
-	defer metrics.TileInFlight.Dec()
-	start := time.Now()
 
 	mapPath = "staticmap"
 	templateType := ""
@@ -804,6 +794,8 @@ func (r *Resolver) pregenerateID(maptype string, data map[string]any, staticMapT
 	reqURL := fmt.Sprintf("%s/%s/poracle-%s%s?%s",
 		r.internalBase(), mapPath, templateType, maptype, pregenQuery)
 
+	// Marshal failures are local (not a tileserver fault), so they stay outside
+	// the breaker and don't count toward tripping it.
 	body, err := json.Marshal(data)
 	if err != nil {
 		l.Warnf("staticmap: marshal data: %s", err)
@@ -813,59 +805,63 @@ func (r *Resolver) pregenerateID(maptype string, data map[string]any, staticMapT
 
 	l.Debugf("staticmap: POST %s type=%s%s body=%s", reqURL, templateType, maptype, string(body))
 
-	resp, err := r.client.Post(reqURL, "application/json", bytes.NewReader(body))
-	if err != nil {
-		r.recordError()
-		r.statErrors.Add(1)
-		metrics.TileTotal.WithLabelValues("error").Inc()
-		metrics.TileDuration.Observe(time.Since(start).Seconds())
-		l.Warnf("staticmap: pregenerate request failed: %s", err)
+	berr := r.breaker.Do(func() error {
+		metrics.TileInFlight.Inc()
+		defer metrics.TileInFlight.Dec()
+		start := time.Now()
+
+		resp, err := r.client.Post(reqURL, "application/json", bytes.NewReader(body))
+		if err != nil {
+			r.statErrors.Add(1)
+			metrics.TileTotal.WithLabelValues("error").Inc()
+			metrics.TileDuration.Observe(time.Since(start).Seconds())
+			l.Warnf("staticmap: pregenerate request failed: %s", err)
+			return err
+		}
+		defer resp.Body.Close()
+
+		respBody, err := io.ReadAll(resp.Body)
+		if err != nil {
+			r.statErrors.Add(1)
+			metrics.TileTotal.WithLabelValues("error").Inc()
+			metrics.TileDuration.Observe(time.Since(start).Seconds())
+			l.Warnf("staticmap: read pregenerate response: %s", err)
+			return err
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			r.statErrors.Add(1)
+			metrics.TileTotal.WithLabelValues("error").Inc()
+			metrics.TileDuration.Observe(time.Since(start).Seconds())
+			l.Warnf("staticmap: pregenerate %s got status %d: %s (sent fields: %v)", reqURL, resp.StatusCode, string(respBody), mapKeys(data))
+			return fmt.Errorf("staticmap: pregenerate status %d", resp.StatusCode)
+		}
+
+		result = strings.TrimSpace(string(respBody))
+		if result == "" || strings.Contains(result, "<") {
+			r.statErrors.Add(1)
+			metrics.TileTotal.WithLabelValues("error").Inc()
+			metrics.TileDuration.Observe(time.Since(start).Seconds())
+			l.Warnf("staticmap: pregenerate got invalid response: %s", result)
+			return fmt.Errorf("staticmap: pregenerate invalid response")
+		}
+
+		duration := time.Since(start)
+		metrics.TileDuration.Observe(duration.Seconds())
+		metrics.TileTotal.WithLabelValues("success").Inc()
+		r.statCalls.Add(1)
+		r.statTotalMs.Add(duration.Milliseconds())
+		return nil
+	})
+
+	if errors.Is(berr, breaker.ErrOpen) {
+		metrics.TileTotal.WithLabelValues("circuit_break").Inc()
+		l.Debugf("staticmap: circuit breaker open for %s, skipping tile", maptype)
 		return "", ""
 	}
-	defer resp.Body.Close()
-
-	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		r.recordError()
-		r.statErrors.Add(1)
-		metrics.TileTotal.WithLabelValues("error").Inc()
-		metrics.TileDuration.Observe(time.Since(start).Seconds())
-		l.Warnf("staticmap: read pregenerate response: %s", err)
+	if berr != nil {
 		return "", ""
 	}
-
-	if resp.StatusCode != http.StatusOK {
-		r.recordError()
-		r.statErrors.Add(1)
-		metrics.TileTotal.WithLabelValues("error").Inc()
-		metrics.TileDuration.Observe(time.Since(start).Seconds())
-		l.Warnf("staticmap: pregenerate %s got status %d: %s (sent fields: %v)", reqURL, resp.StatusCode, string(respBody), mapKeys(data))
-		return "", ""
-	}
-
-	result = strings.TrimSpace(string(respBody))
-	if result == "" || strings.Contains(result, "<") {
-		r.recordError()
-		r.statErrors.Add(1)
-		metrics.TileTotal.WithLabelValues("error").Inc()
-		metrics.TileDuration.Observe(time.Since(start).Seconds())
-		l.Warnf("staticmap: pregenerate got invalid response: %s", result)
-		return "", ""
-	}
-
-	duration := time.Since(start)
-	metrics.TileDuration.Observe(duration.Seconds())
-	metrics.TileTotal.WithLabelValues("success").Inc()
-	r.statCalls.Add(1)
-	r.statTotalMs.Add(duration.Milliseconds())
-
-	// Reset circuit breaker on success
-	r.mu.Lock()
-	r.consecutiveErrors = 0
-	r.halfOpenProbeActive = false
-	r.mu.Unlock()
-	metrics.TileCircuitHealthy.Set(1)
-
 	return result, mapPath
 }
 
@@ -924,28 +920,6 @@ func (r *Resolver) downloadTileBytes(fetchURL, ref string) []byte {
 // receiving the rendered PNG bytes directly. No file is stored on disk.
 func (r *Resolver) GenerateInlineTile(maptype string, data map[string]any, staticMapType, ref string) []byte {
 	l := reflog(ref)
-	// Circuit breaker check
-	r.mu.Lock()
-	if r.consecutiveErrors >= r.config.TileserverFailureThreshold {
-		elapsed := time.Since(r.circuitOpenSince)
-		cooldown := time.Duration(r.config.TileserverCooldownMs) * time.Millisecond
-		if elapsed < cooldown {
-			r.mu.Unlock()
-			metrics.TileTotal.WithLabelValues("circuit_break").Inc()
-			return nil
-		}
-		if r.halfOpenProbeActive {
-			r.mu.Unlock()
-			metrics.TileTotal.WithLabelValues("circuit_break").Inc()
-			return nil
-		}
-		r.halfOpenProbeActive = true
-	}
-	r.mu.Unlock()
-
-	metrics.TileInFlight.Inc()
-	defer metrics.TileInFlight.Dec()
-	start := time.Now()
 
 	mapPath := "staticmap"
 	templateType := ""
@@ -970,6 +944,8 @@ func (r *Resolver) GenerateInlineTile(maptype string, data map[string]any, stati
 	reqURL := fmt.Sprintf("%s/%s/poracle-%s%s%s",
 		r.internalBase(), mapPath, templateType, maptype, query)
 
+	// Marshal failures are local (not a tileserver fault), so they stay outside
+	// the breaker and don't count toward tripping it.
 	body, err := json.Marshal(data)
 	if err != nil {
 		l.Warnf("staticmap: marshal inline data: %s", err)
@@ -979,57 +955,64 @@ func (r *Resolver) GenerateInlineTile(maptype string, data map[string]any, stati
 
 	l.Debugf("staticmap: POST inline %s type=%s%s body=%s", reqURL, templateType, maptype, string(body))
 
-	resp, err := r.client.Post(reqURL, "application/json", bytes.NewReader(body))
-	if err != nil {
-		r.recordError()
-		r.statErrors.Add(1)
-		metrics.TileTotal.WithLabelValues("error").Inc()
-		metrics.TileDuration.Observe(time.Since(start).Seconds())
-		l.Warnf("staticmap: inline request failed: %s", err)
+	var respBody []byte
+	berr := r.breaker.Do(func() error {
+		metrics.TileInFlight.Inc()
+		defer metrics.TileInFlight.Dec()
+		start := time.Now()
+
+		resp, err := r.client.Post(reqURL, "application/json", bytes.NewReader(body))
+		if err != nil {
+			r.statErrors.Add(1)
+			metrics.TileTotal.WithLabelValues("error").Inc()
+			metrics.TileDuration.Observe(time.Since(start).Seconds())
+			l.Warnf("staticmap: inline request failed: %s", err)
+			return err
+		}
+		defer resp.Body.Close()
+
+		b, err := io.ReadAll(resp.Body)
+		if err != nil {
+			r.statErrors.Add(1)
+			metrics.TileTotal.WithLabelValues("error").Inc()
+			metrics.TileDuration.Observe(time.Since(start).Seconds())
+			l.Warnf("staticmap: read inline response: %s", err)
+			return err
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			r.statErrors.Add(1)
+			metrics.TileTotal.WithLabelValues("error").Inc()
+			metrics.TileDuration.Observe(time.Since(start).Seconds())
+			truncLen := min(len(b), 200)
+			l.Warnf("staticmap: inline %s got status %d: %s", reqURL, resp.StatusCode, string(b[:truncLen]))
+			return fmt.Errorf("staticmap: inline status %d", resp.StatusCode)
+		}
+
+		duration := time.Since(start)
+		metrics.TileTotal.WithLabelValues("inline_ok").Inc()
+		metrics.TileDuration.Observe(duration.Seconds())
+		r.statCalls.Add(1)
+		r.statTotalMs.Add(duration.Milliseconds())
+
+		// Diagnostic: log size, content-type, and the first 8 magic bytes so we
+		// can tell valid image responses from error-page bodies. A valid PNG
+		// starts with 89504e470d0a1a0a; JPEG with ffd8ff.
+		prefixLen := min(len(b), 8)
+		l.Debugf("staticmap: inline %d bytes from %s (ct=%s, first=%x) in %dms",
+			len(b), reqURL, resp.Header.Get("Content-Type"), b[:prefixLen], duration.Milliseconds())
+
+		respBody = b
+		return nil
+	})
+
+	if errors.Is(berr, breaker.ErrOpen) {
+		metrics.TileTotal.WithLabelValues("circuit_break").Inc()
 		return nil
 	}
-	defer resp.Body.Close()
-
-	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		r.recordError()
-		r.statErrors.Add(1)
-		metrics.TileTotal.WithLabelValues("error").Inc()
-		metrics.TileDuration.Observe(time.Since(start).Seconds())
-		l.Warnf("staticmap: read inline response: %s", err)
+	if berr != nil {
 		return nil
 	}
-
-	if resp.StatusCode != http.StatusOK {
-		r.recordError()
-		r.statErrors.Add(1)
-		metrics.TileTotal.WithLabelValues("error").Inc()
-		metrics.TileDuration.Observe(time.Since(start).Seconds())
-		truncLen := min(len(respBody), 200)
-		l.Warnf("staticmap: inline %s got status %d: %s", reqURL, resp.StatusCode, string(respBody[:truncLen]))
-		return nil
-	}
-
-	// Reset circuit breaker on success
-	r.mu.Lock()
-	r.consecutiveErrors = 0
-	r.halfOpenProbeActive = false
-	r.mu.Unlock()
-	metrics.TileCircuitHealthy.Set(1)
-
-	duration := time.Since(start)
-	metrics.TileTotal.WithLabelValues("inline_ok").Inc()
-	metrics.TileDuration.Observe(duration.Seconds())
-	r.statCalls.Add(1)
-	r.statTotalMs.Add(duration.Milliseconds())
-
-	// Diagnostic: log size, content-type, and the first 8 magic bytes so we
-	// can tell valid image responses from error-page bodies. A valid PNG
-	// starts with 89504e470d0a1a0a; JPEG with ffd8ff.
-	prefixLen := min(len(respBody), 8)
-	l.Debugf("staticmap: inline %d bytes from %s (ct=%s, first=%x) in %dms",
-		len(respBody), reqURL, resp.Header.Get("Content-Type"), respBody[:prefixLen], duration.Milliseconds())
-
 	return respBody
 }
 
@@ -1045,17 +1028,6 @@ func (r *Resolver) GetStaticMapType(maptype string) string {
 	return r.getConfigForTileType(maptype).Type
 }
 
-// recordError increments the consecutive error counter and opens the circuit if threshold reached.
-func (r *Resolver) recordError() {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	r.consecutiveErrors++
-	r.halfOpenProbeActive = false
-	if r.consecutiveErrors >= r.config.TileserverFailureThreshold {
-		r.circuitOpenSince = time.Now()
-		metrics.TileCircuitHealthy.Set(0)
-	}
-}
 
 // limits converts pixel coordinates to lat/lon using the Web Mercator projection.
 // Returns [minLat, minLon, maxLat, maxLon].

--- a/processor/internal/staticmap/staticmap.go
+++ b/processor/internal/staticmap/staticmap.go
@@ -190,9 +190,11 @@ type Resolver struct {
 	done      chan struct{}    // signals tile workers to stop
 	wg        sync.WaitGroup   // tracks tile worker goroutines
 
-	// breaker guards tileserver POSTs (pregenerate + inline). Concurrency is
-	// already bounded by the tile worker pool, so the breaker itself is
-	// unlimited.
+	// breaker guards tileserver POSTs (pregenerate + inline). It has no
+	// concurrency limit — matching the prior hand-rolled breaker. The async
+	// tile path is bounded by the worker pool, but synchronous callers (tile
+	// API, !location/!area, quest summary) are not, so this is not a global
+	// concurrency cap.
 	breaker *breaker.Gate
 
 	// Stats counters for periodic logging
@@ -774,6 +776,15 @@ func (r *Resolver) GetPregeneratedTileURL(maptype string, data map[string]any, s
 func (r *Resolver) pregenerateID(maptype string, data map[string]any, staticMapType, ref string) (result, mapPath string) {
 	l := reflog(ref)
 
+	// Open circuit: skip URL building and the (potentially large) enrichment-map
+	// marshal entirely — Do would only throw them away. Half-open returns false
+	// so the single probe still proceeds.
+	if r.breaker.IsOpen() {
+		metrics.TileTotal.WithLabelValues("circuit_break").Inc()
+		l.Debugf("staticmap: circuit breaker open for %s, skipping tile", maptype)
+		return "", ""
+	}
+
 	mapPath = "staticmap"
 	templateType := ""
 	if strings.EqualFold(staticMapType, "multistaticmap") {
@@ -921,6 +932,13 @@ func (r *Resolver) downloadTileBytes(fetchURL, ref string) []byte {
 func (r *Resolver) GenerateInlineTile(maptype string, data map[string]any, staticMapType, ref string) []byte {
 	l := reflog(ref)
 
+	// Open circuit: skip URL building and the enrichment-map marshal entirely.
+	// Half-open returns false so the single probe still proceeds.
+	if r.breaker.IsOpen() {
+		metrics.TileTotal.WithLabelValues("circuit_break").Inc()
+		return nil
+	}
+
 	mapPath := "staticmap"
 	templateType := ""
 	if strings.EqualFold(staticMapType, "multistaticmap") {
@@ -1027,7 +1045,6 @@ func (r *Resolver) AddNearbyStops(target, data map[string]any, maptype, ref stri
 func (r *Resolver) GetStaticMapType(maptype string) string {
 	return r.getConfigForTileType(maptype).Type
 }
-
 
 // limits converts pixel coordinates to lat/lon using the Web Mercator projection.
 // Returns [minLat, minLon, maxLat, maxLon].

--- a/processor/internal/staticmap/staticmap_test.go
+++ b/processor/internal/staticmap/staticmap_test.go
@@ -2,7 +2,10 @@ package staticmap
 
 import (
 	"math"
+	"net/http"
+	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 )
 
@@ -297,31 +300,41 @@ func TestGetTileURLMulti(t *testing.T) {
 }
 
 func TestCircuitBreaker(t *testing.T) {
+	// Tileserver that always fails; after the failure threshold the breaker
+	// should open and stop hitting it.
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
 	r := New(Config{
 		Provider:                   "tileservercache",
-		ProviderURL:                "https://tiles.example.com",
+		ProviderURL:                srv.URL,
 		TileserverFailureThreshold: 3,
-		TileserverCooldownMs:       100, // short for testing
+		TileserverCooldownMs:       60000, // long so the circuit stays open in-test
 	})
 
-	// Record errors to open circuit
-	r.recordError()
-	r.recordError()
-	r.recordError()
-
-	r.mu.Lock()
-	if r.consecutiveErrors < 3 {
-		t.Errorf("expected >= 3 consecutive errors, got %d", r.consecutiveErrors)
+	// Three failing POSTs trip the breaker.
+	for i := 0; i < 3; i++ {
+		if got := r.GetPregeneratedTileURL("monster", map[string]any{}, "staticMap"); got != "" {
+			t.Fatalf("call %d: expected empty on tileserver 500, got %q", i, got)
+		}
 	}
-	if r.circuitOpenSince.IsZero() {
-		t.Error("expected circuit to be open")
+	hits := calls.Load()
+	if hits != 3 {
+		t.Fatalf("expected 3 tileserver hits before open, got %d", hits)
 	}
-	r.mu.Unlock()
 
-	// Pregenerate should return empty during cooldown
-	result := r.GetPregeneratedTileURL("monster", map[string]any{}, "staticMap")
-	if result != "" {
-		t.Errorf("expected empty during circuit break, got %q", result)
+	// Further calls are short-circuited — the tileserver is not contacted.
+	for i := 0; i < 3; i++ {
+		if got := r.GetPregeneratedTileURL("monster", map[string]any{}, "staticMap"); got != "" {
+			t.Fatalf("expected empty during circuit break, got %q", got)
+		}
+	}
+	if extra := calls.Load() - hits; extra != 0 {
+		t.Errorf("circuit open but tileserver hit %d more times", extra)
 	}
 }
 

--- a/processor/internal/tracker/accuweather.go
+++ b/processor/internal/tracker/accuweather.go
@@ -2,7 +2,6 @@ package tracker
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"math"
 	"net/http"
@@ -14,7 +13,6 @@ import (
 	"github.com/golang/geo/s2"
 	log "github.com/sirupsen/logrus"
 
-	"github.com/pokemon/poracleng/processor/internal/breaker"
 	"github.com/pokemon/poracleng/processor/internal/logref"
 	"github.com/pokemon/poracleng/processor/internal/metrics"
 )
@@ -34,7 +32,6 @@ type AccuWeatherClient struct {
 	cfg     AccuWeatherConfig
 	tracker *WeatherTracker
 	client  *http.Client
-	breaker *breaker.Gate // guards both AccuWeather endpoints (one service)
 
 	mu            sync.Mutex
 	keyUsage      map[string]int // date-key -> count
@@ -76,7 +73,6 @@ func NewAccuWeatherClient(cfg AccuWeatherConfig, tracker *WeatherTracker) *AccuW
 		cfg:           cfg,
 		tracker:       tracker,
 		client:        &http.Client{Timeout: 15 * time.Second},
-		breaker:       breaker.NewGate(breaker.Config{Name: "accuweather"}),
 		keyUsage:      make(map[string]int),
 		cellMutexes:   make(map[string]*sync.Mutex),
 		cellLocations: make(map[string]string),
@@ -164,38 +160,27 @@ func (aw *AccuWeatherClient) fetchForecast(cellID string, currentHour int64) {
 	url := fmt.Sprintf("https://dataservice.accuweather.com/forecasts/v1/hourly/12hour/%s?apikey=%s&details=true&metric=true", locationKey, apiKey)
 	logref.Debugf(cellID, "AccuWeather: fetching forecast")
 
-	// Guard the AccuWeather call with the shared circuit breaker so an outage
-	// doesn't make every weather enrichment wait out the 15s timeout.
+	resp, err := aw.client.Get(url)
+	if err != nil {
+		metrics.AccuWeatherRequests.WithLabelValues("forecast", "error").Inc()
+		logref.Errorf(cellID, "AccuWeather: forecast request failed: %v", err)
+		return
+	}
+	defer resp.Body.Close()
+
+	aw.logRateLimitHeaders(resp, "forecast", apiKey)
+
+	if resp.StatusCode != 200 {
+		metrics.AccuWeatherRequests.WithLabelValues("forecast", fmt.Sprintf("http_%d", resp.StatusCode)).Inc()
+		logref.Errorf(cellID, "AccuWeather: forecast request returned %d", resp.StatusCode)
+		return
+	}
+
+	metrics.AccuWeatherRequests.WithLabelValues("forecast", "success").Inc()
+
 	var forecasts []accuWeatherHourlyResponse
-	berr := aw.breaker.Do(func() error {
-		resp, err := aw.client.Get(url)
-		if err != nil {
-			metrics.AccuWeatherRequests.WithLabelValues("forecast", "error").Inc()
-			logref.Errorf(cellID, "AccuWeather: forecast request failed: %v", err)
-			return err
-		}
-		defer resp.Body.Close()
-
-		aw.logRateLimitHeaders(resp, "forecast", apiKey)
-
-		if resp.StatusCode != 200 {
-			metrics.AccuWeatherRequests.WithLabelValues("forecast", fmt.Sprintf("http_%d", resp.StatusCode)).Inc()
-			logref.Errorf(cellID, "AccuWeather: forecast request returned %d", resp.StatusCode)
-			return fmt.Errorf("accuweather: forecast status %d", resp.StatusCode)
-		}
-
-		metrics.AccuWeatherRequests.WithLabelValues("forecast", "success").Inc()
-
-		if err := json.NewDecoder(resp.Body).Decode(&forecasts); err != nil {
-			logref.Errorf(cellID, "AccuWeather: failed to decode forecast: %v", err)
-			return err
-		}
-		return nil
-	})
-	if berr != nil {
-		if errors.Is(berr, breaker.ErrOpen) {
-			logref.Debugf(cellID, "AccuWeather: circuit open, skipping forecast")
-		}
+	if err := json.NewDecoder(resp.Body).Decode(&forecasts); err != nil {
+		logref.Errorf(cellID, "AccuWeather: failed to decode forecast: %v", err)
 		return
 	}
 
@@ -249,34 +234,25 @@ func (aw *AccuWeatherClient) getLocationKey(cellID string) (string, error) {
 	url := fmt.Sprintf("https://dataservice.accuweather.com/locations/v1/cities/geoposition/search?apikey=%s&q=%f%%2C%f", apiKey, lat, lon)
 	logref.Debugf(cellID, "AccuWeather: fetching location (%f, %f)", lat, lon)
 
+	resp, err := aw.client.Get(url)
+	if err != nil {
+		metrics.AccuWeatherRequests.WithLabelValues("location", "error").Inc()
+		return "", fmt.Errorf("location request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	aw.logRateLimitHeaders(resp, "location", apiKey)
+
+	if resp.StatusCode != 200 {
+		metrics.AccuWeatherRequests.WithLabelValues("location", fmt.Sprintf("http_%d", resp.StatusCode)).Inc()
+		return "", fmt.Errorf("location request returned %d", resp.StatusCode)
+	}
+
+	metrics.AccuWeatherRequests.WithLabelValues("location", "success").Inc()
+
 	var locResp accuWeatherLocationResponse
-	berr := aw.breaker.Do(func() error {
-		resp, err := aw.client.Get(url)
-		if err != nil {
-			metrics.AccuWeatherRequests.WithLabelValues("location", "error").Inc()
-			return fmt.Errorf("location request failed: %w", err)
-		}
-		defer resp.Body.Close()
-
-		aw.logRateLimitHeaders(resp, "location", apiKey)
-
-		if resp.StatusCode != 200 {
-			metrics.AccuWeatherRequests.WithLabelValues("location", fmt.Sprintf("http_%d", resp.StatusCode)).Inc()
-			return fmt.Errorf("location request returned %d", resp.StatusCode)
-		}
-
-		metrics.AccuWeatherRequests.WithLabelValues("location", "success").Inc()
-
-		if err := json.NewDecoder(resp.Body).Decode(&locResp); err != nil {
-			return fmt.Errorf("failed to decode location response: %w", err)
-		}
-		return nil
-	})
-	if berr != nil {
-		if errors.Is(berr, breaker.ErrOpen) {
-			return "", fmt.Errorf("accuweather: circuit open")
-		}
-		return "", berr
+	if err := json.NewDecoder(resp.Body).Decode(&locResp); err != nil {
+		return "", fmt.Errorf("failed to decode location response: %w", err)
 	}
 
 	aw.mu.Lock()

--- a/processor/internal/tracker/accuweather.go
+++ b/processor/internal/tracker/accuweather.go
@@ -2,6 +2,7 @@ package tracker
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math"
 	"net/http"
@@ -13,6 +14,7 @@ import (
 	"github.com/golang/geo/s2"
 	log "github.com/sirupsen/logrus"
 
+	"github.com/pokemon/poracleng/processor/internal/breaker"
 	"github.com/pokemon/poracleng/processor/internal/logref"
 	"github.com/pokemon/poracleng/processor/internal/metrics"
 )
@@ -32,6 +34,7 @@ type AccuWeatherClient struct {
 	cfg     AccuWeatherConfig
 	tracker *WeatherTracker
 	client  *http.Client
+	breaker *breaker.Gate // guards both AccuWeather endpoints (one service)
 
 	mu            sync.Mutex
 	keyUsage      map[string]int // date-key -> count
@@ -73,6 +76,7 @@ func NewAccuWeatherClient(cfg AccuWeatherConfig, tracker *WeatherTracker) *AccuW
 		cfg:           cfg,
 		tracker:       tracker,
 		client:        &http.Client{Timeout: 15 * time.Second},
+		breaker:       breaker.NewGate(breaker.Config{Name: "accuweather"}),
 		keyUsage:      make(map[string]int),
 		cellMutexes:   make(map[string]*sync.Mutex),
 		cellLocations: make(map[string]string),
@@ -160,27 +164,38 @@ func (aw *AccuWeatherClient) fetchForecast(cellID string, currentHour int64) {
 	url := fmt.Sprintf("https://dataservice.accuweather.com/forecasts/v1/hourly/12hour/%s?apikey=%s&details=true&metric=true", locationKey, apiKey)
 	logref.Debugf(cellID, "AccuWeather: fetching forecast")
 
-	resp, err := aw.client.Get(url)
-	if err != nil {
-		metrics.AccuWeatherRequests.WithLabelValues("forecast", "error").Inc()
-		logref.Errorf(cellID, "AccuWeather: forecast request failed: %v", err)
-		return
-	}
-	defer resp.Body.Close()
-
-	aw.logRateLimitHeaders(resp, "forecast", apiKey)
-
-	if resp.StatusCode != 200 {
-		metrics.AccuWeatherRequests.WithLabelValues("forecast", fmt.Sprintf("http_%d", resp.StatusCode)).Inc()
-		logref.Errorf(cellID, "AccuWeather: forecast request returned %d", resp.StatusCode)
-		return
-	}
-
-	metrics.AccuWeatherRequests.WithLabelValues("forecast", "success").Inc()
-
+	// Guard the AccuWeather call with the shared circuit breaker so an outage
+	// doesn't make every weather enrichment wait out the 15s timeout.
 	var forecasts []accuWeatherHourlyResponse
-	if err := json.NewDecoder(resp.Body).Decode(&forecasts); err != nil {
-		logref.Errorf(cellID, "AccuWeather: failed to decode forecast: %v", err)
+	berr := aw.breaker.Do(func() error {
+		resp, err := aw.client.Get(url)
+		if err != nil {
+			metrics.AccuWeatherRequests.WithLabelValues("forecast", "error").Inc()
+			logref.Errorf(cellID, "AccuWeather: forecast request failed: %v", err)
+			return err
+		}
+		defer resp.Body.Close()
+
+		aw.logRateLimitHeaders(resp, "forecast", apiKey)
+
+		if resp.StatusCode != 200 {
+			metrics.AccuWeatherRequests.WithLabelValues("forecast", fmt.Sprintf("http_%d", resp.StatusCode)).Inc()
+			logref.Errorf(cellID, "AccuWeather: forecast request returned %d", resp.StatusCode)
+			return fmt.Errorf("accuweather: forecast status %d", resp.StatusCode)
+		}
+
+		metrics.AccuWeatherRequests.WithLabelValues("forecast", "success").Inc()
+
+		if err := json.NewDecoder(resp.Body).Decode(&forecasts); err != nil {
+			logref.Errorf(cellID, "AccuWeather: failed to decode forecast: %v", err)
+			return err
+		}
+		return nil
+	})
+	if berr != nil {
+		if errors.Is(berr, breaker.ErrOpen) {
+			logref.Debugf(cellID, "AccuWeather: circuit open, skipping forecast")
+		}
 		return
 	}
 
@@ -234,25 +249,34 @@ func (aw *AccuWeatherClient) getLocationKey(cellID string) (string, error) {
 	url := fmt.Sprintf("https://dataservice.accuweather.com/locations/v1/cities/geoposition/search?apikey=%s&q=%f%%2C%f", apiKey, lat, lon)
 	logref.Debugf(cellID, "AccuWeather: fetching location (%f, %f)", lat, lon)
 
-	resp, err := aw.client.Get(url)
-	if err != nil {
-		metrics.AccuWeatherRequests.WithLabelValues("location", "error").Inc()
-		return "", fmt.Errorf("location request failed: %w", err)
-	}
-	defer resp.Body.Close()
-
-	aw.logRateLimitHeaders(resp, "location", apiKey)
-
-	if resp.StatusCode != 200 {
-		metrics.AccuWeatherRequests.WithLabelValues("location", fmt.Sprintf("http_%d", resp.StatusCode)).Inc()
-		return "", fmt.Errorf("location request returned %d", resp.StatusCode)
-	}
-
-	metrics.AccuWeatherRequests.WithLabelValues("location", "success").Inc()
-
 	var locResp accuWeatherLocationResponse
-	if err := json.NewDecoder(resp.Body).Decode(&locResp); err != nil {
-		return "", fmt.Errorf("failed to decode location response: %w", err)
+	berr := aw.breaker.Do(func() error {
+		resp, err := aw.client.Get(url)
+		if err != nil {
+			metrics.AccuWeatherRequests.WithLabelValues("location", "error").Inc()
+			return fmt.Errorf("location request failed: %w", err)
+		}
+		defer resp.Body.Close()
+
+		aw.logRateLimitHeaders(resp, "location", apiKey)
+
+		if resp.StatusCode != 200 {
+			metrics.AccuWeatherRequests.WithLabelValues("location", fmt.Sprintf("http_%d", resp.StatusCode)).Inc()
+			return fmt.Errorf("location request returned %d", resp.StatusCode)
+		}
+
+		metrics.AccuWeatherRequests.WithLabelValues("location", "success").Inc()
+
+		if err := json.NewDecoder(resp.Body).Decode(&locResp); err != nil {
+			return fmt.Errorf("failed to decode location response: %w", err)
+		}
+		return nil
+	})
+	if berr != nil {
+		if errors.Is(berr, breaker.ErrOpen) {
+			return "", fmt.Errorf("accuweather: circuit open")
+		}
+		return "", berr
 	}
 
 	aw.mu.Lock()


### PR DESCRIPTION
Follow-up to the circuit-breaker discussion. Replaces the three near-identical hand-rolled circuit breakers with one shared, tested wrapper over [`sony/gobreaker/v2`](https://github.com/sony/gobreaker), and adds a breaker to one unprotected hot-path call (Shlink).

> **Stacking:** based on `feature/geonames-intersection` (#154), not `develop`, because `intersection.go` only exists on that branch and the whole point is to convert **all three** breakers together (no hand-rolled/library mix). Retarget to `develop` once #154 merges.

## Why
There were exactly three true circuit breakers in the codebase — `geocoder.go`, `staticmap.go`, `intersection.go` — each a copy of the same `sync.Mutex` + `consecutiveErrors`/`circuitOpenSince`/`halfOpenProbeActive` state machine with identical 5-fail/30s/single-probe semantics. Three hand-rolled copies of a concurrency state machine is exactly the drift-risk a library removes, and a shared wrapper makes adding breakers to *new* external calls cheap.

## `internal/breaker`
- **`Breaker[T].Do(func() (T, error))`** — generic typed breaker for calls that return their value through the breaker (geocoder → `*Address`, intersection → `string`).
- **`Gate.Do(func() error)`** — non-generic variant for sites that handle the result themselves via closure, so one breaker can guard several call sites with different return types (the tileserver's pregenerate-URL **and** inline-bytes pair).
- **`IsOpen()`** — lets callers cheaply skip expensive request prep (marshal, key selection) when fully open; half-open returns false so the single probe still runs.
- Both bundle an optional **concurrency limiter** and an **`OnHealthChange`** hook that drives the existing `*CircuitHealthy` Prometheus gauges via gobreaker's `OnStateChange`.
- Defaults match the old breakers exactly: **5** consecutive failures, **30s** cooldown, **single** half-open probe (`ReadyToTrip`/`Timeout`/`MaxRequests` set explicitly — gobreaker's own defaults differ).

## Conversions (behaviour-preserving)
| Component | Notes |
|---|---|
| `geocoder.go` | breaker + concurrency sem folded into one `Breaker[*Address]`; all stats/metrics preserved. A `(nil,nil)` "no address" stays silent (still trips the breaker, as before). |
| `staticmap.go` | two call sites share one `Gate`; `IsOpen()` checked before the enrichment-map marshal; marshal failures stay outside the breaker so a local serialization error can't trip it. |
| `intersection.go` | hand-rolled breaker (added in #154) swapped for the wrapper. |

## Shlink breaker (the one new external-call breaker)
`dts/shlink.go` — per-message URL shortening, 10s timeout, already falls back to the original URL. A breaker skips the doomed call when Shlink is unreachable. A reachable 2xx with an unusable body does **not** trip it (only connectivity/non-2xx do), so a responding-but-unhelpful Shlink degrades per-call rather than globally.

## Code review applied
A high-effort workflow review ran against this branch. Findings addressed in the latest commit:
- **AccuWeather breaker reverted** — it was assessed and initially added, but the review showed it doesn't compose with AccuWeather's existing per-key daily-quota accounting (open circuit burnt quota for requests never sent) and per-cell hourly retry-gate. AccuWeather already self-throttles hard, so the breaker's marginal value didn't justify the regressions. Reverted to base.
- Shlink no longer trips on reachable-bad-body; `IsOpen()` short-circuit before marshal; dropped the unused `Config.IsSuccessful` hook; restored geocoder's silent `(nil,nil)`; corrected the staticmap concurrency comment.

## Tests
- `internal/breaker`: open-after-threshold, success-resets-consecutive, half-open recovery, `OnHealthChange` transitions, concurrency limit, `IsOpen`, `Gate` behaviour.
- Shlink: bad-body-doesn't-trip vs 5xx-trips. Existing geocoder/staticmap/intersection breaker tests drive the new path.
- Full gate green: `go build ./... && go vet ./... && go test -count=1 ./... && golangci-lint run ./...`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)