### PR TITLE
fix(geocoding): log forward-geocode failures so they can be diagnosed

### DIFF
--- a/processor/internal/geocoding/geocoder.go
+++ b/processor/internal/geocoding/geocoder.go
@@ -225,8 +225,23 @@ func normalizeLanguage(language string) string {
 }
 
 // Forward performs a forward geocode (address search). Results are not cached.
+//
+// Failures and empty result sets are logged at WARN. Forward geocoding is
+// user-initiated and low-frequency (the !location command and the
+// /api/geocode/forward endpoint), and the bot surfaces only a generic "could
+// not understand the location" to the user — so this log is the only place the
+// real cause (unreachable URL, HTTP status, unfinished import, out-of-region
+// query) is visible to an operator.
 func (g *Geocoder) Forward(query string) ([]ForwardResult, error) {
-	return g.provider.Forward(query)
+	results, err := g.provider.Forward(query)
+	if err != nil {
+		log.Warnf("Forward geocode %q failed: %s", query, err)
+		return results, err
+	}
+	if len(results) == 0 {
+		log.Warnf("Forward geocode %q returned no results — provider reachable but no match; check the import has finished and the query falls within the imported area", query)
+	}
+	return results, nil
 }
 
 // GetStats returns the current geocoder statistics.

--- a/processor/internal/geocoding/geocoder_test.go
+++ b/processor/internal/geocoding/geocoder_test.go
@@ -1,9 +1,14 @@
 package geocoding
 
 import (
+	"fmt"
+	"strings"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
 
 	"github.com/pokemon/poracleng/processor/internal/breaker"
 )
@@ -28,6 +33,92 @@ func (p *languageProvider) calls() []string {
 	out := make([]string, len(p.languages))
 	copy(out, p.languages)
 	return out
+}
+
+// forwardStubProvider returns canned forward-geocode results/errors so the
+// Geocoder's logging behaviour can be exercised without a network call.
+type forwardStubProvider struct {
+	results []ForwardResult
+	err     error
+}
+
+func (p *forwardStubProvider) Reverse(lat, lon float64, language string) (*Address, error) {
+	return nil, nil
+}
+func (p *forwardStubProvider) Forward(query string) ([]ForwardResult, error) {
+	return p.results, p.err
+}
+
+// newForwardTestGeocoder builds a Geocoder for exercising the forward path.
+// Forward geocoding doesn't go through the circuit breaker, so a nil breaker
+// is fine here — only the provider and logging are involved.
+func newForwardTestGeocoder(p Provider) *Geocoder {
+	return &Geocoder{
+		provider: p,
+		config:   Config{FailureThreshold: 5, CooldownMs: 1},
+	}
+}
+
+func findWarn(hook *test.Hook, contains string) *logrus.Entry {
+	for _, e := range hook.AllEntries() {
+		if e.Level == logrus.WarnLevel && strings.Contains(e.Message, contains) {
+			return e
+		}
+	}
+	return nil
+}
+
+func TestForwardLogsProviderError(t *testing.T) {
+	hook := test.NewGlobal()
+	defer hook.Reset()
+	g := newForwardTestGeocoder(&forwardStubProvider{
+		err: fmt.Errorf("nominatim: request failed: connection refused"),
+	})
+
+	if _, err := g.Forward("London"); err == nil {
+		t.Fatal("expected the provider error to propagate")
+	}
+	entry := findWarn(hook, "London")
+	if entry == nil {
+		t.Fatalf("expected a warning mentioning the query; entries: %v", hook.AllEntries())
+	}
+	if !strings.Contains(entry.Message, "connection refused") {
+		t.Errorf("warning should include the provider error, got %q", entry.Message)
+	}
+}
+
+func TestForwardLogsEmptyResults(t *testing.T) {
+	hook := test.NewGlobal()
+	defer hook.Reset()
+	g := newForwardTestGeocoder(&forwardStubProvider{results: nil})
+
+	results, err := g.Forward("Nowhereville")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 0 {
+		t.Fatalf("expected empty results, got %d", len(results))
+	}
+	if findWarn(hook, "Nowhereville") == nil {
+		t.Fatalf("expected a warning about empty results; entries: %v", hook.AllEntries())
+	}
+}
+
+func TestForwardSuccessNoWarning(t *testing.T) {
+	hook := test.NewGlobal()
+	defer hook.Reset()
+	g := newForwardTestGeocoder(&forwardStubProvider{
+		results: []ForwardResult{{Latitude: 1, Longitude: 2}},
+	})
+
+	if _, err := g.Forward("Paris"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, e := range hook.AllEntries() {
+		if e.Level <= logrus.WarnLevel {
+			t.Errorf("did not expect a warning on success, got %q", e.Message)
+		}
+	}
 }
 
 func TestGeocoderLanguageAffectsProviderAndCacheKey(t *testing.T) {

--- a/processor/internal/geocoding/helpers.go
+++ b/processor/internal/geocoding/helpers.go
@@ -7,6 +7,23 @@ import (
 	"github.com/mailgun/raymond/v2"
 )
 
+// bodySnippet returns a single-line, truncated view of an HTTP response body
+// for inclusion in error messages. Providers wrap it around the raw bytes when
+// a response fails to unmarshal, so a non-JSON reply (e.g. an HTML error page
+// from a Nominatim instance whose import hasn't finished) shows up in logs
+// instead of collapsing into an opaque "invalid character '<'" JSON error.
+func bodySnippet(body []byte) string {
+	const max = 200
+	s := strings.Join(strings.Fields(string(body)), " ") // collapse whitespace/newlines
+	if s == "" {
+		return "empty body"
+	}
+	if r := []rune(s); len(r) > max {
+		return string(r[:max]) + "…"
+	}
+	return s
+}
+
 var helpersOnce sync.Once
 
 // registerAddressHelpers registers the raymond helpers address_format

--- a/processor/internal/geocoding/nominatim.go
+++ b/processor/internal/geocoding/nominatim.go
@@ -111,7 +111,7 @@ func (n *Nominatim) Reverse(lat, lon float64, language string) (*Address, error)
 
 	var result nominatimReverseResult
 	if err := json.Unmarshal(body, &result); err != nil {
-		return nil, fmt.Errorf("nominatim: unmarshal: %w", err)
+		return nil, fmt.Errorf("nominatim: unmarshal reverse response (%s): %w", bodySnippet(body), err)
 	}
 	if result.Error != "" {
 		return nil, fmt.Errorf("nominatim: %s", result.Error)
@@ -183,7 +183,7 @@ func (n *Nominatim) Forward(query string) ([]ForwardResult, error) {
 
 	var results []nominatimForwardResult
 	if err := json.Unmarshal(body, &results); err != nil {
-		return nil, fmt.Errorf("nominatim: unmarshal: %w", err)
+		return nil, fmt.Errorf("nominatim: unmarshal search response (%s): %w", bodySnippet(body), err)
 	}
 
 	out := make([]ForwardResult, 0, len(results))

--- a/processor/internal/geocoding/nominatim_test.go
+++ b/processor/internal/geocoding/nominatim_test.go
@@ -132,6 +132,69 @@ func TestNominatimFallsBackToDisplayName(t *testing.T) {
 	}
 }
 
+// TestNominatimForwardParsesResults covers the forward-search happy path
+// (previously untested) and asserts the query reaches /search.
+func TestNominatimForwardParsesResults(t *testing.T) {
+	const body = `[{"lat":"51.5074","lon":"-0.1278","display_name":"London, UK","address":{"city":"London","country":"United Kingdom"}}]`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasPrefix(r.URL.Path, "/search") {
+			t.Errorf("expected /search, got %s", r.URL.Path)
+		}
+		if q := r.URL.Query().Get("q"); q != "London" {
+			t.Errorf("q=%q, want London", q)
+		}
+		w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	n := NewNominatim(srv.URL, 2*time.Second, true)
+	results, err := n.Forward("London")
+	if err != nil {
+		t.Fatalf("Forward: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("want 1 result, got %d", len(results))
+	}
+	if results[0].Latitude == 0 || results[0].City != "London" {
+		t.Errorf("unexpected result: %+v", results[0])
+	}
+}
+
+// TestNominatimForwardSnippetOnNonJSON — when the server replies with a
+// non-JSON body (e.g. an HTML error page from an instance whose import hasn't
+// finished), the error must carry a snippet of that body so the operator can
+// see what actually came back instead of an opaque JSON parse error.
+func TestNominatimForwardSnippetOnNonJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.Write([]byte("<html><body>Error: database is not ready yet</body></html>"))
+	}))
+	defer srv.Close()
+
+	n := NewNominatim(srv.URL, 2*time.Second, true)
+	if _, err := n.Forward("London"); err == nil {
+		t.Fatal("expected error for non-JSON response")
+	} else if !strings.Contains(err.Error(), "database is not ready") {
+		t.Errorf("error should include a snippet of the response body, got %q", err.Error())
+	}
+}
+
+// TestNominatimForwardHTTPError — a 5xx from the server surfaces the status in
+// the error rather than being masked as an empty result.
+func TestNominatimForwardHTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	n := NewNominatim(srv.URL, 2*time.Second, true)
+	if _, err := n.Forward("London"); err == nil {
+		t.Fatal("expected error for HTTP 500")
+	} else if !strings.Contains(err.Error(), "500") {
+		t.Errorf("error should mention the HTTP status, got %q", err.Error())
+	}
+}
+
 func TestNominatimReverseSendsLanguage(t *testing.T) {
 	const body = `{"lat":"0","lon":"0","display_name":"Ort","address":{"country_code":"de"}}`
 	var got string

--- a/processor/internal/geocoding/photon.go
+++ b/processor/internal/geocoding/photon.go
@@ -99,7 +99,7 @@ func (p *Photon) Reverse(lat, lon float64, language string) (*Address, error) {
 
 	var result photonResponse
 	if err := json.Unmarshal(body, &result); err != nil {
-		return nil, fmt.Errorf("photon: unmarshal: %w", err)
+		return nil, fmt.Errorf("photon: unmarshal reverse response (%s): %w", bodySnippet(body), err)
 	}
 	if len(result.Features) == 0 {
 		return nil, fmt.Errorf("photon: no results")
@@ -275,7 +275,7 @@ func (p *Photon) Forward(query string) ([]ForwardResult, error) {
 
 	var result photonResponse
 	if err := json.Unmarshal(body, &result); err != nil {
-		return nil, fmt.Errorf("photon: unmarshal: %w", err)
+		return nil, fmt.Errorf("photon: unmarshal search response (%s): %w", bodySnippet(body), err)
 	}
 
 	out := make([]ForwardResult, 0, len(result.Features))


### PR DESCRIPTION
## Problem

A user self-hosting Nominatim (mediagis/nominatim:5.1) reported `!location <place>` always returns "Could not understand the location," with nothing in the logs to explain why.

Root cause: forward-geocode failures are silently swallowed. `location.go` discards the error, and `Geocoder.Forward` did no logging — so whether it was a connection error, an HTTP status, an unfinished import, or a legitimately empty result set, they all collapsed into the same generic user message with no operator-facing signal. (Reverse geocoding logs its failures; forward never did.) Forward geocoding also had zero test coverage.

## Fix

- **`Geocoder.Forward` logs at WARN** on both failure modes — provider error and empty result set. Provider-agnostic, covers all three call sites (`!location`, `!location add`, `/api/geocode/forward`). Forward geocoding is user-initiated and low-frequency, so a warn per failure won't spam logs. The empty-vs-error distinction is the key diagnostic: *reached the server but got nothing* vs *couldn't reach it*.
- **Nominatim/Photon include a response-body snippet** in their unmarshal errors, so a non-JSON reply (e.g. an HTML error page from an instance whose import hasn't finished) shows up as `unmarshal search response (<html>…database is not ready…): invalid character '<'` instead of a bare `invalid character '<'`. New `bodySnippet` helper, rune-safe truncation at 200 chars.

## Tests

Adds forward-geocode coverage (previously none): happy-path parse, non-JSON snippet, HTTP 5xx, and the three logging behaviours (error logged, empty logged, success stays quiet).

Full pre-commit gate passes: `go build`, `go vet`, `go test -count=1 ./...`, `golangci-lint run ./...` (0 issues). Rebased onto current `develop` (adapted the forward test helper to the new `breaker`-based `Geocoder`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)