### PR TITLE
fix(pokemon): monsterChanged follow-ups reuse the original template, not the default

### DIFF
--- a/processor/cmd/processor/pokemon.go
+++ b/processor/cmd/processor/pokemon.go
@@ -195,7 +195,7 @@ func (ps *ProcessorService) ProcessPokemon(raw json.RawMessage) error {
 					// Prior already TTL-evicted; original is gone, nothing to reply to.
 					continue
 				}
-				if u := ps.rebuildMatchedUserForChange(targetID, prior.Clean); u != nil {
+				if u := ps.rebuildMatchedUserForChange(targetID, prior.Clean, prior.Template); u != nil {
 					priorOnlyUsers = append(priorOnlyUsers, *u)
 				}
 			}
@@ -439,12 +439,13 @@ func (ps *ProcessorService) perLangWithChangeFields(perLang map[string]map[strin
 
 // rebuildMatchedUserForChange synthesises a MatchedUser for a target
 // that had a prior alert for this encounter but no longer matches.
-// Clean is inherited from the prior tracked message so the
-// monsterChanged reply follows the same auto-delete behaviour as
-// the original. Template / Ping / Distance stay at zero values —
-// the T1 tracking rule isn't known here. Returns nil for unknown
-// or disabled humans; their reply-index entry expires on its own.
-func (ps *ProcessorService) rebuildMatchedUserForChange(targetID string, clean int) *webhook.MatchedUser {
+// Clean and Template are inherited from the prior tracked message so the
+// monsterChanged reply follows the same auto-delete behaviour AND uses the
+// same DTS template name as the original alert (rather than falling back to
+// the default). Ping / Distance stay at zero values — the T1 tracking rule
+// isn't known here. Returns nil for unknown or disabled humans; their
+// reply-index entry expires on its own.
+func (ps *ProcessorService) rebuildMatchedUserForChange(targetID string, clean int, template string) *webhook.MatchedUser {
 	if ps.humans == nil {
 		return nil
 	}
@@ -461,6 +462,7 @@ func (ps *ProcessorService) rebuildMatchedUserForChange(targetID string, clean i
 		Name:     human.Name,
 		Language: effectiveLanguage(webhook.MatchedUser{Language: human.Language}, ps.cfg.General.Locale),
 		Clean:    clean,
+		Template: template,
 	}
 }
 

--- a/processor/cmd/processor/pokemon_change_test.go
+++ b/processor/cmd/processor/pokemon_change_test.go
@@ -317,20 +317,29 @@ func TestRebuildMatchedUserForChange_InheritsClean(t *testing.T) {
 	})
 	ps.humans = humans
 
-	got := ps.rebuildMatchedUserForChange("user-1", 1)
+	got := ps.rebuildMatchedUserForChange("user-1", 1, "5")
 	if got == nil {
 		t.Fatalf("rebuildMatchedUserForChange returned nil for a registered enabled human")
 	}
 	if got.Clean != 1 {
 		t.Errorf("Clean = %d, want 1 (inherited from prior tracked message)", got.Clean)
 	}
+	if got.Template != "5" {
+		t.Errorf("Template = %q, want 5 (inherited so monsterChanged uses the same template, not the default)", got.Template)
+	}
 	if got.ID != "user-1" || got.Type != "discord:user" || got.Name != "Tester" {
 		t.Errorf("identity fields wrong: %+v", *got)
 	}
 
+	// Empty template (user was on config default) stays empty → resolves to
+	// default at render time, same as the original alert did.
+	if got := ps.rebuildMatchedUserForChange("user-1", 1, ""); got == nil || got.Template != "" {
+		t.Errorf("empty template should be preserved as empty, got %+v", got)
+	}
+
 	// Disabled humans drop out so their reply-index entry expires naturally.
 	humans.AddHuman(&store.Human{ID: "user-2", Enabled: false})
-	if got := ps.rebuildMatchedUserForChange("user-2", 1); got != nil {
+	if got := ps.rebuildMatchedUserForChange("user-2", 1, "5"); got != nil {
 		t.Errorf("disabled human should produce nil MatchedUser, got %+v", *got)
 	}
 }

--- a/processor/cmd/processor/render.go
+++ b/processor/cmd/processor/render.go
@@ -209,6 +209,7 @@ func (ps *ProcessorService) processRenderJob(job RenderJob) {
 				MsgType:       job.AlertType,
 				StaticMapData: tileBytesForMessage(j.Message, job.TileImageData, tileURL),
 				Language:      j.Language,
+				Template:      j.TemplateRequested,
 				SnapshotData:  ps.buildSnapshot(job, j, tth),
 			})
 		}

--- a/processor/internal/delivery/delivery.go
+++ b/processor/internal/delivery/delivery.go
@@ -42,6 +42,14 @@ type Job struct {
 	StaticMapData []byte          `json:"-"` // inline tile image bytes
 	Language      string          `json:"-"` // matched user's language (for hooks notifications)
 
+	// Template is the per-user tracking-rule template as requested (the raw
+	// value, typically "" = config default). It is stored on the reply-index
+	// TrackedMessage so a later change event can rebuild the recipient's
+	// MatchedUser with the SAME template — otherwise monsterChanged follow-ups
+	// resolve to the default. Ephemeral (render → queue → tracker); not
+	// persisted with the job.
+	Template string `json:"-"`
+
 	// ReplyToID is an *ephemeral* field stamped on the Job by the delivery
 	// queue immediately before send when ReplyKey is set and the
 	// MessageTracker has a known prior message for (ReplyKey, Target). The

--- a/processor/internal/delivery/queue.go
+++ b/processor/internal/delivery/queue.go
@@ -406,6 +406,7 @@ func (fq *FairQueue) processJob(job *Job) {
 			MsgType:  job.MsgType,
 			Clean:    job.Clean,
 			ReplyKey: job.ReplyKey,
+			Template: job.Template,
 		}, ttl)
 		logref.Debugf(job.LogReference, "tracked message key=%s sentID=%s ttl=%v clean=%d replyKey=%q", key, sent.ID, ttl, job.Clean, job.ReplyKey)
 	}

--- a/processor/internal/delivery/tracker.go
+++ b/processor/internal/delivery/tracker.go
@@ -32,6 +32,14 @@ type TrackedMessage struct {
 	MsgType  string `json:"msg_type,omitempty"`
 	Clean    int    `json:"clean"`
 	ReplyKey string `json:"reply_key,omitempty"`
+	// Template is the source tracking rule's requested template (raw value,
+	// "" = config default). Change-event dispatch reads it back to rebuild a
+	// prior-only recipient's MatchedUser with the same template so the
+	// monsterChanged follow-up uses the same template name, not the default.
+	// Backward compat: entries persisted before this field existed
+	// deserialise with Template="" (config default) — same graceful fallback
+	// as the pre-existing behaviour.
+	Template string `json:"template,omitempty"`
 }
 
 // MessageTracker manages sent messages with TTL-based expiry and clean

--- a/processor/internal/delivery/tracker_test.go
+++ b/processor/internal/delivery/tracker_test.go
@@ -269,7 +269,7 @@ func TestLookupReplyMessage_ReturnsFullPrior(t *testing.T) {
 
 	mt.Track("edit-clean", &TrackedMessage{
 		SentID: "msg-clean", Target: "userA", Type: "discord:user",
-		Clean: 1, ReplyKey: "enc-x",
+		Clean: 1, ReplyKey: "enc-x", Template: "5",
 	}, time.Hour)
 
 	got := mt.LookupReplyMessage("enc-x", "userA")
@@ -281,6 +281,9 @@ func TestLookupReplyMessage_ReturnsFullPrior(t *testing.T) {
 	}
 	if got.Clean != 1 {
 		t.Errorf("Clean = %d, want 1 (inherited by monsterChanged dispatch)", got.Clean)
+	}
+	if got.Template != "5" {
+		t.Errorf("Template = %q, want 5 (monsterChanged reuses the original template name)", got.Template)
 	}
 	if got.Type != "discord:user" {
 		t.Errorf("Type = %q, want discord:user", got.Type)


### PR DESCRIPTION
## Problem
When a tracked pokemon changes (species/form/stats), the `monsterChanged` follow-up is meant to render with the **same DTS template the user chose** for the original alert. Instead it always used the config default.

## Cause
`monsterChanged` recipients are *prior-only* users — they had an alert for this encounter but no longer match the changed pokemon — so their `MatchedUser` is synthesised by `rebuildMatchedUserForChange`, not taken from a fresh match. That synth left `Template=""` (*"the tracking rule isn't known here"*), and `renderForUsers`' `resolveTemplate("")` returns the default.

The template was captured at render time (`webhook.DeliveryJob.TemplateRequested`) but **discarded before the reply-index record**, so at change time there was nothing to inherit.

## Fix
Thread the template through the exact path `Clean` already takes to reach `monsterChanged`:

`renderForUsers` (`TemplateRequested = user.Template`) → `delivery.Job.Template` → reply-index `TrackedMessage.Template` → read back in `rebuildMatchedUserForChange` → stamped on the rebuilt `MatchedUser`.

The change render then resolves the same template name (`monsterChanged/<id>`). An empty template (user was on the config default) stays empty and resolves to the default — matching what the original alert did. `TrackedMessage.Template` is `json:",omitempty"`, so records persisted before this field deserialise with `Template=""` (graceful default, same as before).

## Testing
- `TestLookupReplyMessage_ReturnsFullPrior` — the reply record now round-trips `Template`.
- `TestRebuildMatchedUserForChange_InheritsClean` — the rebuilt user inherits the template (and empty stays empty).
- Full gate green: build, vet, `go test -count=1 ./...`, `golangci-lint` (0 issues).

## Operator note
This selects `monsterChanged/<same-id>` — so to see a custom follow-up, an operator needs a `monsterChanged` template authored under the same id/name as their `monster` template. If none exists, selection falls back to the default `monsterChanged` (unchanged behaviour for that case).

🤖 Generated with [Claude Code](https://claude.com/claude-code)