### PR TITLE
fix(dts): restore legacy PoracleJS quest field aliases

### DIFF
--- a/DTS.md
+++ b/DTS.md
@@ -723,10 +723,13 @@ See `examples/dts/rsvpChanges/rsvp-update.json` for an installable starting poin
 | `pokestopUrl` | string | Pokestop image URL (alias for `pokestop_url`) |
 | `questString` | string | Translated quest objective |
 | `questStringEng` | string | English quest objective |
+| `quest_task` | string | Legacy PoracleJS alias for `questString` (translated objective) |
 | `rewardString` | string | All rewards as text (translated) |
 | `rewardStringEng` | string | English rewards text |
+| `quest_reward` | string | Legacy PoracleJS alias for `rewardString` |
 | `conditionString` | string | Comma-joined completion conditions, translated, e.g. "Excellent Throw, Curve Ball" |
 | `conditionStringEng` | string | English copy of `conditionString` |
+| `quest_conditions` | string | Legacy PoracleJS alias for `conditionString` |
 | `conditionList` | array | Per-condition objects: `{type, name, formatted}` where `name` is the bare label ("Throw Type") and `formatted` includes the payload ("Excellent Throw"). Falls back to bare name when the webhook payload doesn't carry the data needed for the formatted variant. |
 | `conditionListEng` | array | English copy of `conditionList` |
 | `dustAmount` | int | Stardust reward amount |

--- a/processor/internal/dts/layered_view_test.go
+++ b/processor/internal/dts/layered_view_test.go
@@ -339,6 +339,26 @@ func TestLayeredView_RaidAliases(t *testing.T) {
 	assert.Equal(t, "http://example.com/gym", v)
 }
 
+func TestLayeredView_QuestLegacyAliases(t *testing.T) {
+	// Legacy PoracleJS snake_case names resolve to the translated
+	// questString / rewardString / conditionString computed by enrichment.
+	lv := newTestView(t, func(o *testViewOpts) {
+		o.templateType = "quest"
+		o.base = map[string]any{
+			"questString":     "Catch 5 Pokémon",
+			"rewardString":    "500 Stardust",
+			"conditionString": "Excellent Throw",
+		}
+	})
+	v, ok := lv.GetField("quest_task")
+	require.True(t, ok)
+	assert.Equal(t, "Catch 5 Pokémon", v)
+	v, _ = lv.GetField("quest_reward")
+	assert.Equal(t, "500 Stardust", v)
+	v, _ = lv.GetField("quest_conditions")
+	assert.Equal(t, "Excellent Throw", v)
+}
+
 func TestLayeredView_GymAliases(t *testing.T) {
 	lv := newTestView(t, func(o *testViewOpts) {
 		o.templateType = "gym"

--- a/processor/internal/dts/view.go
+++ b/processor/internal/dts/view.go
@@ -233,6 +233,14 @@ var typeAliases = map[string][]aliasPair{
 		{"pokestopId", "pokestop_id"},
 		{"name", "pokestop_name"},
 		{"url", "pokestop_url"},
+		// Legacy PoracleJS snake_case field names. The translated objective,
+		// rewards, and conditions are computed under questString / rewardString
+		// / conditionString; alias the old names so ported PoracleJS quest
+		// templates keep resolving. Aliases outrank the raw webhook layer, so
+		// any scanner-provided quest_task is overridden by our translation.
+		{"quest_task", "questString"},
+		{"quest_reward", "rewardString"},
+		{"quest_conditions", "conditionString"},
 	},
 	"lure": {
 		{"pokestopName", "pokestop_name"},


### PR DESCRIPTION
Ported PoracleJS quest templates reference `quest_task`, `quest_reward`, and `quest_conditions`, but the processor only exposes the translated values as `questString` / `rewardString` / `conditionString`. So `{{quest_task}}` et al. resolved to nothing — reported by a user migrating quest templates.

The value was always computed (`enrichment/quest.go` sets `questString` from the `quest_title_*` translation); this was an **alias gap, not a missing field**.

### Changes
- Add the three legacy snake_case aliases to the quest alias table (`dts/view.go`): `quest_task`→`questString`, `quest_reward`→`rewardString`, `quest_conditions`→`conditionString`.
- Aliases resolve ahead of the raw webhook layer, so the translated objective wins over any scanner-supplied `quest_task` (Golbat sends `title`; MAD's `quest_task` is obsolete).
- `LayeredView` alias test + DTS.md docs.

Pre-commit gate green locally: `go build ./... && go vet ./... && go test ./... && golangci-lint run ./...`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)