### PR TITLE
feat(health): add derivedDtsTypes capability flag

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -547,7 +547,7 @@ All API endpoints are accessed via the processor (port 3030). The processor hand
 | DELETE | `/api/profiles/{id}/byProfileNo/{profile_no}` | Delete profile |
 | GET | `/api/snapshots/{messageID}?target={id}` | Inspect a delivered-message snapshot (admin diagnostics; 503 if `[snapshots] enabled = false`) |
 | GET | `/api/dts/actions` | List registered button actions + their scopes/params (drives the config editor's button UI) |
-| GET | `/health` | Health check; returns `{status, version, capabilities}` where `capabilities` is a static feature map (`buttons`, `snapshots`, `autocreate`, `tomlDts`, `buttonResponseObject`) so clients can do explicit feature detection without probing endpoints |
+| GET | `/health` | Health check; returns `{status, version, capabilities}` where `capabilities` is a static feature map (`buttons`, `snapshots`, `autocreate`, `tomlDts`, `buttonResponseObject`, `derivedDtsTypes`) so clients can do explicit feature detection without probing endpoints |
 | GET | `/metrics` | Prometheus metrics |
 | GET | `/openapi.json` | OpenAPI 3.1 spec (whole `/api` + `/api/v2` surface; public) |
 | GET | `/docs` | Interactive API docs (public) |

--- a/processor/internal/api/api.go
+++ b/processor/internal/api/api.go
@@ -65,6 +65,19 @@ type Capabilities struct {
 	// accepts a JSON object (not just a string). Lets editors send
 	// Form-mode authored response templates without flattening.
 	ButtonResponseObject bool `json:"buttonResponseObject"`
+
+	// DerivedDtsTypes reports whether this binary carries the enhanced DTS
+	// enricher: GET /api/dts/testdata returns the DTS-type→source `types`
+	// map and honours the ?dtsType=<name> filter, and POST /api/dts/enrich
+	// accepts DTS type names — including the derived types (monsterChanged,
+	// incident, questSummary, weatherchange, rsvpChanges) and showcase. A
+	// single flag stands for that whole feature since those pieces ship
+	// together (they were added by the same change as this flag), so "flag
+	// present and true" is exactly equivalent to "enricher available".
+	// Editors that see the flag can detect support from the unauthenticated
+	// /health response and skip probing /api/dts/testdata; when the key is
+	// absent they fall back to structural detection (presence of `types`).
+	DerivedDtsTypes bool `json:"derivedDtsTypes"`
 }
 
 // HandleHealth returns a Gin handler that responds with a small health
@@ -93,5 +106,6 @@ func BuildCapabilities() Capabilities {
 		Autocreate:           true,
 		TomlDts:              true,
 		ButtonResponseObject: true,
+		DerivedDtsTypes:      true,
 	}
 }

--- a/processor/internal/api/health_test.go
+++ b/processor/internal/api/health_test.go
@@ -43,7 +43,7 @@ func TestHandleHealthReturnsCapabilities(t *testing.T) {
 
 	// Every capability documented in the Capabilities struct should
 	// appear in the response. New keys land here automatically.
-	expected := []string{"buttons", "snapshots", "autocreate", "tomlDts", "buttonResponseObject"}
+	expected := []string{"buttons", "snapshots", "autocreate", "tomlDts", "buttonResponseObject", "derivedDtsTypes"}
 	for _, k := range expected {
 		v, ok := got.Capabilities[k]
 		if !ok {


### PR DESCRIPTION
Adds a `derivedDtsTypes` boolean to the `capabilities` object returned by `GET /health`, alongside the existing flags (`buttons`, `snapshots`, `autocreate`, `tomlDts`, `buttonResponseObject`).

## What it means
Set `true` on any build that carries the **enhanced DTS enricher** — the one that:
- returns the DTS-type→source `types` map from `GET /api/dts/testdata` and honours the `?dtsType=<name>` filter, and
- accepts DTS type names at `POST /api/dts/enrich`, including the derived types (`monsterChanged`, `incident`, `questSummary`, `weatherchange`, `rsvpChanges`) and `showcase`.

Those pieces all ship together, so a single flag represents the whole feature. The flag is hardcoded `true` in `BuildCapabilities` — landing it in a build that already has the enricher (it merged to `develop` in #166 + #173) — so **"flag present and true" is exactly equivalent to "enricher available"**; no build has one without the other.

## Non-breaking
Backward-compat is handled editor-side: when the `derivedDtsTypes` key is absent, the editor falls back to structural detection (presence of the `types` map). The flag's benefit is that the editor can detect support directly from the **unauthenticated** `/health` response and skip an extra API round-trip. No other endpoint or response shape changes.

## Changes
- `Capabilities` struct + `BuildCapabilities()` in `processor/internal/api/api.go` — new `DerivedDtsTypes bool \`json:"derivedDtsTypes"\`` field, set `true`.
- `health_test.go` — `derivedDtsTypes` added to the asserted capability keys (each must be present and true).
- `CLAUDE.md` — `/health` capability list updated.

## Testing
Full gate green: `go build`, `go vet`, `go test -count=1 ./...`, `golangci-lint run` (0 issues). The health test round-trips the JSON and asserts `derivedDtsTypes` is present and `true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)