### PR TITLE
feat(quest): add pokecoins reward tracking (type 8)

### DIFF
--- a/API.md
+++ b/API.md
@@ -333,8 +333,8 @@ Use `level: 90` for all levels.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `reward_type` | int | required | Reward type (2=item, 3=stardust, 4=candy, 7=pokemon, 12=mega energy) |
-| `reward` | int | 0 | Reward ID (pokemon ID, item ID, or stardust amount) |
+| `reward_type` | int | required | Reward type (2=item, 3=stardust, 4=candy, 7=pokemon, 8=pokecoins, 12=mega energy) |
+| `reward` | int | 0 | Reward ID (pokemon ID, item ID, or stardust/pokecoin amount) |
 | `form` | int | 0 | Form ID (for pokemon rewards) |
 | `shiny` | bool | false | Shiny only |
 | `amount` | int | 0 | Minimum reward amount |
@@ -1045,7 +1045,7 @@ Returns test webhook scenarios from `testdata.json`. The editor can use these as
 }
 ```
 
-Available test scenarios: boring, hundo, great-rank1, great-rank9, ultra1, unencountered, boosted, shiny (pokemon); egg1, level1, egg5, level5, egg6, level3 (raid); invasion, lure, giovanni, kecleon, goldstop, goldlure, showcase, pokemoncontest (pokestop); teamchange (gym); level1, level3 (max_battle); quest-item, quest-stardust, quest-pokemon, quest-energy (quest); edit, new, remove, etc. (fort_update).
+Available test scenarios: boring, hundo, great-rank1, great-rank9, ultra1, unencountered, boosted, shiny (pokemon); egg1, level1, egg5, level5, egg6, level3 (raid); invasion, lure, giovanni, kecleon, goldstop, goldlure, showcase, pokemoncontest (pokestop); teamchange (gym); level1, level3 (max_battle); quest-item, quest-stardust, quest-pokecoins, quest-pokemon, quest-energy (quest); edit, new, remove, etc. (fort_update).
 
 ### GET/POST /api/dts/reload
 

--- a/DTS.md
+++ b/DTS.md
@@ -730,6 +730,7 @@ See `examples/dts/rsvpChanges/rsvp-update.json` for an installable starting poin
 | `conditionList` | array | Per-condition objects: `{type, name, formatted}` where `name` is the bare label ("Throw Type") and `formatted` includes the payload ("Excellent Throw"). Falls back to bare name when the webhook payload doesn't carry the data needed for the formatted variant. |
 | `conditionListEng` | array | English copy of `conditionList` |
 | `dustAmount` | int | Stardust reward amount |
+| `pokecoinAmount` | int | Pokecoin reward amount |
 | `itemAmount` | int | Item reward amount |
 | `energyAmount` | int | Mega energy amount (first reward) |
 | `candyAmount` | int | Candy amount (first reward) |
@@ -761,6 +762,8 @@ These are flat top-level strings, not nested under a `rewardData` object:
 | `itemNamesEng` | string | English item names |
 | `dustText` | string | Translated stardust text (e.g. "500 Stardust") |
 | `dustTextEng` | string | English stardust text |
+| `pokecoinText` | string | Translated pokecoin text (e.g. "10 Pokécoins") |
+| `pokecoinTextEng` | string | English pokecoin text |
 | `energyMonstersNames` | string | Mega energy reward text (translated) |
 | `energyMonstersNamesEng` | string | English energy reward text |
 | `candyMonstersNames` | string | Candy reward text (translated) |
@@ -781,7 +784,7 @@ The view passed to `questSummary` is shaped differently from a regular `quest` t
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `rewardType` | int | Reward type ID (2=item, 3=stardust, 4=candy, 7=pokemon, 12=mega energy) |
+| `rewardType` | int | Reward type ID (2=item, 3=stardust, 4=candy, 7=pokemon, 8=pokecoins, 12=mega energy) |
 | `reward` | int | Reward ID (item ID for type 2, dust amount for type 3, pokemon ID for types 4/7/12) |
 | `rewardForm` | int | Pokemon form ID for `rewardType == 7` (so e.g. two different Spinda forms group separately). `0` for all other reward types. |
 | `rewardName` | string | Translated reward name for the group header. Formatted to match the per-row reward strings from regular `quest` enrichment, **with amounts stripped** for types 2/4/12 because amounts vary across stops within a group. Examples: `"Spinda 01"` (type 7 + form, matches per-row `fullName`), `"Lapras Candy"` (type 4), `"Charizard Mega Energy"` (type 12), `"Razz Berry"` (type 2), `"1500 Stardust"` (type 3 — amount is included because it's part of the group key). |

--- a/fallbacks/testdata.json
+++ b/fallbacks/testdata.json
@@ -1622,6 +1622,31 @@
   },
   {
     "type": "quest",
+    "test": "quest-pokecoins",
+    "location": "current",
+    "webhook": {
+      "pokestop_id": "4273655acfdc4b5380f3d217232367ff.16",
+      "latitude": 33.774889,
+      "longitude": -118.192531,
+      "pokestop_name": "Street Art",
+      "type": 4,
+      "target": 3,
+      "template": "challenge_catch_easy",
+      "title": "quest_catch_pokemon_plural",
+      "conditions": [],
+      "rewards": [
+        {
+          "info": {
+            "amount": 10
+          },
+          "type": 8
+        }
+      ],
+      "updated": 1774471518
+    }
+  },
+  {
+    "type": "quest",
     "test": "quest-pokemon",
     "location": "current",
     "webhook": {

--- a/processor/cmd/processor/quest.go
+++ b/processor/cmd/processor/quest.go
@@ -237,6 +237,8 @@ func (ps *ProcessorService) bufferQuestMatches(
 			reward = rewards[0].ItemID
 		case 3: // stardust → amount
 			reward = rewards[0].Amount
+		case 8: // pokecoins → amount
+			reward = rewards[0].Amount
 		}
 	}
 

--- a/processor/internal/api/dts_fields.go
+++ b/processor/internal/api/dts_fields.go
@@ -241,6 +241,7 @@ var questFields = []FieldDef{
 	{Name: "questString", Type: "string", Description: "Quest description", Category: "quest", Preferred: true},
 	{Name: "rewardString", Type: "string", Description: "Reward description", Category: "quest", Preferred: true},
 	{Name: "dustAmount", Type: "int", Description: "Stardust amount", Category: "quest"},
+	{Name: "pokecoinAmount", Type: "int", Description: "Pokecoin amount", Category: "quest"},
 	{Name: "itemAmount", Type: "int", Description: "Item amount", Category: "quest"},
 	{Name: "itemName", Type: "string", Description: "Item name", Category: "quest"},
 	{Name: "monsterName", Type: "string", Description: "Reward pokemon name", Category: "quest"},
@@ -728,8 +729,8 @@ var monsterChangedExtraFields = []FieldDef{
 // a regular quest template (questString, rewardString, pokestopName,
 // imgUrl, latitude, longitude, etc.) plus the per-row withAR boolean.
 var questSummaryFields = []FieldDef{
-	{Name: "rewardType", Type: "int", Description: "Reward type code (2=item, 3=stardust, 4=candy, 7=pokemon, 12=mega energy)", Category: "quest", Preferred: true},
-	{Name: "reward", Type: "int", Description: "Reward identifier — pokemon ID for type 4/7/12, item ID for type 2, dust amount for type 3", Category: "quest", Preferred: true},
+	{Name: "rewardType", Type: "int", Description: "Reward type code (2=item, 3=stardust, 4=candy, 7=pokemon, 8=pokecoins, 12=mega energy)", Category: "quest", Preferred: true},
+	{Name: "reward", Type: "int", Description: "Reward identifier — pokemon ID for type 4/7/12, item ID for type 2, dust amount for type 3, pokecoin amount for type 8", Category: "quest", Preferred: true},
 	{Name: "rewardForm", Type: "int", Description: "Pokemon form ID for type==7 rewards (so different Spinda forms, costumes, etc. group separately). 0 for all other reward types.", Category: "quest"},
 	{Name: "rewardName", Type: "string", Description: "Translated display name for the shared reward — matches the per-row reward strings from regular quest enrichment, with amounts stripped for types 2/4/12 (amounts vary per stop within a group). Examples: \"Spinda 01\" (type 7 with form), \"Lapras Candy\" (type 4), \"Charizard Mega Energy\" (type 12), \"Razz Berry\" (type 2), \"1500 Stardust\" (type 3 — amount kept because it's part of the group key).", Category: "quest", Preferred: true},
 	{Name: "imgUrl", Type: "string", Description: "Shared reward icon URL — best used as a Discord thumbnail/image. Discord renders webp/png/gif. Telegram's sticker endpoint is stricter — use stickerUrl there.", Category: "maps", Preferred: true},

--- a/processor/internal/api/testdata/openapi.golden.json
+++ b/processor/internal/api/testdata/openapi.golden.json
@@ -6504,7 +6504,7 @@
                   ]
                 },
                 "reward": {
-                  "description": "Reward selector (game-master id; meaning depends on reward_type: item id (2), stardust amount (3), pokemon/candy id (4/7/12)). Omit (or send 0) to match ANY reward of that category — i.e. {reward_type:2} is 'all items', {reward_type:7} is 'all pokemon' (stored as 0 = any). Returned as null when at its wildcard.",
+                  "description": "Reward selector (game-master id; meaning depends on reward_type: item id (2), stardust amount (3), pokecoin amount (8), pokemon/candy id (4/7/12)). Omit (or send 0) to match ANY reward of that category — i.e. {reward_type:2} is 'all items', {reward_type:7} is 'all pokemon', {reward_type:8} is 'any pokecoin amount' (stored as 0 = any). Returned as null when at its wildcard.",
                   "format": "int64",
                   "type": [
                     "integer",
@@ -6512,7 +6512,7 @@
                   ]
                 },
                 "reward_type": {
-                  "description": "Reward category (game-master proto id; no wildcard); one of 2 (item) | 3 (stardust) | 4 (candy) | 7 (pokemon) | 12 (mega_energy) (required).",
+                  "description": "Reward category (game-master proto id; no wildcard); one of 2 (item) | 3 (stardust) | 4 (candy) | 7 (pokemon) | 8 (pokecoins) | 12 (mega_energy) (required).",
                   "format": "int64",
                   "type": "integer"
                 },
@@ -6618,7 +6618,7 @@
                   ]
                 },
                 "reward": {
-                  "description": "Reward selector (game-master id; meaning depends on reward_type: item id (2), stardust amount (3), pokemon/candy id (4/7/12)). Omit (or send 0) to match ANY reward of that category — i.e. {reward_type:2} is 'all items', {reward_type:7} is 'all pokemon' (stored as 0 = any). Returned as null when at its wildcard.",
+                  "description": "Reward selector (game-master id; meaning depends on reward_type: item id (2), stardust amount (3), pokecoin amount (8), pokemon/candy id (4/7/12)). Omit (or send 0) to match ANY reward of that category — i.e. {reward_type:2} is 'all items', {reward_type:7} is 'all pokemon', {reward_type:8} is 'any pokecoin amount' (stored as 0 = any). Returned as null when at its wildcard.",
                   "format": "int64",
                   "type": [
                     "integer",
@@ -6626,7 +6626,7 @@
                   ]
                 },
                 "reward_type": {
-                  "description": "Reward category (game-master proto id; no wildcard); one of 2 (item) | 3 (stardust) | 4 (candy) | 7 (pokemon) | 12 (mega_energy) (required).",
+                  "description": "Reward category (game-master proto id; no wildcard); one of 2 (item) | 3 (stardust) | 4 (candy) | 7 (pokemon) | 8 (pokecoins) | 12 (mega_energy) (required).",
                   "format": "int64",
                   "type": "integer"
                 },
@@ -6732,7 +6732,7 @@
                   ]
                 },
                 "reward": {
-                  "description": "Reward selector (game-master id; meaning depends on reward_type: item id (2), stardust amount (3), pokemon/candy id (4/7/12)). Omit (or send 0) to match ANY reward of that category — i.e. {reward_type:2} is 'all items', {reward_type:7} is 'all pokemon' (stored as 0 = any). Returned as null when at its wildcard.",
+                  "description": "Reward selector (game-master id; meaning depends on reward_type: item id (2), stardust amount (3), pokecoin amount (8), pokemon/candy id (4/7/12)). Omit (or send 0) to match ANY reward of that category — i.e. {reward_type:2} is 'all items', {reward_type:7} is 'all pokemon', {reward_type:8} is 'any pokecoin amount' (stored as 0 = any). Returned as null when at its wildcard.",
                   "format": "int64",
                   "type": [
                     "integer",
@@ -6740,7 +6740,7 @@
                   ]
                 },
                 "reward_type": {
-                  "description": "Reward category (game-master proto id; no wildcard); one of 2 (item) | 3 (stardust) | 4 (candy) | 7 (pokemon) | 12 (mega_energy) (required).",
+                  "description": "Reward category (game-master proto id; no wildcard); one of 2 (item) | 3 (stardust) | 4 (candy) | 7 (pokemon) | 8 (pokecoins) | 12 (mega_energy) (required).",
                   "format": "int64",
                   "type": "integer"
                 },
@@ -8600,7 +8600,7 @@
                   ]
                 },
                 "reward": {
-                  "description": "Reward selector (game-master id; meaning depends on reward_type: item id (2), stardust amount (3), pokemon/candy id (4/7/12)). Omit (or send 0) to match ANY reward of that category — i.e. {reward_type:2} is 'all items', {reward_type:7} is 'all pokemon' (stored as 0 = any). Returned as null when at its wildcard.",
+                  "description": "Reward selector (game-master id; meaning depends on reward_type: item id (2), stardust amount (3), pokecoin amount (8), pokemon/candy id (4/7/12)). Omit (or send 0) to match ANY reward of that category — i.e. {reward_type:2} is 'all items', {reward_type:7} is 'all pokemon', {reward_type:8} is 'any pokecoin amount' (stored as 0 = any). Returned as null when at its wildcard.",
                   "format": "int64",
                   "type": [
                     "integer",
@@ -8608,7 +8608,7 @@
                   ]
                 },
                 "reward_type": {
-                  "description": "Reward category (game-master proto id; no wildcard); one of 2 (item) | 3 (stardust) | 4 (candy) | 7 (pokemon) | 12 (mega_energy) (required).",
+                  "description": "Reward category (game-master proto id; no wildcard); one of 2 (item) | 3 (stardust) | 4 (candy) | 7 (pokemon) | 8 (pokecoins) | 12 (mega_energy) (required).",
                   "format": "int64",
                   "type": "integer"
                 },
@@ -10583,7 +10583,7 @@
                   ]
                 },
                 "reward": {
-                  "description": "Reward selector (game-master id; meaning depends on reward_type: item id (2), stardust amount (3), pokemon/candy id (4/7/12)). Omit (or send 0) to match ANY reward of that category — i.e. {reward_type:2} is 'all items', {reward_type:7} is 'all pokemon' (stored as 0 = any). Returned as null when at its wildcard.",
+                  "description": "Reward selector (game-master id; meaning depends on reward_type: item id (2), stardust amount (3), pokecoin amount (8), pokemon/candy id (4/7/12)). Omit (or send 0) to match ANY reward of that category — i.e. {reward_type:2} is 'all items', {reward_type:7} is 'all pokemon', {reward_type:8} is 'any pokecoin amount' (stored as 0 = any). Returned as null when at its wildcard.",
                   "format": "int64",
                   "type": [
                     "integer",
@@ -10591,7 +10591,7 @@
                   ]
                 },
                 "reward_type": {
-                  "description": "Reward category (game-master proto id; no wildcard); one of 2 (item) | 3 (stardust) | 4 (candy) | 7 (pokemon) | 12 (mega_energy) (required).",
+                  "description": "Reward category (game-master proto id; no wildcard); one of 2 (item) | 3 (stardust) | 4 (candy) | 7 (pokemon) | 8 (pokecoins) | 12 (mega_energy) (required).",
                   "format": "int64",
                   "type": "integer"
                 },
@@ -11637,7 +11637,7 @@
             ]
           },
           "reward": {
-            "description": "Reward selector (game-master id; meaning depends on reward_type: item id (2), stardust amount (3), pokemon/candy id (4/7/12)). Omit (or send 0) to match ANY reward of that category — i.e. {reward_type:2} is 'all items', {reward_type:7} is 'all pokemon' (stored as 0 = any). Returned as null when at its wildcard.",
+            "description": "Reward selector (game-master id; meaning depends on reward_type: item id (2), stardust amount (3), pokecoin amount (8), pokemon/candy id (4/7/12)). Omit (or send 0) to match ANY reward of that category — i.e. {reward_type:2} is 'all items', {reward_type:7} is 'all pokemon', {reward_type:8} is 'any pokecoin amount' (stored as 0 = any). Returned as null when at its wildcard.",
             "format": "int64",
             "type": [
               "integer",
@@ -11645,7 +11645,7 @@
             ]
           },
           "reward_type": {
-            "description": "Reward category (game-master proto id; no wildcard); one of 2 (item) | 3 (stardust) | 4 (candy) | 7 (pokemon) | 12 (mega_energy) (required).",
+            "description": "Reward category (game-master proto id; no wildcard); one of 2 (item) | 3 (stardust) | 4 (candy) | 7 (pokemon) | 8 (pokecoins) | 12 (mega_energy) (required).",
             "format": "int64",
             "type": "integer"
           },

--- a/processor/internal/api/trackingQuest.go
+++ b/processor/internal/api/trackingQuest.go
@@ -16,7 +16,7 @@ import (
 
 // validRewardTypes defines the set of valid reward_type values.
 var validRewardTypes = map[int]bool{
-	2: true, 3: true, 4: true, 7: true, 12: true,
+	2: true, 3: true, 4: true, 7: true, 8: true, 12: true,
 }
 
 // HandleGetQuest returns the GET /api/tracking/quest/{id} handler.

--- a/processor/internal/api/v2_quest.go
+++ b/processor/internal/api/v2_quest.go
@@ -22,8 +22,8 @@ import (
 // distinguishing behaviour of quest tracking. quest also carries the clean/edit
 // lifecycle bits, all packed into the clean column.
 type v2QuestRule struct {
-	RewardType int   `json:"reward_type" required:"true" doc:"Reward category (game-master proto id; no wildcard); one of 2 (item) | 3 (stardust) | 4 (candy) | 7 (pokemon) | 12 (mega_energy) (required)."`
-	Reward     *int  `json:"reward,omitempty" nullable:"true" doc:"Reward selector (game-master id; meaning depends on reward_type: item id (2), stardust amount (3), pokemon/candy id (4/7/12)). Omit (or send 0) to match ANY reward of that category — i.e. {reward_type:2} is 'all items', {reward_type:7} is 'all pokemon' (stored as 0 = any). Returned as null when at its wildcard."`
+	RewardType int   `json:"reward_type" required:"true" doc:"Reward category (game-master proto id; no wildcard); one of 2 (item) | 3 (stardust) | 4 (candy) | 7 (pokemon) | 8 (pokecoins) | 12 (mega_energy) (required)."`
+	Reward     *int  `json:"reward,omitempty" nullable:"true" doc:"Reward selector (game-master id; meaning depends on reward_type: item id (2), stardust amount (3), pokecoin amount (8), pokemon/candy id (4/7/12)). Omit (or send 0) to match ANY reward of that category — i.e. {reward_type:2} is 'all items', {reward_type:7} is 'all pokemon', {reward_type:8} is 'any pokecoin amount' (stored as 0 = any). Returned as null when at its wildcard."`
 	Form       *int  `json:"form,omitempty" nullable:"true" doc:"Form id (game-master), meaningful when reward_type=7 (pokemon). Omit to match any form (stored as 0 = any). Returned as null when at its wildcard."`
 	Shiny      *bool `json:"shiny,omitempty" nullable:"true" doc:"Match shiny-possible quest rewards only. Omit to match regardless (default false). Returned as null when false."`
 	Amount     *int  `json:"amount,omitempty" nullable:"true" doc:"Minimum reward amount, meaningful for reward_type 2/4/12. Omit to impose no minimum (stored as 0 = any). Returned as null when at its wildcard."`

--- a/processor/internal/api/v2_quest_test.go
+++ b/processor/internal/api/v2_quest_test.go
@@ -97,6 +97,22 @@ func TestV2Quest_CreateSingleElementArray_OK(t *testing.T) {
 	}
 }
 
+// TestV2Quest_PokecoinsRoundTrip verifies pokecoins (reward_type 8) stores its
+// minimum amount in the Reward column (mirroring stardust) and round-trips.
+func TestV2Quest_PokecoinsRoundTrip(t *testing.T) {
+	r, qs, _, restore := newV2QuestTestAPI(t)
+	defer restore()
+
+	w := v2DoReq(t, r, http.MethodPost, "/api/v2/humans/u1/tracking/quest", `[{"reward_type":8,"reward":10}]`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	rows := qs.AllRows()
+	if len(rows) != 1 || rows[0].RewardType != 8 || rows[0].Reward != 10 {
+		t.Fatalf("expected 1 stored row reward_type=8 reward=10 (min pokecoin amount), got %+v", rows)
+	}
+}
+
 // --- reward_type required + discrete-set validation -------------------------
 
 func TestV2Quest_RejectsMissingRewardType(t *testing.T) {
@@ -129,7 +145,7 @@ func TestV2Quest_RejectsBadRewardType(t *testing.T) {
 }
 
 func TestV2Quest_AcceptsAllValidRewardTypes(t *testing.T) {
-	for _, rt := range []int{2, 3, 4, 7, 12} {
+	for _, rt := range []int{2, 3, 4, 7, 8, 12} {
 		r, qs, _, restore := newV2QuestTestAPI(t)
 		body := `[{"reward_type":` + itoa(int64(rt)) + `}]`
 		w := v2DoReq(t, r, http.MethodPost, "/api/v2/humans/u1/tracking/quest", body)

--- a/processor/internal/bot/argmatch.go
+++ b/processor/internal/bot/argmatch.go
@@ -310,7 +310,7 @@ var knownPrefixKeys = []string{
 	"arg.prefix.d", "arg.prefix.t", "arg.prefix.gen", "arg.prefix.cap", "arg.prefix.mega",
 	"arg.prefix.form", "arg.prefix.costume", "arg.prefix.template", "arg.prefix.move", "arg.prefix.language",
 	"arg.prefix.gym",
-	"arg.prefix.stardust", "arg.prefix.energy", "arg.prefix.candy",
+	"arg.prefix.stardust", "arg.prefix.pokecoin", "arg.prefix.energy", "arg.prefix.candy",
 	"arg.prefix.minspawn",
 	"arg.prefix.great", "arg.prefix.greathigh", "arg.prefix.greatcp",
 	"arg.prefix.ultra", "arg.prefix.ultrahigh", "arg.prefix.ultracp",
@@ -326,7 +326,7 @@ var knownKeywordKeys = []string{
 	"arg.rsvp", "arg.no_rsvp", "arg.rsvp_only",
 	"arg.gmax", "arg.mega",
 	"arg.pokestop", "arg.gym", "arg.station", "arg.location", "arg.new", "arg.removal", "arg.photo", "arg.name", "arg.description", "arg.include_empty",
-	"arg.stardust", "arg.energy", "arg.candy",
+	"arg.stardust", "arg.pokecoin", "arg.energy", "arg.candy",
 	"arg.slot_changes", "arg.battle_changes",
 }
 

--- a/processor/internal/bot/commands/quest.go
+++ b/processor/internal/bot/commands/quest.go
@@ -59,7 +59,7 @@ func (c *QuestCommand) matchItemName(ctx *bot.CommandContext, parsed *bot.Parsed
 	return 0
 }
 
-// QuestCommand implements !quest — track quest rewards (pokemon, stardust, items, candy, energy).
+// QuestCommand implements !quest — track quest rewards (pokemon, stardust, pokecoins, items, candy, energy).
 type QuestCommand struct{}
 
 func (c *QuestCommand) Name() string      { return "cmd.quest" }
@@ -71,6 +71,7 @@ var questParams = []bot.ParamDef{
 	{Type: bot.ParamPrefixString, Key: "arg.prefix.template"},
 	{Type: bot.ParamPrefixString, Key: "arg.prefix.form"},
 	{Type: bot.ParamPrefixString, Key: "arg.prefix.stardust"}, // stardust:1000 (min amount)
+	{Type: bot.ParamPrefixString, Key: "arg.prefix.pokecoin"}, // pokecoins:10 (min amount)
 	{Type: bot.ParamPrefixString, Key: "arg.prefix.energy"},   // energy:charizard (pokemon)
 	{Type: bot.ParamPrefixString, Key: "arg.prefix.candy"},    // candy:pikachu (pokemon)
 	{Type: bot.ParamPrefixString, Key: "arg.prefix.amount"},   // amount:N (min amount for item/candy/mega_energy quests)
@@ -84,6 +85,7 @@ var questParams = []bot.ParamDef{
 	{Type: bot.ParamKeyword, Key: "arg.summary"},
 	{Type: bot.ParamKeyword, Key: "arg.shiny"},
 	{Type: bot.ParamKeyword, Key: "arg.stardust"}, // bare "stardust" keyword (any amount)
+	{Type: bot.ParamKeyword, Key: "arg.pokecoin"}, // bare "pokecoins" keyword (any amount)
 	{Type: bot.ParamKeyword, Key: "arg.energy"},   // bare "energy" keyword (any pokemon)
 	{Type: bot.ParamKeyword, Key: "arg.candy"},    // bare "candy" keyword (any pokemon)
 	{Type: bot.ParamPokemonName},
@@ -185,6 +187,16 @@ func (c *QuestCommand) Run(ctx *bot.CommandContext, args []string) []bot.Reply {
 		// column (the stardust grammar's own min-amount slot). bare
 		// "stardust" alone means "any amount".
 		insert = append(insert, c.makeQuest(ctx, common, override, shiny, pings, 3, amountVal, 0, 0))
+	} else if pokecoinVal, ok := parsed.Strings["pokecoin"]; ok {
+		// pokecoins:N — min amount lives in Reward, mirroring stardust.
+		_ = amountSet
+		amount := questParseInt(pokecoinVal)
+		insert = append(insert, c.makeQuest(ctx, common, override, shiny, pings, 8, amount, 0, 0))
+	} else if parsed.HasKeyword("arg.pokecoin") {
+		// bare "pokecoins" + amount:N — route amount into Reward
+		// (pokecoins' own min-amount slot). bare "pokecoins" alone means
+		// "any amount".
+		insert = append(insert, c.makeQuest(ctx, common, override, shiny, pings, 8, amountVal, 0, 0))
 	} else if energyVal, ok := parsed.Strings["energy"]; ok {
 		// energy:charizard — resolve pokemon name
 		resolved := ctx.Resolver.Resolve(energyVal, ctx.Language)
@@ -232,6 +244,7 @@ func (c *QuestCommand) Run(ctx *bot.CommandContext, args []string) []bot.Reply {
 		//	candy / mega / item — q.Amount > 0 filter (the natural slot)
 		insert = append(insert, c.makeQuest(ctx, common, override, shiny, pings, 7, 0, 0, 0))
 		insert = append(insert, c.makeQuest(ctx, common, override, shiny, pings, 3, amountVal, 0, 0))
+		insert = append(insert, c.makeQuest(ctx, common, override, shiny, pings, 8, amountVal, 0, 0))
 		insert = append(insert, c.makeQuest(ctx, common, override, shiny, pings, 12, 0, 0, amountVal))
 		insert = append(insert, c.makeQuest(ctx, common, override, shiny, pings, 4, 0, 0, amountVal))
 		insert = append(insert, c.makeQuest(ctx, common, override, shiny, pings, 2, 0, 0, amountVal))
@@ -384,7 +397,7 @@ func (c *QuestCommand) handleRemove(ctx *bot.CommandContext, parsed *bot.ParsedA
 	noOverride := Override{}
 	if parsed.HasKeyword("arg.everything") {
 		// remove everything — match all reward types
-		for _, rt := range []int{7, 3, 12, 4, 2} {
+		for _, rt := range []int{7, 3, 8, 12, 4, 2} {
 			targets = append(targets, c.makeQuest(ctx, common, noOverride, shiny, pings, rt, 0, 0, 0))
 		}
 	} else if parsed.HasKeyword("arg.all_pokemon") || parsed.HasKeyword("arg.all_items") {
@@ -400,6 +413,11 @@ func (c *QuestCommand) handleRemove(ctx *bot.CommandContext, parsed *bot.ParsedA
 		targets = append(targets, c.makeQuest(ctx, common, noOverride, shiny, pings, 3, amount, 0, 0))
 	} else if parsed.HasKeyword("arg.stardust") {
 		targets = append(targets, c.makeQuest(ctx, common, noOverride, shiny, pings, 3, 0, 0, 0))
+	} else if pokecoinVal, ok := parsed.Strings["pokecoin"]; ok {
+		amount := questParseInt(pokecoinVal)
+		targets = append(targets, c.makeQuest(ctx, common, noOverride, shiny, pings, 8, amount, 0, 0))
+	} else if parsed.HasKeyword("arg.pokecoin") {
+		targets = append(targets, c.makeQuest(ctx, common, noOverride, shiny, pings, 8, 0, 0, 0))
 	} else if energyVal, ok := parsed.Strings["energy"]; ok {
 		resolved := ctx.Resolver.Resolve(energyVal, ctx.Language)
 		if len(resolved) > 0 {
@@ -450,7 +468,7 @@ func (c *QuestCommand) handleRemove(ctx *bot.CommandContext, parsed *bot.ParsedA
 		targets = append(targets, c.makeQuest(ctx, common, noOverride, shiny, pings, 2, itemID, 0, 0))
 	} else {
 		// No specific type — remove everything
-		for _, rt := range []int{7, 3, 12, 4, 2} {
+		for _, rt := range []int{7, 3, 8, 12, 4, 2} {
 			targets = append(targets, c.makeQuest(ctx, common, noOverride, shiny, pings, rt, 0, 0, 0))
 		}
 	}

--- a/processor/internal/bot/commands/quest_test.go
+++ b/processor/internal/bot/commands/quest_test.go
@@ -107,6 +107,32 @@ func TestQuest_BareStardust(t *testing.T) {
 	assert.Equal(t, 0, rows[0].Reward, "bare stardust = any amount")
 }
 
+func TestQuest_Pokecoins(t *testing.T) {
+	ctx := questCtx(t)
+	replies := runQuest(t, ctx, "pokecoins:10")
+
+	require.NotEmpty(t, replies)
+	assert.Equal(t, "✅", replies[0].React, "reply: %s", replies[0].Text)
+
+	rows, _ := ctx.Tracking.Quests.SelectByIDProfile("user1", 1)
+	require.Len(t, rows, 1)
+	assert.Equal(t, 8, rows[0].RewardType, "pokecoins reward type")
+	assert.Equal(t, 10, rows[0].Reward, "pokecoins min amount stored in Reward")
+}
+
+func TestQuest_BarePokecoins(t *testing.T) {
+	ctx := questCtx(t)
+	replies := runQuest(t, ctx, "pokecoins")
+
+	require.NotEmpty(t, replies)
+	assert.Equal(t, "✅", replies[0].React, "reply: %s", replies[0].Text)
+
+	rows, _ := ctx.Tracking.Quests.SelectByIDProfile("user1", 1)
+	require.Len(t, rows, 1)
+	assert.Equal(t, 8, rows[0].RewardType, "pokecoins reward type")
+	assert.Equal(t, 0, rows[0].Reward, "bare pokecoins = any amount")
+}
+
 func TestQuest_Duplicate(t *testing.T) {
 	ctx := questCtx(t)
 	replies1 := runQuest(t, ctx, "25")
@@ -180,8 +206,8 @@ func TestQuest_Everything(t *testing.T) {
 	assert.Equal(t, "✅", replies[0].React, "reply: %s", replies[0].Text)
 
 	rows, _ := ctx.Tracking.Quests.SelectByIDProfile("user1", 1)
-	// everything creates: pokemon(7), stardust(3), energy(12), candy(4), item(2)
-	assert.Len(t, rows, 5, "everything should create 5 reward types")
+	// everything creates: pokemon(7), stardust(3), pokecoins(8), energy(12), candy(4), item(2)
+	assert.Len(t, rows, 6, "everything should create 6 reward types")
 }
 
 // !quest all_pokemon → single "all pokemon" token after underscore
@@ -440,7 +466,7 @@ func TestQuest_EverythingWithAmountRoutesPerRewardType(t *testing.T) {
 	assert.Equal(t, "✅", replies[0].React, "should accept everything + amount:N, reply: %s", replies[0].Text)
 
 	rows, _ := ctx.Tracking.Quests.SelectByIDProfile("user1", 1)
-	require.Len(t, rows, 5, "everything inserts one row per reward type")
+	require.Len(t, rows, 6, "everything inserts one row per reward type")
 
 	byType := map[int]db.QuestTrackingAPI{}
 	for _, r := range rows {
@@ -450,6 +476,8 @@ func TestQuest_EverythingWithAmountRoutesPerRewardType(t *testing.T) {
 	assert.Equal(t, 0, byType[7].Reward, "pokemon: no reward filter")
 	assert.Equal(t, 25, byType[3].Reward, "stardust: amount routes into Reward")
 	assert.Equal(t, 0, byType[3].Amount, "stardust: Amount unused")
+	assert.Equal(t, 25, byType[8].Reward, "pokecoins: amount routes into Reward")
+	assert.Equal(t, 0, byType[8].Amount, "pokecoins: Amount unused")
 	assert.Equal(t, 25, byType[12].Amount, "mega energy: amount → Amount")
 	assert.Equal(t, 25, byType[4].Amount, "candy: amount → Amount")
 	assert.Equal(t, 25, byType[2].Amount, "item: amount → Amount")

--- a/processor/internal/bot/commands/script.go
+++ b/processor/internal/bot/commands/script.go
@@ -347,6 +347,12 @@ func (c *ScriptCommand) questToScript(ctx *bot.CommandContext, prefix string, q 
 		} else {
 			parts = append(parts, "stardust")
 		}
+	case 8: // pokecoins — minimum amount stored in Reward field
+		if q.Reward > 0 {
+			parts = append(parts, fmt.Sprintf("pokecoins:%d", q.Reward))
+		} else {
+			parts = append(parts, "pokecoins")
+		}
 	case 4: // candy
 		if q.Reward > 0 {
 			parts = append(parts, "candy:"+c.pokemonName(ctx, q.Reward))

--- a/processor/internal/bot/testdata/parity.yaml
+++ b/processor/internal/bot/testdata/parity.yaml
@@ -288,6 +288,16 @@
   text: "!quest stardust:1000 d500 clean template:dust"
   expected_tokens: ["stardust:1000", d500, clean, "template:dust"]
 
+- name: quest-pokecoins-reward
+  description: /quest with pokecoins reward (min amount stored in Reward, mirrors stardust)
+  command: cmd.quest
+  slash:
+    name: quest
+    options:
+      pokecoins: 10
+  text: "!quest pokecoins:10"
+  expected_tokens: ["pokecoins:10"]
+
 - name: quest-candy-reward
   description: /quest with candy reward
   command: cmd.quest

--- a/processor/internal/discordbot/slash/definitions.go
+++ b/processor/internal/discordbot/slash/definitions.go
@@ -591,6 +591,7 @@ func questOptions(bundle *i18n.Bundle) []*discordgo.ApplicationCommandOption {
 		stringOpt(bundle, "quest.pokemon", "pokemon", "Pokemon reward", false, true),
 		stringOpt(bundle, "quest.item", "item", "Item reward (e.g. golden razz berry)", false, true),
 		intOpt(bundle, "quest.stardust", "stardust", "Stardust reward (minimum amount)", false),
+		intOpt(bundle, "quest.pokecoins", "pokecoins", "Pokecoin reward (minimum amount)", false),
 		stringOpt(bundle, "quest.candy", "candy", "Candy reward pokemon", false, true),
 		stringOpt(bundle, "quest.mega_energy", "mega_energy", "Mega energy reward pokemon", false, true),
 		// xl_candy intentionally omitted — matching/quest.go and

--- a/processor/internal/discordbot/slash/mappers/quest.go
+++ b/processor/internal/discordbot/slash/mappers/quest.go
@@ -14,6 +14,7 @@ import (
 //	pokemon     (string, autocomplete) — pokemon name/ID for pokemon-reward quests
 //	item        (string, autocomplete) — item name (golden razz, etc.)
 //	stardust    (int)                  — minimum stardust amount
+//	pokecoins   (int)                  — minimum pokecoin amount
 //	candy       (string, autocomplete) — candy reward pokemon
 //	mega_energy (string, autocomplete) — mega energy reward pokemon
 //	min_amount  (int)                  — minimum reward amount; valid for
@@ -41,7 +42,7 @@ import (
 func Quest(opts []*discordgo.ApplicationCommandInteractionDataOption) ([]string, error) {
 	o := flattenOptions(opts)
 
-	rewardOpts := []string{"pokemon", "item", "stardust", "candy", "mega_energy"}
+	rewardOpts := []string{"pokemon", "item", "stardust", "pokecoins", "candy", "mega_energy"}
 	var set []string
 	for _, name := range rewardOpts {
 		if hasNonZeroValue(o[name]) {
@@ -82,6 +83,8 @@ func Quest(opts []*discordgo.ApplicationCommandInteractionDataOption) ([]string,
 		tokens = append(tokens, strings.ToLower(o["item"].StringValue()))
 	case "stardust":
 		tokens = append(tokens, fmt.Sprintf("stardust:%d", o["stardust"].IntValue()))
+	case "pokecoins":
+		tokens = append(tokens, fmt.Sprintf("pokecoins:%d", o["pokecoins"].IntValue()))
 	case "candy":
 		tokens = append(tokens, "candy:"+o["candy"].StringValue())
 	case "mega_energy":

--- a/processor/internal/discordbot/slash/testdata/quest.json
+++ b/processor/internal/discordbot/slash/testdata/quest.json
@@ -33,6 +33,16 @@
       "choices": null
     },
     {
+      "type": 4,
+      "name": "pokecoins",
+      "description": "Pokecoin reward (minimum amount)",
+      "channel_types": null,
+      "required": false,
+      "options": null,
+      "autocomplete": false,
+      "choices": null
+    },
+    {
       "type": 3,
       "name": "candy",
       "description": "Candy reward pokemon",

--- a/processor/internal/dts/quest_summary.go
+++ b/processor/internal/dts/quest_summary.go
@@ -131,6 +131,7 @@ func BuildQuestSummaryView(g QuestSummaryGroup, sm *staticmap.Resolver, tr *i18n
 //     it's deliberately omitted from the group header).
 //   - Type 3 (stardust): "<amount> <Stardust>" — amount IS the group key
 //     so it's stable across the group.
+//   - Type 8 (pokecoins): "<amount> <Pokécoins>" — same shape as stardust.
 //
 // The lookups stay simple identifier-key translations because pulling
 // in `enrichment` directly would create an enrichment → dts import
@@ -147,6 +148,12 @@ func questSummaryRewardName(rewardType, rewardID, formID int, tr *i18n.Translato
 		}
 	case 3: // Stardust — rewardID is the dust amount
 		label := tr.T("quest_reward_3")
+		if rewardID > 0 {
+			return fmt.Sprintf("%d %s", rewardID, label)
+		}
+		return label
+	case 8: // Pokecoins — rewardID is the pokecoin amount
+		label := tr.T("quest_reward_8")
 		if rewardID > 0 {
 			return fmt.Sprintf("%d %s", rewardID, label)
 		}

--- a/processor/internal/enrichment/quest.go
+++ b/processor/internal/enrichment/quest.go
@@ -20,6 +20,7 @@ type QuestRewardData struct {
 	Monsters       []QuestMonsterReward
 	Items          []QuestItemReward
 	DustAmount     int
+	PokecoinAmount int
 	EnergyMonsters []QuestEnergyReward
 	Candy          []QuestCandyReward
 }
@@ -91,6 +92,7 @@ func (e *Enricher) Quest(lat, lon float64, pokestopID, pokestopURL string, rewar
 	// Structure reward data for per-language enrichment
 	rewardData := buildQuestRewardData(rewards)
 	m["dustAmount"] = rewardData.DustAmount
+	m["pokecoinAmount"] = rewardData.PokecoinAmount
 	if len(rewardData.Items) > 0 {
 		m["itemAmount"] = rewardData.Items[0].Amount
 	}
@@ -142,6 +144,8 @@ func buildQuestRewardData(rewards []matching.QuestRewardData) QuestRewardData {
 			result.Items = append(result.Items, QuestItemReward{ID: r.ItemID, Amount: r.Amount})
 		case 3: // Stardust
 			result.DustAmount = r.Amount
+		case 8: // Pokecoins
+			result.PokecoinAmount = r.Amount
 		case 4: // Candy
 			result.Candy = append(result.Candy, QuestCandyReward{PokemonID: r.PokemonID, Amount: r.Amount})
 		case 7: // Pokemon encounter
@@ -244,6 +248,17 @@ func (e *Enricher) QuestTranslate(base map[string]any, quest *webhook.QuestWebho
 	m["dustText"] = dustText
 	m["dustTextEng"] = dustTextEng
 
+	// Pokecoins
+	var pokecoinText, pokecoinTextEng string
+	if rewardData.PokecoinAmount > 0 {
+		coinName := tr.T("quest_reward_8")
+		coinNameEng := enTr.T("quest_reward_8")
+		pokecoinText = fmt.Sprintf("%d %s", rewardData.PokecoinAmount, coinName)
+		pokecoinTextEng = fmt.Sprintf("%d %s", rewardData.PokecoinAmount, coinNameEng)
+	}
+	m["pokecoinText"] = pokecoinText
+	m["pokecoinTextEng"] = pokecoinTextEng
+
 	// Mega energy names + energyMonsters array
 	var energyNames, energyNamesEng []string
 	energyList := make([]map[string]any, 0, len(rewardData.EnergyMonsters))
@@ -288,12 +303,12 @@ func (e *Enricher) QuestTranslate(base map[string]any, quest *webhook.QuestWebho
 
 	// Reward string (join all non-empty reward parts)
 	var rewardParts, rewardPartsEng []string
-	for _, s := range []string{strings.Join(monsterNames, ", "), dustText, strings.Join(itemNames, ", "), strings.Join(energyNames, ", "), strings.Join(candyNames, ", ")} {
+	for _, s := range []string{strings.Join(monsterNames, ", "), dustText, pokecoinText, strings.Join(itemNames, ", "), strings.Join(energyNames, ", "), strings.Join(candyNames, ", ")} {
 		if s != "" {
 			rewardParts = append(rewardParts, s)
 		}
 	}
-	for _, s := range []string{strings.Join(monsterNamesEng, ", "), dustTextEng, strings.Join(itemNamesEng, ", "), strings.Join(energyNamesEng, ", "), strings.Join(candyNamesEng, ", ")} {
+	for _, s := range []string{strings.Join(monsterNamesEng, ", "), dustTextEng, pokecoinTextEng, strings.Join(itemNamesEng, ", "), strings.Join(energyNamesEng, ", "), strings.Join(candyNamesEng, ", ")} {
 		if s != "" {
 			rewardPartsEng = append(rewardPartsEng, s)
 		}
@@ -467,7 +482,7 @@ func joinIDList(v any) string {
 }
 
 // addQuestIconURLs resolves icon URLs based on the quest reward type.
-// Reward types: 2=item, 3=stardust, 4=candy, 7=pokemon, 12=mega energy
+// Reward types: 2=item, 3=stardust, 4=candy, 7=pokemon, 8=pokecoins, 12=mega energy
 func (e *Enricher) addQuestIconURLs(m map[string]any, rewards []matching.QuestRewardData) {
 	if len(rewards) == 0 {
 		return
@@ -505,6 +520,16 @@ func (e *Enricher) addQuestIconURLs(m map[string]any, rewards []matching.QuestRe
 		}
 		if e.StickerUicons != nil {
 			m["stickerUrl"] = e.StickerUicons.RewardStardustIcon(r.Amount)
+		}
+	case r.Type == 8: // Pokecoins reward
+		if e.ImgUicons != nil {
+			m["imgUrl"] = e.ImgUicons.RewardPokecoinIcon(r.Amount)
+		}
+		if e.ImgUiconsAlt != nil {
+			m["imgUrlAlt"] = e.ImgUiconsAlt.RewardPokecoinIcon(r.Amount)
+		}
+		if e.StickerUicons != nil {
+			m["stickerUrl"] = e.StickerUicons.RewardPokecoinIcon(r.Amount)
 		}
 	case r.Type == 12 && r.PokemonID > 0: // Mega energy reward
 		if e.ImgUicons != nil {

--- a/processor/internal/enrichment/quest_enrichment_test.go
+++ b/processor/internal/enrichment/quest_enrichment_test.go
@@ -193,6 +193,40 @@ func TestQuestTranslateStardustReward(t *testing.T) {
 	}
 }
 
+// --- Test 5b: Pokecoins reward ---
+
+func TestQuestTranslatePokecoinsReward(t *testing.T) {
+	gd := &gamedata.GameData{
+		Monsters: map[gamedata.MonsterKey]*gamedata.Monster{},
+	}
+
+	e := newQuestEnricher(t, gd, map[string]map[string]string{
+		"en": {
+			"quest_reward_8": "Pokécoins",
+		},
+	})
+
+	quest := &webhook.QuestWebhook{
+		Title:  "some_quest",
+		Target: 1,
+	}
+
+	rewards := []matching.QuestRewardData{{Type: 8, Amount: 10}}
+	base := map[string]any{"pokecoinAmount": 10}
+
+	m := e.QuestTranslate(base, quest, rewards, "en")
+
+	rewardString, _ := m["rewardString"].(string)
+	if !strings.Contains(rewardString, "10 Pokécoins") {
+		t.Errorf("rewardString = %q, want to contain %q", rewardString, "10 Pokécoins")
+	}
+
+	pokecoinText, _ := m["pokecoinText"].(string)
+	if pokecoinText != "10 Pokécoins" {
+		t.Errorf("pokecoinText = %q, want %q", pokecoinText, "10 Pokécoins")
+	}
+}
+
 // --- Test 6: Mega energy reward ---
 
 func TestQuestTranslateMegaEnergyReward(t *testing.T) {

--- a/processor/internal/i18n/locale/en.json
+++ b/processor/internal/i18n/locale/en.json
@@ -386,8 +386,6 @@
 
   "weather_1": "Sunny",
 
-  "quest_reward_8": "Pokécoins",
-
   "status.enabled": "enabled",
   "status.disabled": "disabled",
   "status.alerts_currently": "Your alerts are currently **{0}**",

--- a/processor/internal/i18n/locale/en.json
+++ b/processor/internal/i18n/locale/en.json
@@ -92,6 +92,8 @@
   "tracking.reward_fmt": "Reward: **{0}**",
   "tracking.reward_stardust_min_fmt": "{0} or more stardust",
   "tracking.reward_stardust": "stardust",
+  "tracking.reward_pokecoin_min_fmt": "{0} or more pokecoins",
+  "tracking.reward_pokecoin": "pokecoins",
   "tracking.reward_mega_energy": "mega energy",
   "tracking.reward_mega_energy_fmt": "mega energy {0}",
   "tracking.reward_candy": "candy",
@@ -264,6 +266,7 @@
   "arg.shiny": "shiny",
   "arg.gmax": "gmax",
   "arg.stardust": "stardust",
+  "arg.pokecoin": "pokecoins",
   "arg.energy": "energy",
   "arg.candy": "candy",
   "arg.pvp": "pvp",
@@ -349,6 +352,7 @@
   "arg.prefix.littlehigh": "littlehigh",
   "arg.prefix.littlecp": "littlecp",
   "arg.prefix.stardust": "stardust",
+  "arg.prefix.pokecoin": "pokecoins",
   "arg.prefix.energy": "energy",
   "arg.prefix.candy": "candy",
   "arg.prefix.amount": "amount",
@@ -381,6 +385,8 @@
   "raid.level.shadow_legendary": "shadow legendary",
 
   "weather_1": "Sunny",
+
+  "quest_reward_8": "Pokécoins",
 
   "status.enabled": "enabled",
   "status.disabled": "disabled",
@@ -435,7 +441,7 @@
   "msg.track.everything_no_filters": "This would result in too many alerts. You need to provide additional filters to limit the number of valid candidates.",
   "msg.track.invalid_cap": "This level cap is not supported, valid choices are: {0}",
   "msg.track.no_mega_form": "⚠️ {0} has no Mega {1} form — this PVP rule will never match.",
-  "msg.quest.usage": "Valid commands are e.g. `{0}quest pikachu`, `{0}quest stardust:1000`, `{0}quest energy:charizard`",
+  "msg.quest.usage": "Valid commands are e.g. `{0}quest pikachu`, `{0}quest stardust:1000`, `{0}quest pokecoins:10`, `{0}quest energy:charizard`",
   "msg.quest.edit_summary_conflict": "`edit` and `summary` are mutually exclusive — pick one.",
   "msg.summary.usage": "Valid commands are `{0}summary quest`, `{0}summary quest settime <times>`, `{0}summary quest cleartime`, `{0}summary quest now`",
   "msg.summary.settime_invalid": "Cannot parse schedule entry `{0}`: {1}",

--- a/processor/internal/matching/quest.go
+++ b/processor/internal/matching/quest.go
@@ -11,7 +11,7 @@ import (
 
 // QuestRewardData holds a single parsed quest reward for matching.
 type QuestRewardData struct {
-	Type      int // 2=item, 3=stardust, 4=candy, 7=pokemon, 12=mega energy
+	Type      int // 2=item, 3=stardust, 4=candy, 7=pokemon, 8=pokecoins, 12=mega energy
 	PokemonID int
 	ItemID    int
 	Amount    int
@@ -145,6 +145,12 @@ func singleRewardMatches(q *db.QuestTracking, r *QuestRewardData) bool {
 		return true
 
 	case 3: // stardust
+		if q.Reward > r.Amount {
+			return false
+		}
+		return true
+
+	case 8: // pokecoins — min amount stored in Reward (mirrors stardust)
 		if q.Reward > r.Amount {
 			return false
 		}

--- a/processor/internal/matching/quest_test.go
+++ b/processor/internal/matching/quest_test.go
@@ -242,6 +242,49 @@ func TestSingleRewardMatchesStardust(t *testing.T) {
 	}
 }
 
+func TestSingleRewardMatchesPokecoins(t *testing.T) {
+	tests := []struct {
+		name     string
+		tracking *db.QuestTracking
+		reward   *QuestRewardData
+		expected bool
+	}{
+		{
+			"pokecoins exact match",
+			&db.QuestTracking{RewardType: 8, Reward: 10},
+			&QuestRewardData{Type: 8, Amount: 10},
+			true,
+		},
+		{
+			"pokecoins exceeds minimum",
+			&db.QuestTracking{RewardType: 8, Reward: 5},
+			&QuestRewardData{Type: 8, Amount: 10},
+			true,
+		},
+		{
+			"pokecoins below minimum",
+			&db.QuestTracking{RewardType: 8, Reward: 15},
+			&QuestRewardData{Type: 8, Amount: 10},
+			false,
+		},
+		{
+			"pokecoins reward=0 matches any amount",
+			&db.QuestTracking{RewardType: 8, Reward: 0},
+			&QuestRewardData{Type: 8, Amount: 10},
+			true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := singleRewardMatches(tt.tracking, tt.reward)
+			if got != tt.expected {
+				t.Errorf("singleRewardMatches() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
 func TestSingleRewardMatchesMegaEnergy(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/processor/internal/nlp/filters.go
+++ b/processor/internal/nlp/filters.go
@@ -57,6 +57,8 @@ var synonyms = contextSynonyms{
 		"shiny":       "shiny",
 		"shinies":     "shiny",
 		"stardust":    "stardust",
+		"pokecoins":   "pokecoins",
+		"pokecoin":    "pokecoins",
 		"energy":      "energy",
 		"mega energy": "energy",
 		"candy":       "candy",
@@ -151,7 +153,7 @@ var poracleFilterRe = regexp.MustCompile(
 		`|new` +
 		`|ex` +
 		`|shiny` +
-		`|stardust|energy|candy` +
+		`|stardust|pokecoins|energy|candy` +
 		`)$`,
 )
 

--- a/processor/internal/rowtext/quest.go
+++ b/processor/internal/rowtext/quest.go
@@ -40,6 +40,14 @@ func (g *Generator) QuestRowText(tr *i18n.Translator, quest *db.QuestTracking) s
 			rewardThing = tr.T("tracking.reward_stardust")
 		}
 
+	case 8:
+		// Pokecoins reward
+		if quest.Reward > 0 {
+			rewardThing = tr.Tf("tracking.reward_pokecoin_min_fmt", quest.Reward)
+		} else {
+			rewardThing = tr.T("tracking.reward_pokecoin")
+		}
+
 	case 2:
 		// Item reward (reward==0 is the "all items" wildcard)
 		if quest.Reward == 0 {

--- a/processor/internal/tracker/summary_buffer.go
+++ b/processor/internal/tracker/summary_buffer.go
@@ -21,7 +21,7 @@ import (
 // Form is only meaningful for pokemon-encounter rewards (type 7) where
 // different forms of the same species (Spinda 01 vs 08, Unown, costumes)
 // must NOT collapse into one group — they have distinct icons and
-// distinct rewardName labels. For item/stardust/candy/mega-energy
+// distinct rewardName labels. For item/stardust/pokecoins/candy/mega-energy
 // rewards Form is always 0.
 type BufferedQuest struct {
 	RewardType int    `json:"reward_type"`

--- a/processor/internal/uicons/uicons.go
+++ b/processor/internal/uicons/uicons.go
@@ -32,6 +32,7 @@ type Index struct {
 	Egg            map[string]bool
 	RewardItem     map[string]bool
 	RewardStardust map[string]bool
+	RewardPokecoin map[string]bool
 	RewardCandy    map[string]bool
 	RewardXlCandy  map[string]bool
 	RewardMega     map[string]bool
@@ -123,6 +124,7 @@ func (u *Uicons) fetchIndex() {
 		Reward *struct {
 			Item     []string `json:"item"`
 			Stardust []string `json:"stardust"`
+			Pokecoin []string `json:"pokecoin"`
 			Candy    []string `json:"candy"`
 			XlCandy  []string `json:"xl_candy"`
 			Mega     []string `json:"mega_resource"`
@@ -150,12 +152,14 @@ func (u *Uicons) fetchIndex() {
 	if raw.Reward != nil {
 		idx.RewardItem = toSet(raw.Reward.Item)
 		idx.RewardStardust = toSet(raw.Reward.Stardust)
+		idx.RewardPokecoin = toSet(raw.Reward.Pokecoin)
 		idx.RewardCandy = toSet(raw.Reward.Candy)
 		idx.RewardXlCandy = toSet(raw.Reward.XlCandy)
 		idx.RewardMega = toSet(raw.Reward.Mega)
 	} else {
 		idx.RewardItem = map[string]bool{}
 		idx.RewardStardust = map[string]bool{}
+		idx.RewardPokecoin = map[string]bool{}
 		idx.RewardCandy = map[string]bool{}
 		idx.RewardXlCandy = map[string]bool{}
 		idx.RewardMega = map[string]bool{}
@@ -276,6 +280,15 @@ func (u *Uicons) RewardStardustIcon(amount int) string {
 		return u.url + "/reward/stardust/" + file
 	}
 	return fmt.Sprintf("%s/rewards/reward_stardust.%s", u.url, u.imageType)
+}
+
+// RewardPokecoinIcon resolves the URL for a pokecoin reward icon.
+func (u *Uicons) RewardPokecoinIcon(amount int) string {
+	if idx := u.index.Load(); idx != nil {
+		file := resolveItemIcon(idx.RewardPokecoin, u.imageType, amount, 0)
+		return u.url + "/reward/pokecoin/" + file
+	}
+	return fmt.Sprintf("%s/rewards/reward_pokecoin.%s", u.url, u.imageType)
 }
 
 // RewardCandyIcon resolves the URL for a candy reward icon.


### PR DESCRIPTION
Mirror stardust (type 3) as an amount-based quest reward: min amount stored in the Reward column. Covers matcher, enrichment (fields, icon, rewardString), bot command grammar (pokecoins:N / bare pokecoins / everything / remove), slash option, NLP keyword, summary grouping, rowtext, DTS fields, i18n labels, docs, and a poracle-test scenario.

Untested