### PR TITLE
fix(weather): share one tile gate across weatherchange users (fix fallback-image race)

### DIFF
--- a/processor/cmd/processor/weather.go
+++ b/processor/cmd/processor/weather.go
@@ -2,12 +2,10 @@ package main
 
 import (
 	"encoding/json"
-	"maps"
 	"time"
 
 	log "github.com/sirupsen/logrus"
 
-	"github.com/pokemon/poracleng/processor/internal/geo"
 	"github.com/pokemon/poracleng/processor/internal/staticmap"
 	"github.com/pokemon/poracleng/processor/internal/tracker"
 	"github.com/pokemon/poracleng/processor/internal/webhook"
@@ -156,79 +154,134 @@ func (ps *ProcessorService) consumeWeatherChanges() {
 
 		webhookFields := parseWebhookFields(msg)
 
-		for _, user := range matched {
-			lang := user.Language
+		ps.dispatchWeatherChange(weatherChangeDispatchInput{
+			s2CellID:        change.S2CellID,
+			oldCondition:    change.OldGameplayCondition,
+			newCondition:    change.GameplayCondition,
+			baseEnrichment:  baseEnrichment,
+			baseTilePending: baseTilePending,
+			matched:         matched,
+			matchedAreas:    matchedAreas,
+			webhookFields:   webhookFields,
+			now:             now,
+			minAlert:        minAlert,
+		})
+	}
+}
+
+// weatherChangeDispatchInput carries the shared, per-change context into
+// dispatchWeatherChange. baseEnrichment/baseTilePending are computed once per
+// weather change and shared across every matched user's RenderJob.
+type weatherChangeDispatchInput struct {
+	s2CellID        string
+	oldCondition    int
+	newCondition    int
+	baseEnrichment  map[string]any
+	baseTilePending *staticmap.TilePending
+	matched         []webhook.MatchedUser
+	matchedAreas    []webhook.MatchedArea
+	webhookFields   map[string]any
+	now             int64
+	minAlert        int64
+}
+
+// dispatchWeatherChange fans a weather change out to one RenderJob per matched
+// user, mirroring dispatchPokemonAlert's tile handling.
+//
+// When the base weather tile is SHARED (show_altered_pokemon_static_map off, so
+// every user renders the same cell tile), all jobs share a SINGLE tileGate: the
+// tile resolves once and its URL is written once into the shared baseEnrichment
+// map, with chan-close happens-before making it visible to every render worker.
+// Wrapping the shared *staticmap.TilePending in a gate PER USER was a bug — the
+// pending's Result/ResultImg channels deliver to exactly one receiver, so only
+// one message got the real tile URL and the rest blocked to their deadline and
+// applied the fallback image; and the per-user gate goroutines raced writing
+// baseEnrichment.
+//
+// Per-user tiles (the per-pokemon plot config, show_altered_pokemon_static_map
+// on) keep their own gate — each user's pending is distinct, so there is no
+// sharing to coordinate.
+//
+// Clean users carry their per-user clean-deletion TTH via RenderJob.
+// OverrideCleanTTH (aligned to their last-tracked pokemon's despawn) instead of
+// a pre-resolution COPY of baseEnrichment. The copy snapshotted the map before
+// the async tile resolved, so a clean user's message lost the shared tile;
+// sharing baseEnrichment + OverrideCleanTTH keeps both the resolved tile and the
+// correct auto-delete timing. The weatherchange template renders no tth field,
+// so this is a behaviour-preserving swap for the clean-deletion timing only.
+func (ps *ProcessorService) dispatchWeatherChange(in weatherChangeDispatchInput) {
+	if ps.renderCh == nil {
+		return
+	}
+	l := log.WithField("ref", in.s2CellID)
+
+	// Single shared gate for the shared base tile (nil when a per-user tile is
+	// used instead, in which case each user gets their own gate below).
+	baseGate := ps.newTileGate(in.baseTilePending)
+
+	for _, user := range in.matched {
+		lang := user.Language
+		if lang == "" {
+			lang = ps.cfg.General.Locale
 			if lang == "" {
-				lang = ps.cfg.General.Locale
-				if lang == "" {
-					lang = "en"
+				lang = "en"
+			}
+		}
+
+		var perLang map[string]map[string]any
+		var userTilePending *staticmap.TilePending
+		if ps.enricher.GameData != nil && ps.enricher.Translations != nil {
+			userMode := ps.tileMode("weatherchange", []webhook.MatchedUser{user}, in.s2CellID)
+			langEnrichment, utp := ps.enricher.WeatherTranslate(
+				in.baseEnrichment,
+				in.oldCondition,
+				in.newCondition,
+				user.ActivePokemons,
+				lang,
+				ps.cfg.Weather.ShowAlteredPokemonStaticMap,
+				userMode,
+				in.s2CellID,
+			)
+			userTilePending = utp
+			perLang = map[string]map[string]any{lang: langEnrichment}
+		}
+
+		// Clean users auto-delete when their longest-lived shown pokemon
+		// despawns (weatherAlertCleanUntil), carried per-job via
+		// OverrideCleanTTH so the shared baseEnrichment map is untouched.
+		var overrideCleanTTH int64
+		if user.Clean > 0 {
+			cleanUntil := weatherAlertCleanUntil(user)
+			if cleanUntil > 0 {
+				// Re-check the min-alert threshold with the alert-accurate TTH
+				// (the pre-filter used CaresUntil, which can over-estimate when
+				// only short-lived active pokemon remain).
+				if remaining := cleanUntil - in.now; remaining < in.minAlert {
+					l.Debugf("Weather alert suppressed for %s (%s) — alert TTH %ds below alert_minimum_time %ds",
+						user.Name, user.ID, remaining, in.minAlert)
+					continue
 				}
+				overrideCleanTTH = cleanUntil
 			}
+		}
 
-			var perLang map[string]map[string]any
-			var userTilePending *staticmap.TilePending
-			if ps.enricher.GameData != nil && ps.enricher.Translations != nil {
-				var langEnrichment map[string]any
-				userMode := ps.tileMode("weatherchange", []webhook.MatchedUser{user}, change.S2CellID)
-				langEnrichment, userTilePending = ps.enricher.WeatherTranslate(
-					baseEnrichment,
-					change.OldGameplayCondition,
-					change.GameplayCondition,
-					user.ActivePokemons,
-					lang,
-					ps.cfg.Weather.ShowAlteredPokemonStaticMap,
-					userMode,
-					change.S2CellID,
-				)
-				perLang = map[string]map[string]any{lang: langEnrichment}
-			}
+		// Shared base tile → shared gate; per-user tile → its own gate.
+		gate := baseGate
+		if userTilePending != nil {
+			gate = ps.newTileGate(userTilePending)
+		}
 
-			// For clean weather alerts, align TTH with the longest-lived
-			// pokemon actually shown in the alert. CaresUntil is the max
-			// across every pokemon ever registered for this cell (extended,
-			// never reduced — see WeatherCareTracker.Register) and so can
-			// outlive the pokemon the alert mentions. Using it directly
-			// produced a real-world bug: pokemon A despawned and was
-			// clean-deleted, but the weather alert that mentioned A stayed
-			// behind until pokemon B's later despawn time. When the
-			// activePokemon tracker is off we have no per-pokemon data,
-			// so we fall back to CaresUntil as the best estimate.
-			userEnrichment := baseEnrichment
-			if user.Clean > 0 {
-				cleanUntil := weatherAlertCleanUntil(user)
-				if cleanUntil > 0 {
-					// Re-check the min-alert threshold with the
-					// alert-accurate TTH (the pre-filter at the top of
-					// the loop used CaresUntil, which can over-estimate
-					// when only short-lived active pokemon remain).
-					if remaining := cleanUntil - now; remaining < minAlert {
-						l.Debugf("Weather alert suppressed for %s (%s) — alert TTH %ds below alert_minimum_time %ds",
-							user.Name, user.ID, remaining, minAlert)
-						continue
-					}
-					userEnrichment = make(map[string]any, len(baseEnrichment)+1)
-					maps.Copy(userEnrichment, baseEnrichment)
-					userEnrichment["tth"] = geo.ComputeTTH(cleanUntil)
-				}
-			}
-
-			// Use per-user tile if available, otherwise base tile
-			tp := baseTilePending
-			if userTilePending != nil {
-				tp = userTilePending
-			}
-
-			ps.renderCh <- RenderJob{
-				AlertType:         "weatherchange",
-				TemplateType:      "weatherchange",
-				Enrichment:        userEnrichment,
-				PerLangEnrichment: perLang,
-				WebhookFields:     webhookFields,
-				MatchedUsers:      []webhook.MatchedUser{user},
-				MatchedAreas:      matchedAreas,
-				TileGate:          ps.newTileGate(tp),
-				LogReference:      change.S2CellID,
-			}
+		ps.renderCh <- RenderJob{
+			AlertType:         "weatherchange",
+			TemplateType:      "weatherchange",
+			Enrichment:        in.baseEnrichment,
+			PerLangEnrichment: perLang,
+			WebhookFields:     in.webhookFields,
+			MatchedUsers:      []webhook.MatchedUser{user},
+			MatchedAreas:      in.matchedAreas,
+			TileGate:          gate,
+			OverrideCleanTTH:  overrideCleanTTH,
+			LogReference:      in.s2CellID,
 		}
 	}
 }

--- a/processor/cmd/processor/weather.go
+++ b/processor/cmd/processor/weather.go
@@ -215,10 +215,17 @@ func (ps *ProcessorService) dispatchWeatherChange(in weatherChangeDispatchInput)
 	}
 	l := log.WithField("ref", in.s2CellID)
 
-	// Single shared gate for the shared base tile (nil when a per-user tile is
-	// used instead, in which case each user gets their own gate below).
-	baseGate := ps.newTileGate(in.baseTilePending)
-
+	// Build every user's RenderJob FIRST, THEN spawn the shared base-tile gate.
+	// WeatherTranslate READS in.baseEnrichment (lat/lon); the shared gate's
+	// goroutine WRITES in.baseEnrichment via TilePending.Apply. Spawning that
+	// gate before the loop finished would race the writes against these reads
+	// (concurrent map read+write → runtime crash, reachable under render-queue
+	// pressure where Apply fires synchronously). Deferring the single shared
+	// gate until every read is done makes the reads happen-before the write via
+	// goroutine-spawn ordering — mirroring dispatchPokemonAlert, whose loop
+	// never touches the gated map. Per-user tiles get their own gate in the loop
+	// (they write a per-user map, so there is no shared-map hazard).
+	var jobs []RenderJob
 	for _, user := range in.matched {
 		lang := user.Language
 		if lang == "" {
@@ -265,13 +272,7 @@ func (ps *ProcessorService) dispatchWeatherChange(in weatherChangeDispatchInput)
 			}
 		}
 
-		// Shared base tile → shared gate; per-user tile → its own gate.
-		gate := baseGate
-		if userTilePending != nil {
-			gate = ps.newTileGate(userTilePending)
-		}
-
-		ps.renderCh <- RenderJob{
+		job := RenderJob{
 			AlertType:         "weatherchange",
 			TemplateType:      "weatherchange",
 			Enrichment:        in.baseEnrichment,
@@ -279,10 +280,26 @@ func (ps *ProcessorService) dispatchWeatherChange(in weatherChangeDispatchInput)
 			WebhookFields:     in.webhookFields,
 			MatchedUsers:      []webhook.MatchedUser{user},
 			MatchedAreas:      in.matchedAreas,
-			TileGate:          gate,
 			OverrideCleanTTH:  overrideCleanTTH,
 			LogReference:      in.s2CellID,
 		}
+		// Per-user tile → its own gate now (writes a per-user map, no shared
+		// hazard). Shared-tile users are left with a nil gate and get the single
+		// shared baseGate attached below, after all baseEnrichment reads finish.
+		if userTilePending != nil {
+			job.TileGate = ps.newTileGate(userTilePending)
+		}
+		jobs = append(jobs, job)
+	}
+
+	// All in.baseEnrichment reads are complete — now spawn the single shared
+	// gate (nil when there is no shared base tile) and enqueue.
+	baseGate := ps.newTileGate(in.baseTilePending)
+	for i := range jobs {
+		if jobs[i].TileGate == nil {
+			jobs[i].TileGate = baseGate
+		}
+		ps.renderCh <- jobs[i]
 	}
 }
 

--- a/processor/cmd/processor/weather_test.go
+++ b/processor/cmd/processor/weather_test.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"testing"
+	"time"
 
+	"github.com/pokemon/poracleng/processor/internal/staticmap"
 	"github.com/pokemon/poracleng/processor/internal/webhook"
 )
 
@@ -50,5 +52,83 @@ func TestWeatherAlertCleanUntil(t *testing.T) {
 				t.Errorf("got %d, want %d", got, c.want)
 			}
 		})
+	}
+}
+
+// TestDispatchWeatherChange_SharedTileUsesSingleGate is the regression test for
+// the weather-change shared-tile bug: when the base weather tile is shared
+// across users (show_altered_pokemon_static_map off), every user's RenderJob
+// must resolve the tile through ONE shared tileGate. Wrapping the shared
+// *staticmap.TilePending in a gate per user meant its size-1 Result channel
+// delivered the URL to exactly one goroutine, so one message got the real tile
+// and the rest fell back to the fallback (pokemon) image. Clean users must also
+// share the base enrichment map (carrying their per-user TTH via
+// OverrideCleanTTH), not a pre-resolution copy that loses the tile.
+func TestDispatchWeatherChange_SharedTileUsesSingleGate(t *testing.T) {
+	ps, _, _ := minimalProcessor(t)
+	ch := make(chan RenderJob, 16)
+	ps.renderCh = ch
+
+	// A shared base weather tile: one non-nil pending with a past deadline so
+	// the gate goroutine resolves immediately (Apply is a no-op — no target).
+	baseTilePending := &staticmap.TilePending{
+		Result:    make(chan string, 1),
+		ResultImg: make(chan []byte, 1),
+		Deadline:  time.Now(),
+	}
+	baseEnrichment := map[string]any{"weatherName": "Sunny"}
+
+	now := time.Now().Unix()
+	matched := []webhook.MatchedUser{
+		{ID: "u1", Type: "discord:user", Language: "en"},
+		{ID: "u2", Type: "discord:user", Language: "en", Clean: 1, CaresUntil: now + 3600},
+		{ID: "u3", Type: "discord:user", Language: "en"},
+		{ID: "u4", Type: "discord:user", Language: "en"},
+	}
+
+	ps.dispatchWeatherChange(weatherChangeDispatchInput{
+		s2CellID:        "cell-1",
+		oldCondition:    5,
+		newCondition:    3,
+		baseEnrichment:  baseEnrichment,
+		baseTilePending: baseTilePending,
+		matched:         matched,
+		now:             now,
+		minAlert:        0,
+	})
+
+	jobs := drainRenderJobs(ch)
+	if len(jobs) != len(matched) {
+		t.Fatalf("expected %d render jobs, got %d", len(matched), len(jobs))
+	}
+
+	// THE FIX: one shared gate across all shared-tile jobs.
+	gates := map[*tileGate]int{}
+	for _, j := range jobs {
+		if j.TileGate == nil {
+			t.Fatalf("shared-tile job for %s has a nil TileGate", j.MatchedUsers[0].ID)
+		}
+		gates[j.TileGate]++
+	}
+	if len(gates) != 1 {
+		t.Errorf("shared base tile must use ONE gate across all %d users; got %d distinct gates (per-user gates on a shared pending is the bug)", len(jobs), len(gates))
+	}
+
+	// Every user (clean included) shares the base enrichment map — proven by a
+	// post-dispatch mutation being visible in every job — and clean users carry
+	// their per-user clean-deletion TTH via OverrideCleanTTH.
+	baseEnrichment["sharedMarker"] = "yes"
+	for _, j := range jobs {
+		uid := j.MatchedUsers[0].ID
+		if j.Enrichment["sharedMarker"] != "yes" {
+			t.Errorf("job for %s does not share baseEnrichment (got a copy) — clean users must share so they still get the resolved tile", uid)
+		}
+		if uid == "u2" {
+			if j.OverrideCleanTTH != now+3600 {
+				t.Errorf("clean user u2 OverrideCleanTTH = %d, want %d", j.OverrideCleanTTH, now+3600)
+			}
+		} else if j.OverrideCleanTTH != 0 {
+			t.Errorf("non-clean user %s OverrideCleanTTH = %d, want 0", uid, j.OverrideCleanTTH)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

Fixes a weather-change ("⚠️ Weather change ⚠️") delivery bug: when the base weather tile is **shared** across users (`show_altered_pokemon_static_map` off), only one user's message got the real weather-cell map and the rest showed a **fallback pokemon icon**.

## Root cause

`consumeWeatherChanges` wrapped the **shared** base-tile `*staticmap.TilePending` in a `tileGate` **per user**. The pending's `Result`/`ResultImg` are **size-1 channels delivered once**, so exactly one user's gate received the real tile URL and every other gate blocked to its deadline → `Apply(Fallback)` → the fallback image. The per-user gate goroutines also raced writing the shared `baseEnrichment` map. (1 correct map, N−1 fallback icons — matching the reported screenshot.)

## Fix

Extract `dispatchWeatherChange`, mirroring `dispatchPokemonAlert`'s tile handling:

- **Shared base tile → one gate** reused across all users: the tile resolves once and its URL is written once into the shared `baseEnrichment`, with `chan`-close happens-before making it visible to every render worker.
- **Per-user tiles** (`show_altered_pokemon_static_map` on) keep their own gate — each user's pending is distinct, so there is no sharing to coordinate.
- **Clean users** share `baseEnrichment` (so they still get the resolved tile) and carry their per-user clean-deletion TTH via `RenderJob.OverrideCleanTTH` instead of a pre-resolution **copy** of `baseEnrichment` that snapshotted the map before the async tile resolved (and so lost the tile). The weatherchange template renders no `tth` field, so clean-deletion timing (aligned to the last-tracked pokemon's despawn) is preserved with **zero display change**.

Adds a regression test asserting one shared gate + shared enrichment + per-user `OverrideCleanTTH`; it **fails on the old per-user-gate code** ("got 4 distinct gates") and passes on the fix.

## Stacked on #183

This branches off `feature/per-destination-delivery-lanes` (PR #183) so a combined user can test both features together. **Base is set to `feature/per-destination-delivery-lanes`**, so this PR's diff shows only the weather fix. Retarget to `develop` (or merge after) once #183 lands.

## Testing

`go build ./... && go vet ./... && go test -race ./... && golangci-lint run ./...` — all green (45 packages, 0 races, 0 lint issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
