### PR TITLE
fix(rowtext): show explicitly-tracked Normal form in !tracked

### DIFF
--- a/processor/internal/rowtext/rowtext.go
+++ b/processor/internal/rowtext/rowtext.go
@@ -59,8 +59,10 @@ func translateMonsterName(tr *i18n.Translator, gd *gamedata.GameData, pokemonID,
 		// Translation key returned as-is means no translation found
 		formName = ""
 	} else if form == 0 && enrichment.IsNormalForm(formName) {
-		formName = ""
-	} else if enrichment.IsNormalForm(formName) {
+		// form 0 = "any form": suppress a default "Normal"/"Unset" label so the
+		// row reads as the whole species. An explicitly-tracked form
+		// (form != 0) keeps its name — including "Normal" — so distinct form
+		// trackings stay distinguishable in !tracked.
 		formName = ""
 	}
 

--- a/processor/internal/rowtext/rowtext_test.go
+++ b/processor/internal/rowtext/rowtext_test.go
@@ -695,3 +695,46 @@ func TestUcFirst(t *testing.T) {
 		}
 	}
 }
+
+// TestTranslateMonsterName_FormSuppression covers the Rattata scenario: an
+// explicitly-tracked "Normal" form (form 45, non-zero) must show its name in
+// !tracked so it's distinguishable from the "any form" (form 0) tracking and
+// from other named forms (Alola, form 46). Only form 0 suppresses a
+// Normal/Unset label.
+func TestTranslateMonsterName_FormSuppression(t *testing.T) {
+	gd := &gamedata.GameData{
+		Monsters: map[gamedata.MonsterKey]*gamedata.Monster{
+			{ID: 19, Form: 0}:  {PokemonID: 19, FormID: 0},
+			{ID: 19, Form: 45}: {PokemonID: 19, FormID: 45},
+			{ID: 19, Form: 46}: {PokemonID: 19, FormID: 46},
+		},
+	}
+	// form_45 → "Normal" and form_46 → "Alola" come from gamelocale in
+	// production; inject them directly since i18n.Load("") skips gamelocale.
+	tr := i18n.NewTranslator("en", map[string]string{
+		"poke_19": "Rattata",
+		"form_45": "Normal",
+		"form_46": "Alola",
+	})
+
+	tests := []struct {
+		name     string
+		form     int
+		wantForm string
+	}{
+		{"explicit normal form shows Normal", 45, "Normal"},
+		{"named form shows its name", 46, "Alola"},
+		{"any form (0) stays blank", 0, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotName, gotForm := translateMonsterName(tr, gd, 19, tt.form)
+			if gotName != "Rattata" {
+				t.Errorf("name = %q, want %q", gotName, "Rattata")
+			}
+			if gotForm != tt.wantForm {
+				t.Errorf("form %d: formName = %q, want %q", tt.form, gotForm, tt.wantForm)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem
A user tracking `rattata form:normal` (and other forms) sees duplicate-looking rows in `!tracked` with no way to tell them apart:

```
[id:305756] Rattata Alola | ...
[id:305757] Rattata       | ...   ← this is the Normal form
[id:305758] Rattata       | ...
```

## Root cause
`translateMonsterName` (`internal/rowtext/rowtext.go`) suppressed **any** form whose translated name was `"Normal"`/`"Unset"`/`""`, regardless of the form value:

```go
} else if enrichment.IsNormalForm(formName) {   // fires for ANY form value
    formName = ""
}
```

Rattata's Normal form is stored as a non-zero value (form **45**; masterfile `defaultFormId: 45`, `forms: [45, 46]`), and `form_45` → `"Normal"` from gamelocale. So the explicit Normal form rendered identically to the `form 0` ("any form") tracking. Alola (46) survived only because "Alola" isn't a Normal-ish name.

## Fix
Only `form 0` ("any form") drops a default Normal/Unset label. An explicitly-tracked form (`form != 0`) keeps its name — including "Normal" — so distinct form trackings stay distinguishable:

```
[id:305756] Rattata Alola  | ...
[id:305757] Rattata Normal | ...
[id:305758] Rattata        | ...   (form 0 = any)
```

Scoped to `rowtext` (tracking descriptions); alert/enrichment display uses a separate path, so no "Normal" noise is added to actual alerts.

## Tests
- Added a failing-first table-driven `translateMonsterName` test (normal / named / any-form).
- Full gate green: `go build ./... && go vet ./... && go test ./... && golangci-lint run ./...`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)