### PR TITLE
fix(bot): apply form filter on !raid, reject form on remove

### DIFF
--- a/processor/internal/bot/commands/helpers.go
+++ b/processor/internal/bot/commands/helpers.go
@@ -389,6 +389,19 @@ func parseCommonTrackFields(ctx *bot.CommandContext, parsed *bot.ParsedArgs, dts
 	return f, nil
 }
 
+// rejectFormOnRemove mirrors pokemon untrack, which treats form: as an
+// unrecognized argument on removal: removes are species-wide, so silently
+// accepting the token would delete rules for every form. Per-form rules
+// are removed via id:N. Returns nil when no form argument is present.
+func rejectFormOnRemove(ctx *bot.CommandContext, parsed *bot.ParsedArgs) *bot.Reply {
+	formName, ok := parsed.Strings["form"]
+	if !ok || formName == "" {
+		return nil
+	}
+	tr := ctx.Tr()
+	return &bot.Reply{React: "🙅", Text: tr.Tf("msg.unrecognized", "form:"+formName)}
+}
+
 // applyFormFilter applies parsed["form"] to monsters. Returns a
 // helpful reply when the form filter rejects every input — e.g.
 // `!track sinistea form:incorrect` should not silently degrade into

--- a/processor/internal/bot/commands/maxbattle.go
+++ b/processor/internal/bot/commands/maxbattle.go
@@ -208,6 +208,10 @@ func (c *MaxbattleCommand) resolveMonsters(ctx *bot.CommandContext, parsed *bot.
 }
 
 func (c *MaxbattleCommand) removeMaxbattles(ctx *bot.CommandContext, parsed *bot.ParsedArgs) []bot.Reply {
+	if reply := rejectFormOnRemove(ctx, parsed); reply != nil {
+		return []bot.Reply{*reply}
+	}
+
 	if len(parsed.RemoveUIDs) > 0 {
 		tr := ctx.Tr()
 		return removeByUIDs(ctx, ctx.Tracking.Maxbattles, parsed.RemoveUIDs,

--- a/processor/internal/bot/commands/maxbattle_test.go
+++ b/processor/internal/bot/commands/maxbattle_test.go
@@ -57,6 +57,23 @@ func runMaxbattle(t *testing.T, ctx *bot.CommandContext, input string) []bot.Rep
 	return cmd.Run(ctx, args)
 }
 
+func TestMaxbattle_Remove_FormRejected(t *testing.T) {
+	ctx := maxbattleCtx(t)
+	runMaxbattle(t, ctx, "25")
+	rows, _ := ctx.Tracking.Maxbattles.SelectByIDProfile("user1", 1)
+	require.Len(t, rows, 1)
+
+	// Pokemon remove (!untrack) treats form: as unrecognized; maxbattle
+	// remove must do the same rather than silently removing every form.
+	replies := runMaxbattle(t, ctx, "remove 25 form:burn")
+	require.NotEmpty(t, replies)
+	assert.Equal(t, "🙅", replies[0].React, "reply: %s", replies[0].Text)
+	assert.Contains(t, replies[0].Text, "form:burn")
+
+	rows, _ = ctx.Tracking.Maxbattles.SelectByIDProfile("user1", 1)
+	assert.Len(t, rows, 1, "rejected remove must not delete anything")
+}
+
 func TestMaxbattle_BasicPokemon(t *testing.T) {
 	ctx := maxbattleCtx(t)
 	replies := runMaxbattle(t, ctx, "25")

--- a/processor/internal/bot/commands/nest.go
+++ b/processor/internal/bot/commands/nest.go
@@ -57,6 +57,12 @@ func (c *NestCommand) Run(ctx *bot.CommandContext, args []string) []bot.Reply {
 		return []bot.Reply{*warn}
 	}
 
+	if parsed.HasKeyword("arg.remove") {
+		if reply := rejectFormOnRemove(ctx, parsed); reply != nil {
+			return []bot.Reply{*reply}
+		}
+	}
+
 	// `remove id:N` is unambiguous — no pokemon required. Hoist this above the
 	// pokemon-resolution below so a UID-only removal (e.g. from /untrack nest)
 	// doesn't trip the "no pokemon" reply.

--- a/processor/internal/bot/commands/nest_test.go
+++ b/processor/internal/bot/commands/nest_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pokemon/poracleng/processor/internal/db"
 	"github.com/pokemon/poracleng/processor/internal/dts"
 	"github.com/pokemon/poracleng/processor/internal/gamedata"
+	"github.com/pokemon/poracleng/processor/internal/i18n"
 	"github.com/pokemon/poracleng/processor/internal/rowtext"
 	"github.com/pokemon/poracleng/processor/internal/store"
 	"github.com/stretchr/testify/assert"
@@ -30,11 +31,20 @@ func nestCtx(t *testing.T) *bot.CommandContext {
 
 	gd := &gamedata.GameData{
 		Monsters: map[gamedata.MonsterKey]*gamedata.Monster{
-			{ID: 25, Form: 0}: {PokemonID: 25, FormID: 0},
+			{ID: 25, Form: 0}:    {PokemonID: 25, FormID: 0},
+			{ID: 649, Form: 0}:   {PokemonID: 649, FormID: 0},
+			{ID: 649, Form: 917}: {PokemonID: 649, FormID: 917},
 		},
 		Moves: map[int]*gamedata.Move{},
 		Types: map[int]*gamedata.TypeInfo{},
 	}
+
+	// The resolver indexes poke_{id} names at construction, so name and
+	// form translations must land in the bundle first.
+	ctx.Translations.AddTranslator(i18n.NewTranslator("en", map[string]string{
+		"poke_649": "Genesect",
+		"form_917": "Burn",
+	}))
 
 	resolver := bot.NewPokemonResolver(gd, ctx.Translations, []string{"en"}, nil)
 	ctx.Resolver = resolver
@@ -55,6 +65,23 @@ func runNest(t *testing.T, ctx *bot.CommandContext, input string) []bot.Reply {
 	cmd := &NestCommand{}
 	args := strings.Fields(input)
 	return cmd.Run(ctx, args)
+}
+
+func TestNest_Remove_FormRejected(t *testing.T) {
+	ctx := nestCtx(t)
+	runNest(t, ctx, "genesect form:burn")
+	rows, _ := ctx.Tracking.Nests.SelectByIDProfile("user1", 1)
+	require.Len(t, rows, 1)
+
+	// Pokemon remove (!untrack) treats form: as unrecognized; nest remove
+	// must do the same rather than silently removing every form.
+	replies := runNest(t, ctx, "remove genesect form:burn")
+	require.NotEmpty(t, replies)
+	assert.Equal(t, "🙅", replies[0].React, "reply: %s", replies[0].Text)
+	assert.Contains(t, replies[0].Text, "form:burn")
+
+	rows, _ = ctx.Tracking.Nests.SelectByIDProfile("user1", 1)
+	assert.Len(t, rows, 1, "rejected remove must not delete anything")
 }
 
 func TestNest_BasicPokemon(t *testing.T) {

--- a/processor/internal/bot/commands/quest.go
+++ b/processor/internal/bot/commands/quest.go
@@ -367,6 +367,10 @@ func questBulkAllowed(ctx *bot.CommandContext) bool {
 
 // handleRemove handles !quest remove variants. Must be called before reward type detection.
 func (c *QuestCommand) handleRemove(ctx *bot.CommandContext, parsed *bot.ParsedArgs, common *commonTrackFields, shiny bool, pings string) []bot.Reply {
+	if reply := rejectFormOnRemove(ctx, parsed); reply != nil {
+		return []bot.Reply{*reply}
+	}
+
 	if len(parsed.RemoveUIDs) > 0 {
 		tr := ctx.Tr()
 		return removeByUIDs(ctx, ctx.Tracking.Quests, parsed.RemoveUIDs,

--- a/processor/internal/bot/commands/quest_test.go
+++ b/processor/internal/bot/commands/quest_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pokemon/poracleng/processor/internal/db"
 	"github.com/pokemon/poracleng/processor/internal/dts"
 	"github.com/pokemon/poracleng/processor/internal/gamedata"
+	"github.com/pokemon/poracleng/processor/internal/i18n"
 	"github.com/pokemon/poracleng/processor/internal/rowtext"
 	"github.com/pokemon/poracleng/processor/internal/store"
 	"github.com/stretchr/testify/assert"
@@ -30,12 +31,21 @@ func questCtx(t *testing.T) *bot.CommandContext {
 
 	gd := &gamedata.GameData{
 		Monsters: map[gamedata.MonsterKey]*gamedata.Monster{
-			{ID: 25, Form: 0}: {PokemonID: 25, FormID: 0},
+			{ID: 25, Form: 0}:    {PokemonID: 25, FormID: 0},
+			{ID: 649, Form: 0}:   {PokemonID: 649, FormID: 0},
+			{ID: 649, Form: 917}: {PokemonID: 649, FormID: 917},
 		},
 		Moves: map[int]*gamedata.Move{},
 		Types: map[int]*gamedata.TypeInfo{},
 		Items: map[int]*gamedata.Item{},
 	}
+
+	// The resolver indexes poke_{id} names at construction, so name and
+	// form translations must land in the bundle first.
+	ctx.Translations.AddTranslator(i18n.NewTranslator("en", map[string]string{
+		"poke_649": "Genesect",
+		"form_917": "Burn",
+	}))
 
 	resolver := bot.NewPokemonResolver(gd, ctx.Translations, []string{"en"}, nil)
 	ctx.Resolver = resolver
@@ -106,6 +116,23 @@ func TestQuest_Duplicate(t *testing.T) {
 	replies2 := runQuest(t, ctx, "25")
 	require.NotEmpty(t, replies2)
 	assert.Equal(t, "👌", replies2[0].React, "duplicate should be 👌, reply: %s", replies2[0].Text)
+}
+
+func TestQuest_Remove_FormRejected(t *testing.T) {
+	ctx := questCtx(t)
+	runQuest(t, ctx, "genesect form:burn")
+	rows, _ := ctx.Tracking.Quests.SelectByIDProfile("user1", 1)
+	require.Len(t, rows, 1)
+
+	// Pokemon remove (!untrack) treats form: as unrecognized; quest remove
+	// must do the same rather than silently removing every form.
+	replies := runQuest(t, ctx, "remove genesect form:burn")
+	require.NotEmpty(t, replies)
+	assert.Equal(t, "🙅", replies[0].React, "reply: %s", replies[0].Text)
+	assert.Contains(t, replies[0].Text, "form:burn")
+
+	rows, _ = ctx.Tracking.Quests.SelectByIDProfile("user1", 1)
+	assert.Len(t, rows, 1, "rejected remove must not delete anything")
 }
 
 func TestQuest_Remove(t *testing.T) {

--- a/processor/internal/bot/commands/raid.go
+++ b/processor/internal/bot/commands/raid.go
@@ -122,8 +122,12 @@ func (c *RaidCommand) Run(ctx *bot.CommandContext, args []string) []bot.Reply {
 	var insert []db.RaidTrackingAPI
 
 	if len(parsed.Pokemon) > 0 {
+		monsters, formReply := applyFormFilter(ctx, parsed.Pokemon, parsed)
+		if formReply != nil {
+			return []bot.Reply{*formReply}
+		}
 		// Track specific pokemon
-		for _, mon := range parsed.Pokemon {
+		for _, mon := range monsters {
 			insert = append(insert, db.RaidTrackingAPI{
 				ID:                    ctx.TargetID,
 				ProfileNo:             ctx.ProfileNo,
@@ -232,6 +236,10 @@ func (c *RaidCommand) Run(ctx *bot.CommandContext, args []string) []bot.Reply {
 }
 
 func (c *RaidCommand) removeRaids(ctx *bot.CommandContext, parsed *bot.ParsedArgs) []bot.Reply {
+	if reply := rejectFormOnRemove(ctx, parsed); reply != nil {
+		return []bot.Reply{*reply}
+	}
+
 	if len(parsed.RemoveUIDs) > 0 {
 		tr := ctx.Tr()
 		return removeByUIDs(ctx, ctx.Tracking.Raids, parsed.RemoveUIDs,

--- a/processor/internal/bot/commands/raid_test.go
+++ b/processor/internal/bot/commands/raid_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pokemon/poracleng/processor/internal/db"
 	"github.com/pokemon/poracleng/processor/internal/dts"
 	"github.com/pokemon/poracleng/processor/internal/gamedata"
+	"github.com/pokemon/poracleng/processor/internal/i18n"
 	"github.com/pokemon/poracleng/processor/internal/rowtext"
 	"github.com/pokemon/poracleng/processor/internal/store"
 	"github.com/stretchr/testify/assert"
@@ -30,11 +31,20 @@ func raidCtx(t *testing.T) *bot.CommandContext {
 
 	gd := &gamedata.GameData{
 		Monsters: map[gamedata.MonsterKey]*gamedata.Monster{
-			{ID: 25, Form: 0}: {PokemonID: 25, FormID: 0},
+			{ID: 25, Form: 0}:    {PokemonID: 25, FormID: 0},
+			{ID: 649, Form: 0}:   {PokemonID: 649, FormID: 0},
+			{ID: 649, Form: 917}: {PokemonID: 649, FormID: 917},
 		},
 		Moves: map[int]*gamedata.Move{},
 		Types: map[int]*gamedata.TypeInfo{},
 	}
+
+	// The resolver indexes poke_{id} names at construction, so name and
+	// form translations must land in the bundle first.
+	ctx.Translations.AddTranslator(i18n.NewTranslator("en", map[string]string{
+		"poke_649": "Genesect",
+		"form_917": "Burn",
+	}))
 
 	resolver := bot.NewPokemonResolver(gd, ctx.Translations, []string{"en"}, nil)
 	ctx.Resolver = resolver
@@ -81,6 +91,47 @@ func TestRaid_ByLevel(t *testing.T) {
 	require.Len(t, rows, 1)
 	assert.Equal(t, 5, rows[0].Level)
 	assert.Equal(t, bot.WildcardID, rows[0].PokemonID, "level tracking should use wildcard pokemon")
+}
+
+func TestRaid_FormFilter(t *testing.T) {
+	ctx := raidCtx(t)
+	replies := runRaid(t, ctx, "genesect form:burn")
+
+	require.NotEmpty(t, replies)
+	assert.Equal(t, "✅", replies[0].React, "reply: %s", replies[0].Text)
+
+	rows, _ := ctx.Tracking.Raids.SelectByIDProfile("user1", 1)
+	require.Len(t, rows, 1)
+	assert.Equal(t, 649, rows[0].PokemonID)
+	assert.Equal(t, 917, rows[0].Form, "form:burn must narrow the rule to the Burn form, not form 0")
+}
+
+func TestRaid_FormFilter_UnknownForm(t *testing.T) {
+	ctx := raidCtx(t)
+	replies := runRaid(t, ctx, "genesect form:bogus")
+
+	require.NotEmpty(t, replies)
+	assert.Equal(t, "🙅", replies[0].React, "unknown form must be rejected, reply: %s", replies[0].Text)
+
+	rows, _ := ctx.Tracking.Raids.SelectByIDProfile("user1", 1)
+	assert.Empty(t, rows, "unknown form must not silently create a form-0 rule")
+}
+
+func TestRaid_Remove_FormRejected(t *testing.T) {
+	ctx := raidCtx(t)
+	runRaid(t, ctx, "genesect form:burn")
+	rows, _ := ctx.Tracking.Raids.SelectByIDProfile("user1", 1)
+	require.Len(t, rows, 1)
+
+	// Pokemon remove (!untrack) rejects form: as unrecognized; raid remove
+	// must do the same rather than silently removing every form.
+	replies := runRaid(t, ctx, "remove genesect form:burn")
+	require.NotEmpty(t, replies)
+	assert.Equal(t, "🙅", replies[0].React, "reply: %s", replies[0].Text)
+	assert.Contains(t, replies[0].Text, "form:burn")
+
+	rows, _ = ctx.Tracking.Raids.SelectByIDProfile("user1", 1)
+	assert.Len(t, rows, 1, "rejected remove must not delete anything")
 }
 
 func TestRaid_Duplicate(t *testing.T) {


### PR DESCRIPTION
## Problem

`!raid genesect form:burn` gets a ✅ but the rule lands in the DB as `form=0`, so the user gets pinged for every Genesect form (same for Deoxys and any multi-form raid boss).

Root cause: `raid.go` declares `arg.prefix.form` in its params (so the token parses without an "unrecognized arg" warning) but never runs the mon list through `applyFormFilter()` before inserting. The other commands (track, quest, nest, maxbattle) all do this — raid just skipped it and inserted with form 0. The matching side is fine, and rules created through the API with a proper form ID work — it was only the bot command dropping the filter.

## Fix

- **Add path**: wire `applyFormFilter()` into raid's pokemon insert path, mirroring track/quest/nest/maxbattle. `!raid genesect form:burn` now stores the Burn form ID; an unknown form (`form:bogus`) is rejected with the "Form not recognised" reply instead of silently creating a track-all-forms rule.
- **Remove path**: pokemon untrack treats `form:` as an unrecognized argument (removes are species-wide). raid/maxbattle/nest/quest instead silently consumed the token and deleted rules for *every* form. Added a shared `rejectFormOnRemove()` helper that mirrors untrack's refusal across all four commands; per-form rules are removed via `id:N`.

Slash commands are unaffected — `/raid` doesn't expose a `form` option.

## Tests

New tests reproduce each bug before the fix and pass after:
- `TestRaid_FormFilter` / `TestRaid_FormFilter_UnknownForm`
- `TestRaid_Remove_FormRejected`, `TestMaxbattle_Remove_FormRejected`, `TestNest_Remove_FormRejected`, `TestQuest_Remove_FormRejected`

Full pre-commit gate passes: `go build`, `go vet`, `go test -count=1 ./...`, `golangci-lint run ./...` (0 issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)