### PR TITLE
fix(delivery): only upload inline tile bytes when the message's image is the tile

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -874,6 +874,8 @@ Discord/Telegram fetch to display the image.
 
 Why `URLWithBytes` exists: before this mode, a single event fanning out to N Discord-upload destinations plus a Telegram destination triggered N separate downloads of the public URL from the processor (one per destination, inside each job's critical section). Each download was a chance for Cloudflare-style proxy buffering to fail — losing the map for that destination. `URLWithBytes` collapses those N downloads into one, routes it through the internal URL, and guarantees the same bytes for every Discord destination in the batch.
 
+**Per-message byte gating** (`tileBytesForMessage` in `cmd/processor/render.go`): the batch tile mode is decided once for all matched users, but the bytes are attached **per rendered message** — only when that message's embed image URL equals the resolved `staticMap` tile URL. A single event fans out to many templates: one may render `{{staticMap}}` (gets the bytes), another may set a static image (`"image":{"url":"https://…/x.png"}`) or a **hand-built** tileserver URL (`https://…/staticmap/poracle-monster?imgUrl={{imgUrl}}&…`). The hand-built case is exactly why gating happens here and not on `tileMode` alone: `UsesTile` matches the substring `staticmap`, so a hand-built URL trips it and the batch generates bytes even though that template renders its own URL. Without gating, delivery's `len(StaticMapData) > 0 && imageURL != ""` short-circuit would upload the poracle tile over the operator's chosen image. Gating returns nil bytes for those messages so delivery downloads their real image instead.
+
 ## Configuration
 
 Single TOML file at `config/config.toml`, used by the processor. See `config/config.example.toml` for all options with comments.

--- a/processor/cmd/processor/render.go
+++ b/processor/cmd/processor/render.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"strconv"
 	"time"
 
@@ -181,6 +182,11 @@ func (ps *ProcessorService) processRenderJob(job RenderJob) {
 			metrics.RenderTotal.WithLabelValues("error").Inc()
 			return
 		}
+		// tileURL is what {{staticMap}} resolved to for this batch (the real
+		// pregen URL in URL/URLWithBytes mode, the fallback URL in inline mode).
+		// The inline tile bytes must only replace a message whose embed image IS
+		// that tile — see tileBytesForMessage.
+		tileURL, _ := job.Enrichment["staticMap"].(string)
 		for _, j := range jobs {
 			var tth delivery.TTH
 			if job.OverrideCleanTTH != 0 {
@@ -201,7 +207,7 @@ func (ps *ProcessorService) processRenderJob(job RenderJob) {
 				EditKey:       j.EditKey,
 				ReplyKey:      job.ReplyKey,
 				MsgType:       job.AlertType,
-				StaticMapData: job.TileImageData,
+				StaticMapData: tileBytesForMessage(j.Message, job.TileImageData, tileURL),
 				Language:      j.Language,
 				SnapshotData:  ps.buildSnapshot(job, j, tth),
 			})
@@ -209,6 +215,33 @@ func (ps *ProcessorService) processRenderJob(job RenderJob) {
 	}
 
 	metrics.RenderTotal.WithLabelValues("ok").Inc()
+}
+
+// tileBytesForMessage decides whether this rendered message should carry the
+// batch's inline tile bytes. The bytes are the poracle staticMap tile; the
+// delivery layer, when it sees non-empty StaticMapData plus any embed image
+// URL, uploads the bytes and rewrites the embed image to attachment://map.png.
+// That is only correct when the embed image actually IS the tile.
+//
+// A single event fans out to many templates: some render {{staticMap}} (image
+// URL == tileURL — attach bytes), others set a static image URL or a
+// hand-built tileserver URL (image URL != tileURL — must keep their own
+// image). The hand-built case is why we can't rely on tileMode/UsesTile alone:
+// UsesTile matches the substring "staticmap", so a URL like
+// ".../staticmap/poracle-monster?imgUrl=..." trips it and the batch generates
+// bytes even though that template renders its own URL. Returning nil here makes
+// delivery download the message's real image instead of overwriting it with
+// the tile.
+func tileBytesForMessage(msg json.RawMessage, tileBytes []byte, tileURL string) []byte {
+	if len(tileBytes) == 0 || tileURL == "" {
+		return tileBytes
+	}
+	// Reuse delivery's exact extraction so the URL we compare is identical to
+	// the one the sender's short-circuit would test.
+	if _, imgURL, err := delivery.NormalizeAndExtractImage(msg, true); err == nil && imgURL != tileURL {
+		return nil
+	}
+	return tileBytes
 }
 
 // resolveTilePending performs the synchronous tile wait that processRenderJob

--- a/processor/cmd/processor/render_tile_test.go
+++ b/processor/cmd/processor/render_tile_test.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestTileBytesForMessage covers the "wrong image uploaded" bug: the batch's
+// inline tile bytes must only be attached to a message whose embed image IS the
+// resolved staticMap tile URL. Templates that render a static image URL or a
+// hand-built tileserver URL must keep their own image (bytes returned nil so
+// delivery downloads the message's real image).
+func TestTileBytesForMessage(t *testing.T) {
+	const tileURL = "https://tiles.example.com/multistaticmap/pregenerated/abc123"
+	tileBytes := []byte("PNGDATA")
+
+	msg := func(imageURL string) json.RawMessage {
+		return json.RawMessage(`{"embed":{"image":{"url":"` + imageURL + `"}}}`)
+	}
+
+	tests := []struct {
+		name      string
+		message   json.RawMessage
+		tileBytes []byte
+		tileURL   string
+		wantBytes bool
+	}{
+		{
+			name:      "template uses {{staticMap}} — image is the tile → attach bytes",
+			message:   msg(tileURL),
+			tileBytes: tileBytes,
+			tileURL:   tileURL,
+			wantBytes: true,
+		},
+		{
+			name:      "static image URL → keep it, no tile bytes",
+			message:   msg("https://i.ibb.co/Tty3NHn/demo-en.png"),
+			tileBytes: tileBytes,
+			tileURL:   tileURL,
+			wantBytes: false,
+		},
+		{
+			name:      "hand-built tileserver URL (trips UsesTile) → keep it, no tile bytes",
+			message:   msg("https://cache.darkcode.sx/staticmap/poracle-monster?imgUrl=x&latitude=1&longitude=2&style=klokantech-basic"),
+			tileBytes: tileBytes,
+			tileURL:   tileURL,
+			wantBytes: false,
+		},
+		{
+			name:      "embeds-array form is handled too",
+			message:   json.RawMessage(`{"embeds":[{"image":{"url":"https://i.ibb.co/other.png"}}]}`),
+			tileBytes: tileBytes,
+			tileURL:   tileURL,
+			wantBytes: false,
+		},
+		{
+			name:      "no tile bytes → passthrough nil",
+			message:   msg(tileURL),
+			tileBytes: nil,
+			tileURL:   tileURL,
+			wantBytes: false,
+		},
+		{
+			name:      "no tile URL (skip mode) → passthrough bytes unchanged",
+			message:   msg("https://i.ibb.co/anything.png"),
+			tileBytes: tileBytes,
+			tileURL:   "",
+			wantBytes: true,
+		},
+		{
+			name:      "message with no embed image → no bytes (nothing to replace)",
+			message:   json.RawMessage(`{"content":"hi"}`),
+			tileBytes: tileBytes,
+			tileURL:   tileURL,
+			wantBytes: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tileBytesForMessage(tc.message, tc.tileBytes, tc.tileURL)
+			if tc.wantBytes && len(got) == 0 {
+				t.Errorf("expected tile bytes to be attached, got none")
+			}
+			if !tc.wantBytes && len(got) != 0 {
+				t.Errorf("expected no tile bytes, got %d bytes", len(got))
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem
A user with templates using different Discord image options reported the **wrong image** being sent for some messages — the poracle staticMap tile appearing where the template specified a different image:
- a static image: `"image":{"url":"https://i.ffff.co/Tty3NHn/demo-en.png"}`
- a hand-built tileserver URL: `"image":{"url":"https://cache.ffff.sx/staticmap/poracle-monster?imgUrl={{{imgUrl}}}&latitude={{latitude}}&longitude={{longitude}}&style=klokantech-basic"}`
- the automatic `{{staticMap}}` tile

It "felt like poracle is sending the bytes-only version rather than the per-message download" — exactly right.

## Root cause
The render pool attached the batch's inline tile bytes (`RenderJob.TileImageData`) to **every** `delivery.Job` unconditionally (`render.go`). Delivery (`postMessage`/`postWebhook`/`Edit`) then uploads the bytes and rewrites the embed image to `attachment://map.png` whenever `len(StaticMapData) > 0 && imageURL != ""` — **regardless of whether the image URL is actually the tile**. So any batch that produced tile bytes would overwrite a message's real image with the tile.

Two triggers:
1. **Mixed batch** — one user's template renders `{{staticMap}}` (batch generates bytes), another's uses a static/custom image → the second gets the tile.
2. **Hand-built URL alone** — `UsesTile` matches the substring `staticmap`, so a URL like `.../staticmap/poracle-monster?...` trips it; the batch generates bytes that then overwrite that template's own rendered URL. Happens even for a single destination.

## Fix
Gate byte attachment **per rendered message** (`tileBytesForMessage`): only attach the tile bytes when the message's embed image URL equals the resolved `staticMap` URL (`job.Enrichment["staticMap"]` — the real pregen URL in URL/URLWithBytes mode, the fallback URL in inline mode). Otherwise return `nil` so delivery downloads the message's real image. It reuses `delivery.NormalizeAndExtractImage` so the compared URL is identical to what the sender's short-circuit tests, and it fixes both the send and edit paths (both read `job.StaticMapData`).

## Testing
- `TestTileBytesForMessage` covers all three template styles (`{{staticMap}}` → bytes attached; static URL and hand-built tileserver URL → bytes withheld), plus embeds-array form, no-bytes/no-tileURL passthrough, and no-embed-image.
- Full gate green: `go build`, `go vet`, `go test -count=1 ./...`, `golangci-lint run` (0 issues).
- CLAUDE.md tile-modes section updated to document the per-message gating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)