### PR TITLE
fix(lure/invasion): only alert on genuine, active lures and incidents

### DIFF
--- a/processor/cmd/processor/invasion.go
+++ b/processor/cmd/processor/invasion.go
@@ -12,6 +12,13 @@ import (
 	"github.com/pokemon/poracleng/processor/internal/webhook"
 )
 
+// incidentExpired reports whether a resolved incident expiration is known and
+// already in the past. A zero/unknown expiration is treated as not-expired so
+// incidents whose expiry Golbat didn't send still process.
+func incidentExpired(expiration, now int64) bool {
+	return expiration > 0 && expiration <= now
+}
+
 func (ps *ProcessorService) ProcessInvasion(raw json.RawMessage) error {
 	if ps.cfg.General.DisableInvasion {
 		return nil
@@ -45,6 +52,16 @@ func (ps *ProcessorService) ProcessInvasion(raw json.RawMessage) error {
 		expiration := inv.IncidentExpiration
 		if expiration == 0 {
 			expiration = inv.IncidentExpireTimestamp
+		}
+
+		// Drop already-expired incidents. Golbat re-emits a stop's unified
+		// webhook when its lure changes, which can carry a stale incident
+		// (e.g. a showcase whose window already ended); alerting on those
+		// would be spurious. A zero/unknown expiration is left to process —
+		// we can't prove it's stale.
+		if incidentExpired(expiration, time.Now().Unix()) {
+			l.Debugf("Skipping expired incident: expiration=%d", expiration)
+			return
 		}
 
 		// Duplicate check

--- a/processor/cmd/processor/invasion_test.go
+++ b/processor/cmd/processor/invasion_test.go
@@ -6,6 +6,46 @@ import (
 	"testing"
 )
 
+// TestIncidentExpired covers the incident-expiration gate. Golbat re-emits a
+// stop's unified webhook when its lure changes, which can carry a stale
+// incident (e.g. a showcase whose window already ended). A known past
+// expiration is dropped; a zero/unknown expiration is treated as not-expired
+// (we can't prove it's stale).
+func TestIncidentExpired(t *testing.T) {
+	const now = int64(1_000_000)
+	cases := []struct {
+		name       string
+		expiration int64
+		want       bool
+	}{
+		{"active incident", now + 600, false},
+		{"expiring exactly now", now, true},
+		{"expired incident", now - 1, true},
+		{"stale showcase", now - 3600, true},
+		{"unknown expiration", 0, false},
+		{"negative/unset", -1, false},
+	}
+	for _, c := range cases {
+		if got := incidentExpired(c.expiration, now); got != c.want {
+			t.Errorf("%s: incidentExpired(%d, %d) = %v, want %v",
+				c.name, c.expiration, now, got, c.want)
+		}
+	}
+}
+
+// TestProcessInvasion_GatesOnExpiration verifies the gate is wired into the
+// handler. Source-grep for the same reason as the other invasion tests.
+func TestProcessInvasion_GatesOnExpiration(t *testing.T) {
+	src, err := os.ReadFile("invasion.go")
+	if err != nil {
+		t.Fatalf("read invasion.go: %v", err)
+	}
+	normalized := strings.Join(strings.Fields(string(src)), " ")
+	if !strings.Contains(normalized, "incidentExpired(expiration") {
+		t.Fatal("invasion.go must call incidentExpired(expiration, ...) and return early — otherwise a stale re-emitted incident (e.g. a showcase whose window ended) still alerts")
+	}
+}
+
 // TestInvasion_TemplateType_Incident checks that the invasion handler emits
 // TemplateType="incident" for event-only pokestop webhooks (gruntTypeID == 0 &&
 // displayType >= 7), and TemplateType="invasion" for real grunt invasions.

--- a/processor/cmd/processor/lure.go
+++ b/processor/cmd/processor/lure.go
@@ -13,6 +13,15 @@ import (
 	"github.com/pokemon/poracleng/processor/internal/webhook"
 )
 
+// hasActiveLure reports whether a pokestop webhook represents a genuine,
+// currently-active lure. Valid lure IDs are 501+ (util.json lures 501–506);
+// lure_id 0 means "no lure". An active lure expires in the future. Golbat's
+// unified pokestop webhook can carry a stale lure_id + past lure_expiration on
+// incident/showcase stops, so both conditions must hold to alert.
+func hasActiveLure(lureID int, lureExpiration, now int64) bool {
+	return lureID > 500 && lureExpiration > now
+}
+
 func (ps *ProcessorService) ProcessLure(raw json.RawMessage) error {
 	if ps.cfg.General.DisableLure {
 		return nil
@@ -41,6 +50,15 @@ func (ps *ProcessorService) ProcessLure(raw json.RawMessage) error {
 		}
 
 		l := log.WithField("ref", lure.PokestopID)
+
+		// Only alert on a genuine, currently-active lure. Golbat's pokestop
+		// webhook is a unified object: incident/showcase stops can carry a
+		// leftover lure_id and an already-passed lure_expiration. Without this
+		// gate, `!lure everything` (lure_id 0 = match any) fires on them.
+		if !hasActiveLure(lure.LureID, lure.LureExpiration, time.Now().Unix()) {
+			l.Debugf("Skipping non-lure/expired pokestop: lure_id=%d expiration=%d", lure.LureID, lure.LureExpiration)
+			return
+		}
 
 		// Duplicate check
 		if lure.LureExpiration > 0 && ps.duplicates.CheckLure(lure.PokestopID, lure.LureExpiration) {

--- a/processor/cmd/processor/lure_test.go
+++ b/processor/cmd/processor/lure_test.go
@@ -6,6 +6,63 @@ import (
 	"testing"
 )
 
+// TestHasActiveLure covers the genuine-active-lure gate. Golbat's unified
+// pokestop webhook can carry a leftover lure_id and a past lure_expiration on
+// incident/showcase stops; without this gate `!lure everything` (lure_id 0 =
+// any) fires on them. Valid lure IDs are 501+; an active lure expires in the
+// future.
+func TestHasActiveLure(t *testing.T) {
+	const now = int64(1_000_000)
+	cases := []struct {
+		name       string
+		lureID     int
+		expiration int64
+		want       bool
+	}{
+		{"active normal lure", 501, now + 600, true},
+		{"active golden lure", 506, now + 1, true},
+		{"no lure id", 0, now + 600, false},
+		{"boundary id 500 invalid", 500, now + 600, false},
+		{"valid id but expired", 501, now - 1, false},
+		{"valid id expiring exactly now", 501, now, false},
+		{"stale showcase leftover", 502, now - 3600, false},
+	}
+	for _, c := range cases {
+		if got := hasActiveLure(c.lureID, c.expiration, now); got != c.want {
+			t.Errorf("%s: hasActiveLure(%d, %d, %d) = %v, want %v",
+				c.name, c.lureID, c.expiration, now, got, c.want)
+		}
+	}
+}
+
+// TestHasActiveLure_RealShowcaseStopWithStaleLure locks the exact production
+// webhook that surfaced the bug: a pokestop actively showcasing (future
+// showcase_expiry, populated showcase_rankings) that still carries a
+// lure_expiration from ~2 days earlier with a valid lure_id 501. Pre-gate,
+// `!lure everything` fired on it. The id > 500 half doesn't catch it (501 is
+// valid) — the expiry half must.
+func TestHasActiveLure_RealShowcaseStopWithStaleLure(t *testing.T) {
+	const now = int64(1784062072)     // webhook `updated`
+	const lureExpiration = 1783895246 // ~1.93 days before `now`
+	if hasActiveLure(501, lureExpiration, now) {
+		t.Fatalf("stale lure (expired %d s ago) on an active-showcase stop must not count as active", now-lureExpiration)
+	}
+}
+
+// TestProcessLure_GatesOnActiveLure verifies the gate is actually wired into
+// the handler (predicate-defined-but-not-called would otherwise pass). Source-
+// grep for the same reason as TestProcessLure_SetsEditKey.
+func TestProcessLure_GatesOnActiveLure(t *testing.T) {
+	src, err := os.ReadFile("lure.go")
+	if err != nil {
+		t.Fatalf("read lure.go: %v", err)
+	}
+	normalized := strings.Join(strings.Fields(string(src)), " ")
+	if !strings.Contains(normalized, "hasActiveLure(lure.LureID, lure.LureExpiration") {
+		t.Fatal("lure.go must call hasActiveLure(lure.LureID, lure.LureExpiration, ...) and return early — otherwise expired/no-lure pokestops (e.g. showcases) still alert `!lure everything` users")
+	}
+}
+
 // TestProcessLure_SetsEditKey: lure RenderJobs must carry
 // EditKey = "lure:<pokestop>:<lure_id>" so users with the edit
 // flag get revised-expiration updates edited in place. Source-grep


### PR DESCRIPTION
## Problem

`!lure everything` fired alerts for pokestops that were actually **showcasing**, not lured.

Root cause, confirmed against the Golbat source (`decoder/pokestop_state.go` + `webhooks.md`): the `pokestop` webhook is a **snapshot that multiplexes three event classes** — lure, community power-up, and showcase. Golbat's own doc:

> The full snapshot of all three event classes (lure, power-up, showcase) is included in every firing regardless of which class triggered the fire.
> A lure *expiring* does not fire this webhook ... it will be reflected in the next webhook fired for any other reason (since all fields are a snapshot at send time).

So when a **showcase** event fires the pokestop webhook, the snapshot still carries the **stale lure fields** of a lure that ended days ago. `routePokestop` gates only on `lure_expiration > 0`, and `!lure everything` (lure_id 0 = "match any") has no lure-id or expiry check — so those stale-lure snapshots produced spurious lure alerts on showcase stops.

Real production webhook that surfaced it: `lure_id: 501`, `lure_expiration: 1783895246` (~1.93 days before the webhook's own `updated`), with an active showcase (`showcase_expiry` in the future, populated `showcase_rankings`).

## Fix

- **`hasActiveLure(lureID, lureExpiration, now)`** — `ProcessLure` now requires a real lure id (`> 500`; 501–506 are the only valid `ITEM_TROY_DISK_*` values) **and** an expiration in the future. The id check alone wouldn't catch the production case (501 is valid) — the expiry check is what does the work.
- **`incidentExpired(expiration, now)`** — `ProcessInvasion` drops incidents whose resolved expiration is known and already past; a zero/unknown expiration still processes. Incidents ride the separate `invasion` webhook (`incident_expire_timestamp`/`expiration`), which this reads. This is defense-in-depth against a late `confirmed`/slot-1 fire arriving after expiry — the `invasion` webhook (unlike the pokestop snapshot) only fires on incident changes, so it's a smaller risk, included for correctness.

## Tests

Both handlers need a fully-wired `ProcessorService`, so behaviour is covered by pure-predicate table tests (`TestHasActiveLure`, `TestIncidentExpired`) plus source-grep wiring tests — matching the existing convention in these files. `TestHasActiveLure_RealShowcaseStopWithStaleLure` locks the exact production webhook above.

Full gate green: `go build`, `go vet`, `go test -count=1 ./...`, `golangci-lint run ./...` (0 issues).

## Not included (follow-ups)

- Proper showcase *tracking* (a real feature keyed on `showcase_rankings`/`showcase_expiry`) — under analysis.
- `routePokestop`'s invasion fallback is likely dead code now that pokestop webhooks never carry invasion data — worth revisiting separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)