### PR TITLE
fix(dts): showcase enrich (#172) + weatherchange enrich follow-ups

### DIFF
--- a/processor/cmd/processor/enrich.go
+++ b/processor/cmd/processor/enrich.go
@@ -579,7 +579,16 @@ func (ps *ProcessorService) enrichWeatherChange(raw json.RawMessage, language st
 
 	var perLang map[string]any
 	if ps.enricher.GameData != nil && ps.enricher.Translations != nil {
-		perLang, _ = ps.enricher.WeatherTranslate(base, wc.OldGameplayCondition, wc.GameplayCondition, wc.Affected, language, showAlteredPokemonStaticMap, enrichment.TileModeURL, wc.S2CellID)
+		var userTilePending *staticmap.TilePending
+		perLang, userTilePending = ps.enricher.WeatherTranslate(base, wc.OldGameplayCondition, wc.GameplayCondition, wc.Affected, language, showAlteredPokemonStaticMap, enrichment.TileModeURL, wc.S2CellID)
+		// When show_altered_pokemon_static_map is on, enricher.Weather returns
+		// no base tile — WeatherTranslate produces the per-user tile (with
+		// active-pokemon markers) instead. Prefer it, otherwise keep the base
+		// tile, mirroring the live consumeWeatherChanges selection
+		// ("use per-user tile if available, otherwise base tile").
+		if userTilePending != nil {
+			tilePending = userTilePending
+		}
 	}
 
 	return &enrichResult{

--- a/processor/cmd/processor/enrich.go
+++ b/processor/cmd/processor/enrich.go
@@ -540,13 +540,17 @@ func (ps *ProcessorService) enrichMaxbattle(raw json.RawMessage, language string
 // base/perLang fields match what a live weather alert would carry — nothing
 // about rendering is re-derived here.
 //
-// showAlteredPokemonStaticMap is hardcoded false rather than read from
-// ps.cfg.Weather: it only controls whether the tile gets per-user
-// active-pokemon markers baked in (a live delivery-time concern needing a
-// real per-destination tile mode) and whether a duplicate "activePokemons"
-// field + tile-pending is produced for that purpose. The affected-pokemon
-// list templates actually read — enrichedActivePokemons — is populated by
-// WeatherTranslate whenever len(Affected) > 0, independent of this flag.
+// showAlteredPokemonStaticMap is read from ps.cfg.Weather (nil-safe), exactly
+// like the live consumeWeatherChanges path, so !poracle-test faithfully
+// reproduces the live alert. It matters because WeatherTranslate only
+// populates the "activePokemons" key — the one the bundled and operator
+// weatherchange templates iterate ({{#each activePokemons}}) — when this flag
+// is set. (The sibling "enrichedActivePokemons" key is always populated, but
+// the shipped templates don't read it.) Hardcoding the flag false made the
+// affected-pokemon list vanish from the test render even though production,
+// with show_altered_pokemon_static_map on, shows it. The nil guard preserves
+// the flag-off default for the enrich-parity test harness (which leaves
+// ps.cfg nil).
 func (ps *ProcessorService) enrichWeatherChange(raw json.RawMessage, language string, freshenStaleTime bool) (*enrichResult, error) {
 	var wc webhook.WeatherChangeWebhook
 	if err := json.Unmarshal(raw, &wc); err != nil {
@@ -567,7 +571,10 @@ func (ps *ProcessorService) enrichWeatherChange(raw json.RawMessage, language st
 		}
 	}
 
-	const showAlteredPokemonStaticMap = false
+	showAlteredPokemonStaticMap := false
+	if ps.cfg != nil {
+		showAlteredPokemonStaticMap = ps.cfg.Weather.ShowAlteredPokemonStaticMap
+	}
 	base, tilePending := ps.enricher.Weather(wc.Latitude, wc.Longitude, wc.GameplayCondition, wc.Coords, showAlteredPokemonStaticMap, enrichment.TileModeURL, wc.S2CellID)
 
 	var perLang map[string]any

--- a/processor/cmd/processor/enrich.go
+++ b/processor/cmd/processor/enrich.go
@@ -131,6 +131,8 @@ func (ps *ProcessorService) enrichForType(name string, raw json.RawMessage, lang
 			result, err = ps.enrichFort(raw, language)
 		case "max_battle", "maxbattle":
 			result, err = ps.enrichMaxbattle(raw, language)
+		case "showcase":
+			result, err = ps.enrichShowcase(raw, language, freshenStaleTime)
 		default:
 			return nil, fmt.Errorf("unsupported webhook type: %s", webhookType)
 		}
@@ -362,6 +364,53 @@ func (ps *ProcessorService) enrichInvasion(raw json.RawMessage, language string,
 // enrichInvasion's (see enrichPokemon's doc for the full rationale).
 func (ps *ProcessorService) enrichIncident(raw json.RawMessage, language string, freshenStaleTime bool) (*enrichResult, error) {
 	return ps.enrichPokestopEvent(raw, language, freshenStaleTime, "incident")
+}
+
+// enrichShowcase parses and enriches a showcase (contest) webhook — the
+// dedicated "showcase" DTS template type (leaderboard + featured focus),
+// distinct from the plain "incident" card. Showcases arrive as their own
+// webhook.ShowcaseWebhook shape (not the InvasionWebhook the other pokestop
+// events share), so this can't route through enrichPokestopEvent; it mirrors
+// the live ProcessShowcase / processTestShowcase enrichment exactly —
+// enricher.Invasion with a synthesised display_type, InvasionTranslate over
+// the rankings, and ShowcaseFocusTranslate merged into the same per-language
+// map. The AlertType stays "incident" at render time (showcases are tracked,
+// rate-limited and blocked as incidents); only the templateType is "showcase".
+// freshenStaleTime, when true, bumps an already-past ShowcaseExpiry into the
+// near future — the same editor-preview affordance as enrichInvasion (see
+// enrichPokemon's freshenStaleTime doc for the full rationale).
+func (ps *ProcessorService) enrichShowcase(raw json.RawMessage, language string, freshenStaleTime bool) (*enrichResult, error) {
+	var sc webhook.ShowcaseWebhook
+	if err := json.Unmarshal(raw, &sc); err != nil {
+		return nil, fmt.Errorf("parse showcase: %w", err)
+	}
+
+	if freshenStaleTime && sc.ShowcaseExpiry > 0 && sc.ShowcaseExpiry < time.Now().Unix() {
+		sc.ShowcaseExpiry = time.Now().Unix() + 600
+	}
+
+	base, tilePending := ps.enricher.Invasion(
+		sc.Latitude, sc.Longitude, sc.ShowcaseExpiry, sc.PokestopID, sc.URL,
+		0, showcaseDisplayType, 0, enrichment.TileModeURL)
+	// The showcase webhook carries the pokéstop name in `name`; Invasion()
+	// takes no name arg, so surface it as pokestop_name for the alias.
+	base["pokestop_name"] = sc.Name
+
+	var perLang map[string]any
+	if ps.enricher.GameData != nil && ps.enricher.Translations != nil {
+		perLang = ps.enricher.InvasionTranslate(base, sc.Latitude, sc.Longitude, 0, nil, sc.ShowcaseRankings, language)
+		for k, v := range ps.enricher.ShowcaseFocusTranslate(sc.ShowcaseFocus, language) {
+			perLang[k] = v
+		}
+	}
+
+	return &enrichResult{
+		templateType:  "showcase",
+		base:          base,
+		perLang:       perLang,
+		webhookFields: parseWebhookFields(raw),
+		tilePending:   tilePending,
+	}, nil
 }
 
 // enrichPokestopEvent is the shared enrichment core for enrichInvasion and

--- a/processor/cmd/processor/showcase_enrich_test.go
+++ b/processor/cmd/processor/showcase_enrich_test.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/pokemon/poracleng/processor/internal/webhook"
+)
+
+// TestEnrichForType_Showcase is the direct repro for the reported bug: POST
+// /api/dts/enrich (which flows through enrichForType) returned 500
+// "unsupported webhook type: showcase" because the non-derived switch had no
+// showcase case — even though the dtsmap types map, the ?dtsType=showcase
+// testdata bucket, and the showcase DTS field set all expose it. enrichForType
+// must now enrich showcase like every other DTS type name: its own
+// webhook.ShowcaseWebhook shape, rendered under templateType "showcase"
+// (leaderboard + featured focus), sharing the exact enrichment core the live
+// ProcessShowcase / processTestShowcase paths use.
+func TestEnrichForType_Showcase(t *testing.T) {
+	ps := newEnrichParityService(t)
+	raw := loadTestdataSample(t, "showcase", "type")
+
+	r, err := ps.enrichForType("showcase", raw, "en", false)
+	if err != nil {
+		t.Fatalf(`enrichForType("showcase", ...) error: %v`, err)
+	}
+	if r.templateType != "showcase" {
+		t.Errorf(`templateType = %q, want "showcase"`, r.templateType)
+	}
+	if len(r.base) == 0 {
+		t.Errorf("base enrichment is empty, want populated map")
+	}
+	if r.perLang == nil {
+		t.Fatal("perLang is nil, want the showcase leaderboard + focus fields")
+	}
+
+	// Leaderboard fields (InvasionTranslate -> translateShowcaseRankings).
+	if present, _ := r.perLang["showcasePresent"].(bool); !present {
+		t.Errorf("perLang[showcasePresent] = %v, want true (the sample carries showcase_rankings)", r.perLang["showcasePresent"])
+	}
+	entries, ok := r.perLang["showcase"].([]map[string]any)
+	if !ok || len(entries) == 0 {
+		t.Errorf("perLang[showcase] = %v (%T), want a non-empty contestant list", r.perLang["showcase"], r.perLang["showcase"])
+	}
+
+	// Focus fields (ShowcaseFocusTranslate) — the sample features a Type focus.
+	if present, _ := r.perLang["showcaseFocusPresent"].(bool); !present {
+		t.Errorf("perLang[showcaseFocusPresent] = %v, want true (the sample carries showcase_focus)", r.perLang["showcaseFocusPresent"])
+	}
+}
+
+// TestEnrichWebhook_Showcase covers the exact code path the API endpoint POST
+// /api/dts/enrich runs (EnrichWebhook -> enrichForType -> flatten to
+// variables). Before the fix this returned the "unsupported webhook type:
+// showcase" error the editor surfaced as a 500; now it must return a populated
+// variable map like every other DTS type.
+func TestEnrichWebhook_Showcase(t *testing.T) {
+	ps := newEnrichParityService(t)
+	raw := loadTestdataSample(t, "showcase", "type")
+
+	vars, err := ps.EnrichWebhook("showcase", raw, "en", "discord")
+	if err != nil {
+		t.Fatalf(`EnrichWebhook("showcase", ...) error: %v`, err)
+	}
+	if len(vars) == 0 {
+		t.Errorf("EnrichWebhook returned no variables, want a populated map")
+	}
+}
+
+// TestProcessTestShowcase_EnqueuesShowcaseTemplate guards the refactor of
+// processTestShowcase onto the shared enrichShowcase + renderJobFromEnrich
+// path: the enqueued RenderJob must still carry AlertType "incident" (showcases
+// track/rate-limit/block as incidents) and TemplateType "showcase" (the
+// dedicated leaderboard display), with the showcase leaderboard data present in
+// per-language enrichment.
+func TestProcessTestShowcase_EnqueuesShowcaseTemplate(t *testing.T) {
+	ps := newEnrichParityService(t)
+	ps.renderCh = make(chan RenderJob, 1)
+
+	raw := loadTestdataSample(t, "showcase", "type")
+	target := webhook.MatchedUser{ID: "42", Language: "en"}
+
+	if err := ps.processTestShowcase(raw, target); err != nil {
+		t.Fatalf("processTestShowcase error: %v", err)
+	}
+
+	select {
+	case job := <-ps.renderCh:
+		if job.AlertType != "incident" {
+			t.Errorf("job.AlertType = %q, want %q (showcases track/limit as incidents)", job.AlertType, "incident")
+		}
+		if job.TemplateType != "showcase" {
+			t.Errorf("job.TemplateType = %q, want %q", job.TemplateType, "showcase")
+		}
+		if len(job.MatchedUsers) != 1 || job.MatchedUsers[0].ID != "42" {
+			t.Errorf("job.MatchedUsers = %+v, want single target 42", job.MatchedUsers)
+		}
+		lang := job.PerLangEnrichment["en"]
+		if present, _ := lang["showcasePresent"].(bool); !present {
+			t.Errorf("job perLang[en][showcasePresent] = %v, want true", lang["showcasePresent"])
+		}
+	default:
+		t.Fatal("expected a RenderJob to be enqueued on renderCh")
+	}
+}

--- a/processor/cmd/processor/test.go
+++ b/processor/cmd/processor/test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/pokemon/poracleng/processor/internal/bot"
 	"github.com/pokemon/poracleng/processor/internal/delivery"
-	"github.com/pokemon/poracleng/processor/internal/enrichment"
 	"github.com/pokemon/poracleng/processor/internal/webhook"
 )
 
@@ -295,44 +294,18 @@ func (ps *ProcessorService) processTestMonsterChanged(raw json.RawMessage, targe
 }
 
 func (ps *ProcessorService) processTestShowcase(raw json.RawMessage, target webhook.MatchedUser) error {
-	var sc webhook.ShowcaseWebhook
-	if err := json.Unmarshal(raw, &sc); err != nil {
-		return fmt.Errorf("parse showcase: %w", err)
+	// Shares the exact enrichment core with the editor's /api/dts/enrich path
+	// (enrichForType -> enrichShowcase). AlertType is "incident" — showcases
+	// are tracked, rate-limited and blocked as incidents — while the
+	// enrichResult's templateType is the dedicated "showcase" display model.
+	r, err := ps.enrichShowcase(raw, target.Language, false)
+	if err != nil {
+		return err
 	}
-
-	// Showcases render through the incident template with a synthesised
-	// display_type=9 — mirrors ProcessShowcase.
-	enrichmentData, tilePending := ps.enricher.Invasion(
-		sc.Latitude, sc.Longitude, sc.ShowcaseExpiry, sc.PokestopID, sc.URL,
-		0, showcaseDisplayType, 0, enrichment.TileModeURL)
-	enrichmentData["pokestop_name"] = sc.Name
-	matched := []webhook.MatchedUser{target}
-
-	var perLang map[string]map[string]any
-	if ps.enricher.GameData != nil && ps.enricher.Translations != nil {
-		m := ps.enricher.InvasionTranslate(
-			enrichmentData, sc.Latitude, sc.Longitude, 0, nil, sc.ShowcaseRankings, target.Language)
-		for k, v := range ps.enricher.ShowcaseFocusTranslate(sc.ShowcaseFocus, target.Language) {
-			m[k] = v
-		}
-		perLang = map[string]map[string]any{target.Language: m}
-	}
-
 	if ps.renderCh == nil {
 		return fmt.Errorf("render queue not available")
 	}
-	webhookFields := parseWebhookFields(raw)
-	ps.renderCh <- RenderJob{
-		AlertType:         "incident",
-		TemplateType:      "showcase",
-		Enrichment:        enrichmentData,
-		PerLangEnrichment: perLang,
-		WebhookFields:     webhookFields,
-		MatchedUsers:      matched,
-		MatchedAreas:      []webhook.MatchedArea{},
-		TileGate:          ps.newTileGate(tilePending),
-		LogReference:      "test",
-	}
+	ps.renderCh <- ps.renderJobFromEnrich(r, target, "incident", raw, false, false)
 	return nil
 }
 

--- a/processor/cmd/processor/weatherchange_test.go
+++ b/processor/cmd/processor/weatherchange_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/pokemon/poracleng/processor/internal/config"
 	"github.com/pokemon/poracleng/processor/internal/webhook"
 )
 
@@ -151,6 +152,60 @@ func TestEnrichWeatherChange_FreshenStaleTimeFlag(t *testing.T) {
 	got, _ := editorAffected[0]["disappearTime"].(int64)
 	if got <= wayInThePast {
 		t.Errorf("freshenStaleTime=true: disappearTime = %v, want bumped past %d (editor-preview affordance)", got, wayInThePast)
+	}
+}
+
+// TestEnrichWeatherChange_ActivePokemonsHonorsConfig locks in the fix for the
+// "!poracle-test weatherchange shows no changed pokemon" bug. The bundled and
+// operator weatherchange templates iterate {{#each activePokemons}}, but
+// WeatherTranslate only populates the activePokemons key when
+// [weather] show_altered_pokemon_static_map is set (enrichedActivePokemons is
+// always set — a separate key the templates don't read). enrichWeatherChange
+// used to hardcode the flag false, so the test render never matched
+// production (where the flag is on). It must read the flag from config, like
+// the live consumeWeatherChanges path, so !poracle-test faithfully reproduces
+// the live alert.
+func TestEnrichWeatherChange_ActivePokemonsHonorsConfig(t *testing.T) {
+	ps := newEnrichParityService(t)
+	ps.cfg = &config.Config{Weather: config.WeatherConfig{ShowAlteredPokemonStaticMap: true}}
+
+	raw := loadTestdataSample(t, "weatherchange", "rain")
+	r, err := ps.enrichWeatherChange(raw, "en", false)
+	if err != nil {
+		t.Fatalf("enrichWeatherChange error: %v", err)
+	}
+
+	// activePokemons is the key the weatherchange templates iterate — it must
+	// be present (and non-empty) once the config flag is on.
+	active, ok := r.perLang["activePokemons"].([]map[string]any)
+	if !ok {
+		t.Fatalf("perLang[activePokemons] = %v (%T), want []map[string]any — the key {{#each activePokemons}} reads", r.perLang["activePokemons"], r.perLang["activePokemons"])
+	}
+	if len(active) == 0 {
+		t.Errorf("perLang[activePokemons] is empty, want the affected-pokemon list so the template renders it")
+	}
+}
+
+// TestEnrichWeatherChange_ActivePokemonsNilCfg guards the nil-cfg fallback the
+// original hardcode existed to protect: the enrich-parity harness leaves
+// ps.cfg nil, so the flag reads false and activePokemons stays absent (the
+// always-present enrichedActivePokemons still carries the data) — no panic.
+func TestEnrichWeatherChange_ActivePokemonsNilCfg(t *testing.T) {
+	ps := newEnrichParityService(t)
+	if ps.cfg != nil {
+		t.Fatalf("harness precondition: ps.cfg = %v, want nil", ps.cfg)
+	}
+
+	raw := loadTestdataSample(t, "weatherchange", "rain")
+	r, err := ps.enrichWeatherChange(raw, "en", false)
+	if err != nil {
+		t.Fatalf("enrichWeatherChange error: %v", err)
+	}
+	if _, present := r.perLang["activePokemons"]; present {
+		t.Errorf("nil cfg: perLang[activePokemons] present, want absent (flag defaults off)")
+	}
+	if _, ok := r.perLang["enrichedActivePokemons"].([]map[string]any); !ok {
+		t.Errorf("nil cfg: perLang[enrichedActivePokemons] missing, want the always-present affected list")
 	}
 }
 

--- a/processor/cmd/processor/weatherchange_test.go
+++ b/processor/cmd/processor/weatherchange_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/pokemon/poracleng/processor/internal/config"
+	"github.com/pokemon/poracleng/processor/internal/staticmap"
 	"github.com/pokemon/poracleng/processor/internal/webhook"
 )
 
@@ -206,6 +207,47 @@ func TestEnrichWeatherChange_ActivePokemonsNilCfg(t *testing.T) {
 	}
 	if _, ok := r.perLang["enrichedActivePokemons"].([]map[string]any); !ok {
 		t.Errorf("nil cfg: perLang[enrichedActivePokemons] missing, want the always-present affected list")
+	}
+}
+
+// TestEnrichWeatherChange_TilePreservedWhenFlagOn locks in the tile-selection
+// fix. When [weather] show_altered_pokemon_static_map is on, enricher.Weather
+// returns no base tile — it defers to the per-user tile that WeatherTranslate
+// builds with active-pokemon markers. enrichWeatherChange must carry that
+// pending through (mirroring the live consumeWeatherChanges "use per-user tile
+// if available" selection); discarding it (the original perLang, _ = ... form)
+// made the weather-change tile vanish from !poracle-test even though
+// production shows it. The flag-off arm confirms the base tile still comes
+// from enricher.Weather.
+func TestEnrichWeatherChange_TilePreservedWhenFlagOn(t *testing.T) {
+	ps := newEnrichParityService(t)
+	// A .test URL never resolves (RFC 6761), so the tile workers fail fast
+	// with no real egress; SubmitTile returns the pending synchronously
+	// regardless, which is all this test inspects.
+	resolver := staticmap.New(staticmap.Config{Provider: "tileservercache", ProviderURL: "http://tiles.test"})
+	t.Cleanup(resolver.Close)
+	ps.enricher.StaticMap = resolver
+
+	raw := loadTestdataSample(t, "weatherchange", "rain")
+
+	// Flag ON: base tile is nil, per-user tile must be carried through.
+	ps.cfg = &config.Config{Weather: config.WeatherConfig{ShowAlteredPokemonStaticMap: true}}
+	on, err := ps.enrichWeatherChange(raw, "en", false)
+	if err != nil {
+		t.Fatalf("enrichWeatherChange (flag on) error: %v", err)
+	}
+	if on.tilePending == nil {
+		t.Error("flag on: tilePending = nil, want the per-user weather tile carried through from WeatherTranslate")
+	}
+
+	// Flag OFF: base tile is produced by enricher.Weather as before.
+	ps.cfg = &config.Config{Weather: config.WeatherConfig{ShowAlteredPokemonStaticMap: false}}
+	off, err := ps.enrichWeatherChange(raw, "en", false)
+	if err != nil {
+		t.Fatalf("enrichWeatherChange (flag off) error: %v", err)
+	}
+	if off.tilePending == nil {
+		t.Error("flag off: tilePending = nil, want the base weather tile from enricher.Weather")
 	}
 }
 


### PR DESCRIPTION
Three follow-up fixes to the derived-DTS-test-data feature (PR #166), which merged into `develop` **without** them. All were originally developed on top of that feature; cherry-picked cleanly onto current `develop`.

## Fixes

### 1. Showcase enrich — **closes #172**
`POST /api/dts/enrich {type:"showcase"}` returned `500 unsupported webhook type: showcase`. `showcase` is a real DTS template type (leaderboard + featured focus) exposed by the dtsmap types map and `?dtsType=showcase` testdata, but `enrichForType`'s non-derived switch had no `showcase` case, so the editor's enrich-preview couldn't render Showcase templates (live delivery + `!poracle-test` were unaffected — separate paths).

Adds `enrichShowcase` (parses `webhook.ShowcaseWebhook`, enriches via `enricher.Invasion` + `InvasionTranslate` over the rankings + `ShowcaseFocusTranslate`, templateType `showcase`) and wires it into `enrichForType`. Refactors `processTestShowcase` onto the same `enrichShowcase` + `renderJobFromEnrich` core so the editor-enrich and live-test paths share one implementation — the enqueued RenderJob still carries `AlertType "incident"` / `TemplateType "showcase"`, unchanged.

### 2. weatherchange enrich reads `show_altered_pokemon_static_map` from config
`!poracle-test weatherchange` (and the editor preview) showed no changed pokemon. The bundled/operator templates iterate `{{#each activePokemons}}`, which `WeatherTranslate` only populates when `[weather] show_altered_pokemon_static_map` is set — but `enrichWeatherChange` hardcoded the flag `false`, so the test render never matched production. Now reads the flag from `ps.cfg.Weather` (nil-safe), like the live `consumeWeatherChanges` path.

### 3. weatherchange per-user tile carried through
Follow-up to #2: with the flag on, `enricher.Weather` returns no base tile (it defers to the per-user tile), but `enrichWeatherChange` discarded `WeatherTranslate`'s pending — so the weather tile vanished. Now prefers the per-user pending over the base one, mirroring the live selection.

## Testing
- New/updated tests: showcase enrich (`enrichForType`/`EnrichWebhook` no longer 500; `processTestShowcase` still enqueues incident/showcase), weatherchange `activePokemons` honours the config flag (nil-safe), and the weatherchange tile survives with the flag on/off.
- Full gate green on top of current `develop`: `go build`, `go vet`, `go test -count=1 ./...`, `golangci-lint run` (0 issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)