### PR TITLE
fix(dts): suppress spurious 'no default template' warning for help

### DIFF
--- a/processor/internal/dts/log_summary_default_test.go
+++ b/processor/internal/dts/log_summary_default_test.go
@@ -1,0 +1,46 @@
+package dts
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
+)
+
+// TestLogSummaryNoDefaultWarningSkipsHelp verifies LogSummary does not emit the
+// "no default template" warning for the platform-agnostic help type — help is
+// selected by topic id (help/fort, help/track, …), not via the per-platform
+// default-template fallback, so a missing default is expected, not a
+// misconfiguration. A genuine alert type missing its default must still warn.
+func TestLogSummaryNoDefaultWarningSkipsHelp(t *testing.T) {
+	hook := test.NewGlobal()
+	t.Cleanup(hook.Reset)
+
+	entries := []DTSEntry{
+		{Type: "help", ID: "fort", Platform: "", Language: ""},                    // agnostic, no default → must NOT warn
+		{Type: "monster", ID: "1", Platform: "discord", Language: ""},             // no default → must warn
+		{Type: "raid", ID: "1", Platform: "discord", Language: "", Default: true}, // has default → no warn
+	}
+	ts, _ := newTestStore(t, entries)
+	ts.LogSummary()
+
+	var warnedHelp, warnedMonster bool
+	for _, e := range hook.AllEntries() {
+		if e.Level != logrus.WarnLevel || !strings.Contains(e.Message, "no default template") {
+			continue
+		}
+		if strings.Contains(e.Message, `type="help"`) {
+			warnedHelp = true
+		}
+		if strings.Contains(e.Message, `type="monster"`) {
+			warnedMonster = true
+		}
+	}
+	if warnedHelp {
+		t.Error(`LogSummary warned "no default template" for help; help is topic-based and needs no default`)
+	}
+	if !warnedMonster {
+		t.Error(`LogSummary should still warn "no default template" for monster (a real alert type missing its default)`)
+	}
+}

--- a/processor/internal/dts/templates.go
+++ b/processor/internal/dts/templates.go
@@ -966,6 +966,15 @@ func (ts *TemplateStore) LogSummary() {
 		}
 	}
 	for key := range seen {
+		// Platform-agnostic types (help) are selected by topic id
+		// (help/fort, help/track, …), not via the per-platform
+		// default-template fallback, so having no default is expected — not a
+		// misconfiguration. Warning here is noise (the render-time
+		// "no DTS template found … no default template configured" error in
+		// renderForUsers remains the real safety net for alert types).
+		if IsPlatformAgnosticType(key.typ) {
+			continue
+		}
 		if !hasDefault[key] {
 			log.Warnf("DTS: no default template for type=%q platform=%q", key.typ, key.platform)
 		}


### PR DESCRIPTION
## Problem
On startup/reload the log showed:
```
WARN DTS: no default template for type="help" platform=""
```
As you noted, that doesn't make sense — help doesn't need a default.

## Cause
`LogSummary` (`internal/dts/templates.go`) warns for every `(type, platform)` pair that has no `Default`-flagged entry. help templates are per-topic (`help/fort`, `help/track`, …), platform-agnostic (`platform=""`), and selected by topic id — none are flagged `default`, so the pair `(help, "")` tripped the warning. It's pre-existing (the bundled `fallbacks/dts/help/*.json` are all `platform=""`), just noticed now during testing.

## Fix
Skip platform-agnostic types (`IsPlatformAgnosticType`, i.e. help today) in the missing-default check. Real alert types (monster/raid/…) still warn, and the render-time `"no DTS template found … no default template configured"` error remains the actual safety net for those.

## Test
`TestLogSummaryNoDefaultWarningSkipsHelp` — help no longer warns; a non-agnostic type genuinely missing its default still does. Gate green (build/vet/test/lint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)