### PR TITLE
fix(logging): normalize level names, stop editor shadow-key accumulation

### DIFF
--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -659,11 +659,12 @@ suggest_on_dm = false                    # when true, DMs that don't match a com
 
 
 # ---- Logging ----
-# Log levels: silly, debug, verbose, info, warn
-# Suggestion: start at verbose; info is a bit less logging; debug has more detail
+# Log levels (most to least verbose): trace, debug, info, warn
+# Suggestion: start at info; debug adds hot-path detail; trace is everything.
+# Legacy names are still accepted: "verbose" maps to info, "silly" to trace.
 
 [logging]
-level = "verbose"                        # log level: debug, verbose, info, warn
+level = "info"                           # log level: trace, debug, info, warn
 file_logging_enabled = true              # write logs to file
 filename = "logs/processor.log"          # log file path
 max_size = 50                            # max log file size in megabytes

--- a/processor/internal/api/config_schema.go
+++ b/processor/internal/api/config_schema.go
@@ -544,10 +544,10 @@ var configSchema = []ConfigSection{
 		Name:  "logging",
 		Title: "Logging",
 		Fields: []ConfigFieldDef{
-			{Name: "level", Type: "select", Default: "verbose", Description: "Log verbosity level", Options: []ConfigSelectOption{
-				{Value: "debug", Label: "Debug", Description: "Most verbose — includes internal debug details"},
-				{Value: "verbose", Label: "Verbose", Description: "Recommended starting point — detailed operational logging"},
-				{Value: "info", Label: "Info", Description: "Standard operational messages only"},
+			{Name: "level", Type: "select", Default: "info", Description: "Log verbosity level. (Legacy 'verbose' maps to info, 'silly' to trace.)", Options: []ConfigSelectOption{
+				{Value: "trace", Label: "Trace", Description: "Most verbose — every internal step, very noisy"},
+				{Value: "debug", Label: "Debug", Description: "Detailed debug output, including hot-path details"},
+				{Value: "info", Label: "Info", Description: "Recommended — standard operational messages"},
 				{Value: "warn", Label: "Warn", Description: "Warnings and errors only"},
 			}},
 			{Name: "file_logging_enabled", Type: "bool", Default: true, Description: "Write log output to a file in addition to console"},

--- a/processor/internal/api/config_writer.go
+++ b/processor/internal/api/config_writer.go
@@ -49,6 +49,8 @@ func writeConfigTOML(configDir string, updates map[string]any) (backupRel string
 		return "", fmt.Errorf("parse config.toml: %w", err)
 	}
 
+	migrateLegacyLoggingKeys(rawMap)
+
 	applySchemaUpdates(rawMap, updates)
 
 	// JSON unmarshal gives float64 for every number — including
@@ -86,6 +88,45 @@ func writeConfigTOML(configDir string, updates map[string]any) (backupRel string
 	}
 
 	return backupRel, nil
+}
+
+// migrateLegacyLoggingKeys collapses the legacy Winston-era logging keys
+// (`log_level`, `console_log_level`) into the canonical `level` before the
+// file is rewritten. Those keys aren't in the schema, so without this they'd
+// be preserved verbatim on every save — accumulating contradictory shadow
+// entries (e.g. level="debug" alongside log_level="info"), which is exactly
+// how the web editor left operator files.
+//
+// Precedence mirrors the load-time fallback (config.go): an explicit `level`
+// wins; otherwise the value migrates from `log_level`, then
+// `console_log_level`, so a save that doesn't touch the logging section can't
+// silently drop the setting. Runs before applySchemaUpdates so the editor's
+// own `level` value (and its default-elision) still has the final say.
+func migrateLegacyLoggingKeys(rawMap map[string]any) {
+	logging, ok := rawMap["logging"].(map[string]any)
+	if !ok {
+		return
+	}
+	_, hasLog := logging["log_level"]
+	_, hasConsole := logging["console_log_level"]
+	if !hasLog && !hasConsole {
+		return
+	}
+
+	level, _ := logging["level"].(string)
+	if level == "" {
+		if lv, _ := logging["log_level"].(string); lv != "" {
+			level = lv
+		} else if lv, _ := logging["console_log_level"].(string); lv != "" {
+			level = lv
+		}
+	}
+
+	delete(logging, "log_level")
+	delete(logging, "console_log_level")
+	if level != "" {
+		logging["level"] = level
+	}
 }
 
 // applySchemaUpdates walks the updates and applies them to rawMap.

--- a/processor/internal/api/config_writer_test.go
+++ b/processor/internal/api/config_writer_test.go
@@ -173,6 +173,108 @@ func TestWriteConfigTOML_IntCoercedRoundTrip(t *testing.T) {
 	}
 }
 
+// TestMigrateLegacyLoggingKeys_ExplicitLevelWins — when an explicit `level`
+// is set, it survives and both legacy keys are dropped (they were inert).
+func TestMigrateLegacyLoggingKeys_ExplicitLevelWins(t *testing.T) {
+	raw := map[string]any{"logging": map[string]any{
+		"level": "debug", "log_level": "info", "console_log_level": "info",
+	}}
+	migrateLegacyLoggingKeys(raw)
+	logging := raw["logging"].(map[string]any)
+	if logging["level"] != "debug" {
+		t.Errorf("level = %v, want debug", logging["level"])
+	}
+	if _, ok := logging["log_level"]; ok {
+		t.Error("log_level should be removed")
+	}
+	if _, ok := logging["console_log_level"]; ok {
+		t.Error("console_log_level should be removed")
+	}
+}
+
+// TestMigrateLegacyLoggingKeys_FallbackWhenLevelEmpty — when `level` is absent,
+// the value migrates from log_level (matching the load-time precedence) so the
+// setting is not lost.
+func TestMigrateLegacyLoggingKeys_FallbackWhenLevelEmpty(t *testing.T) {
+	raw := map[string]any{"logging": map[string]any{"log_level": "warn"}}
+	migrateLegacyLoggingKeys(raw)
+	logging := raw["logging"].(map[string]any)
+	if logging["level"] != "warn" {
+		t.Errorf("level = %v, want warn (migrated from log_level)", logging["level"])
+	}
+	if _, ok := logging["log_level"]; ok {
+		t.Error("log_level should be removed")
+	}
+}
+
+// TestMigrateLegacyLoggingKeys_ConsoleFallback — console_log_level is the last
+// resort when neither level nor log_level is set.
+func TestMigrateLegacyLoggingKeys_ConsoleFallback(t *testing.T) {
+	raw := map[string]any{"logging": map[string]any{"console_log_level": "warn"}}
+	migrateLegacyLoggingKeys(raw)
+	logging := raw["logging"].(map[string]any)
+	if logging["level"] != "warn" {
+		t.Errorf("level = %v, want warn (migrated from console_log_level)", logging["level"])
+	}
+}
+
+// TestMigrateLegacyLoggingKeys_NoLegacyNoOp — a section with no legacy keys is
+// left untouched.
+func TestMigrateLegacyLoggingKeys_NoLegacyNoOp(t *testing.T) {
+	raw := map[string]any{"logging": map[string]any{"level": "debug"}}
+	migrateLegacyLoggingKeys(raw)
+	if raw["logging"].(map[string]any)["level"] != "debug" {
+		t.Errorf("level should be unchanged")
+	}
+}
+
+// TestWriteConfigTOML_StripsLegacyLoggingKeys — the exact three-key file the
+// web editor produced: after any save the legacy shadow keys are gone and the
+// effective level (`level`) is the single source of truth.
+func TestWriteConfigTOML_StripsLegacyLoggingKeys(t *testing.T) {
+	dir := t.TempDir()
+	seed := "[logging]\nconsole_log_level = \"info\"\nlevel = \"debug\"\nlog_level = \"info\"\n"
+	if err := os.WriteFile(filepath.Join(dir, "config.toml"), []byte(seed), 0644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	updates := map[string]any{"logging": map[string]any{"level": "debug"}}
+	if _, err := writeConfigTOML(dir, updates); err != nil {
+		t.Fatalf("writeConfigTOML: %v", err)
+	}
+	logging, _ := readTOML(t, filepath.Join(dir, "config.toml"))["logging"].(map[string]any)
+	if logging["level"] != "debug" {
+		t.Errorf("level = %v, want debug", logging["level"])
+	}
+	if _, ok := logging["log_level"]; ok {
+		t.Error("log_level should be stripped from disk")
+	}
+	if _, ok := logging["console_log_level"]; ok {
+		t.Error("console_log_level should be stripped from disk")
+	}
+}
+
+// TestWriteConfigTOML_MigratesLegacyOnUnrelatedSave — saving an unrelated
+// section must still clean up legacy logging keys without dropping the level
+// they carried (partial-save safety).
+func TestWriteConfigTOML_MigratesLegacyOnUnrelatedSave(t *testing.T) {
+	dir := t.TempDir()
+	seed := "[logging]\nlog_level = \"warn\"\n\n[general]\nlocale = \"en\"\n"
+	if err := os.WriteFile(filepath.Join(dir, "config.toml"), []byte(seed), 0644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	updates := map[string]any{"general": map[string]any{"locale": "de"}}
+	if _, err := writeConfigTOML(dir, updates); err != nil {
+		t.Fatalf("writeConfigTOML: %v", err)
+	}
+	logging, _ := readTOML(t, filepath.Join(dir, "config.toml"))["logging"].(map[string]any)
+	if logging == nil || logging["level"] != "warn" {
+		t.Errorf("level = %v, want warn (migrated, not lost)", logging)
+	}
+	if _, ok := logging["log_level"]; ok {
+		t.Error("log_level should be stripped even on an unrelated save")
+	}
+}
+
 func readTOML(t *testing.T, path string) map[string]any {
 	t.Helper()
 	data, err := os.ReadFile(path)

--- a/processor/internal/logging/logging.go
+++ b/processor/internal/logging/logging.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	stdlog "log"
 	"os"
+	"strings"
 
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/natefinch/lumberjack.v2"
@@ -23,12 +24,27 @@ type Config struct {
 	Compress           bool   `toml:"compress"`
 }
 
+// resolveLevel maps a configured level string to a logrus level. It accepts
+// this project's legacy Winston-style names (inherited from PoracleJS) as
+// aliases: logrus has no level between Debug and Info, so "verbose" collapses
+// to Info and "silly" to Trace. Any name logrus already understands passes
+// through. Empty or unrecognised input falls back to Info.
+func resolveLevel(s string) log.Level {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "verbose":
+		return log.InfoLevel
+	case "silly":
+		return log.TraceLevel
+	}
+	if lvl, err := log.ParseLevel(s); err == nil {
+		return lvl
+	}
+	return log.InfoLevel
+}
+
 // Setup initialises the logger matching Golbat's logging pattern.
 func Setup(cfg Config) {
-	logLevel, err := log.ParseLevel(cfg.Level)
-	if err != nil {
-		logLevel = log.InfoLevel
-	}
+	logLevel := resolveLevel(cfg.Level)
 
 	lumberjackLogger = &lumberjack.Logger{
 		Filename:   cfg.Filename,

--- a/processor/internal/logging/logging_test.go
+++ b/processor/internal/logging/logging_test.go
@@ -1,0 +1,35 @@
+package logging
+
+import (
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// TestResolveLevel covers logrus-native levels, the project's legacy
+// Winston-style aliases (verbose/silly, inherited from PoracleJS), and the
+// info fallback for empty/unknown input. logrus has no level between Debug
+// and Info, so "verbose" collapses to Info; "silly" maps to Trace.
+func TestResolveLevel(t *testing.T) {
+	cases := []struct {
+		in   string
+		want log.Level
+	}{
+		{"trace", log.TraceLevel},
+		{"debug", log.DebugLevel},
+		{"info", log.InfoLevel},
+		{"warn", log.WarnLevel},
+		{"error", log.ErrorLevel},
+		{"verbose", log.InfoLevel},  // legacy Winston alias
+		{"silly", log.TraceLevel},   // legacy Winston alias
+		{"VERBOSE", log.InfoLevel},  // case-insensitive
+		{"  silly ", log.TraceLevel}, // trimmed
+		{"", log.InfoLevel},         // empty → default
+		{"nonsense", log.InfoLevel}, // unknown → default
+	}
+	for _, c := range cases {
+		if got := resolveLevel(c.in); got != c.want {
+			t.Errorf("resolveLevel(%q) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## Background

An operator's `config.toml`, produced by the web editor, looked like this:

```toml
[logging]
console_log_level = "info"
level = "debug"
log_level = "info"
```

Two separate problems surfaced from this.

## Problem 1 — `"verbose"` silently means info

The editor's default/recommended level was the string `"verbose"` — a Winston level name inherited from PoracleJS. logrus doesn't know it, so `ParseLevel("verbose")` errored and fell back to `InfoLevel`. Anyone taking the recommended default got info-level logging with no indication why. (`debug` has 118 call sites, many on hot paths, so this genuinely matters for diagnosis.)

**Fix:** `logging.resolveLevel` now maps the legacy names explicitly — `verbose→info`, `silly→trace` (logrus has no level between Debug and Info) — and passes logrus-native names through, falling back to info only for genuinely unknown input. The editor schema is modernized to logrus-native levels (`trace/debug/info/warn`) with **`info` as the default** and honest descriptions; `config.example.toml` updated to match, with the legacy aliases documented. Existing `level = "verbose"` configs keep working (resolve to info) — no install changes what it logs.

## Problem 2 — the editor accumulates contradictory shadow keys

`log_level` and `console_log_level` aren't in the editor schema, so the config writer preserved them verbatim on every save. The file ends up with two `info` keys shadowing the real `level = "debug"` — which *looks* like it should log at info but actually behaves as debug (explicit `level` wins the load-time fallback).

**Fix:** `migrateLegacyLoggingKeys` collapses the legacy keys into the canonical `level` (same precedence as load-time: explicit `level` wins, else `log_level`, else `console_log_level`) and deletes them — run *before* the schema-update/elision step so the editor's own value still has the final say. It migrates the value first, so a partial save that doesn't touch the logging section can't drop the setting.

The load-time fallback chain in `config.go` is kept as defense-in-depth for hand-edited / not-yet-re-saved files.

## Tests

- `logging_test.go`: `resolveLevel` across native levels, the legacy aliases, case/trim handling, and empty/unknown → info.
- `config_writer_test.go`: the migration function's precedence cases plus two end-to-end `writeConfigTOML` tests — the exact three-key file above, and a partial-save-safety case proving an unrelated save still cleans up legacy keys without losing the level.

All red before, green after. Full gate passes: `go build`, `go vet`, `go test -count=1 ./...`, `golangci-lint run ./...` (0 issues).

Note: log level still isn't hot-reloaded — a level change needs a processor restart to take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)