### PR TITLE
fix(autocreate): don't move same-named channels across categories

### DIFF
--- a/processor/internal/discordbot/autocreate.go
+++ b/processor/internal/discordbot/autocreate.go
@@ -105,7 +105,6 @@ type applyAutocreateResult struct {
 	ChannelsCreated       int // channel had to be created (not reused)
 	ChannelsReused        int // channel was found and reused as-is
 	ChannelsReset         int // channel was reused with tracking reset (interactive / reset keyword)
-	ChannelsMoved         int // channel adopted from another category and moved into the canonical one
 	ThreadsCreated        int // thread had to be created (or would-be in dry-run)
 	ThreadsReused         int // thread was found and reused as-is
 	ThreadsReset          int // thread was reused with tracking reset
@@ -460,36 +459,14 @@ func (b *Bot) applyAutocreate(
 		// tweaked tracking is preserved.
 		var channel *discordgo.Channel
 		var channelReused bool
-		// Look in the chosen category first; if the channel exists somewhere
-		// else in the guild (stranded under a stale category from a previous
-		// run, or moved by an admin), adopt it and move it into the canonical
-		// category rather than creating a duplicate.
+		// Reuse a channel only when it already lives UNDER THIS CATEGORY, so a
+		// re-run of !autocreate is idempotent. We deliberately do NOT adopt a
+		// same-named channel from elsewhere in the guild: channels routinely
+		// share names across categories (e.g. City 1/100 and City 2/100), so a
+		// guild-wide name match would relocate an unrelated channel into this
+		// category. When the name isn't found under this category, create anew.
 		existingID := snap.findChannel(categoryID, channelName)
-		var movedFromParent string
-		if existingID == "" {
-			if anyID, otherParent := snap.findChannelAnyParent(channelName); anyID != "" && otherParent != categoryID {
-				existingID = anyID
-				movedFromParent = otherParent
-			}
-		}
 		if existingID != "" {
-			if movedFromParent != "" {
-				result.ChannelsMoved++
-				if opts.DryRun {
-					rep.Info(fmt.Sprintf(">> [dry-run] Would move existing channel %s into category %s", channelName, categoryID))
-					snap.removeChannel(existingID, movedFromParent, channelName)
-					snap.addChannel(existingID, categoryID, channelName)
-				} else {
-					if _, err := s.ChannelEditComplex(existingID, &discordgo.ChannelEdit{ParentID: categoryID}); err != nil {
-						rep.Warn(fmt.Sprintf("Failed to move channel %s into %s: %v", channelName, categoryID, err))
-						result.Errors = append(result.Errors, err)
-					} else {
-						rep.Info(fmt.Sprintf(">> Moved existing channel %s into %s", channelName, categoryID))
-						snap.removeChannel(existingID, movedFromParent, channelName)
-						snap.addChannel(existingID, categoryID, channelName)
-					}
-				}
-			}
 			if opts.ResetOnReuse {
 				result.ChannelsReset++
 				rep.Info(fmt.Sprintf(">> Reusing existing channel %s — resetting tracking", channelName))
@@ -1349,9 +1326,9 @@ func formatSyncSummary(r SyncOneRuleResult) string {
 	if r.CategoriesCreated > 0 {
 		fmt.Fprintf(&b, "Categories: %d created\n", r.CategoriesCreated)
 	}
-	if r.ChannelsCreated+r.ChannelsMoved+r.ChannelsReset+r.ChannelsRemoved+r.ChannelsTemplateOrphan > 0 {
-		fmt.Fprintf(&b, "Channels: %d created, %d moved, %d reset, %d removed, %d reused\n",
-			r.ChannelsCreated, r.ChannelsMoved, r.ChannelsReset, r.ChannelsRemoved, r.ChannelsReused)
+	if r.ChannelsCreated+r.ChannelsReset+r.ChannelsRemoved+r.ChannelsTemplateOrphan > 0 {
+		fmt.Fprintf(&b, "Channels: %d created, %d reset, %d removed, %d reused\n",
+			r.ChannelsCreated, r.ChannelsReset, r.ChannelsRemoved, r.ChannelsReused)
 		if r.ChannelsTemplateOrphan > 0 {
 			fmt.Fprintf(&b, "  (%d cached channel(s) no longer in template — re-run with `removals` to delete; rule.remove_missing must also be true)\n",
 				r.ChannelsTemplateOrphan)

--- a/processor/internal/discordbot/autocreate_crosscategory_test.go
+++ b/processor/internal/discordbot/autocreate_crosscategory_test.go
@@ -1,0 +1,110 @@
+package discordbot
+
+import (
+	"testing"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+func newTestSnapshot() *guildSnapshot {
+	return &guildSnapshot{
+		channels:                  map[string]*discordgo.Channel{},
+		categoriesByLowerName:     map[string]string{},
+		channelsByParentLowerName: map[string]map[string]string{},
+		threads:                   map[string]bool{},
+		rolesByLowerName:          map[string]string{},
+	}
+}
+
+// TestApplyAutocreate_SameChannelNameDifferentCategory is the regression test
+// for the reported bug: creating a new category (City 2) whose channels share
+// names with an existing category (City 1) must CREATE new channels under City
+// 2, never adopt/move City 1's same-named channels. The old code fell back to a
+// guild-wide name lookup (findChannelAnyParent) and relocated City 1/100 into
+// City 2. Runs in dry-run (no Discord/DB writes) with both categories already
+// present and roles: null, so applyAutocreate makes no session calls.
+func TestApplyAutocreate_SameChannelNameDifferentCategory(t *testing.T) {
+	snap := newTestSnapshot()
+	snap.addCategory("cat-city1", "City 1")
+	snap.addCategory("cat-city2", "City 2")
+	// City 1 already owns a "100" channel.
+	snap.addChannel("ch-city1-100", "cat-city1", "100")
+
+	tmpl := &channelTemplate{
+		Name: "city 2",
+		Definition: channelDefinition{
+			Category: &categoryDefinition{CategoryName: "City 2"}, // reused, no roles
+			Channels: []channelEntry{
+				{ChannelName: "100", ChannelType: "text", ControlType: "bot"},
+			},
+		},
+	}
+
+	b := &Bot{}
+	rep := &collectingReporter{}
+	result := b.applyAutocreate(
+		nil, // session — unused in this dry-run shape (reused category, roles:null, no threads/commands)
+		&autocreateActor{UserID: "u1", UserName: "tester"},
+		snap,
+		tmpl,
+		nil, // args
+		nil, // rawArgs
+		"guild-1",
+		rep,
+		applyAutocreateOptions{DryRun: true},
+	)
+
+	// City 2/100 must be a NEW channel, not City 1's existing one.
+	if got := result.ChannelIDs["100"]; got == "ch-city1-100" {
+		t.Fatalf("City 2/100 reused City 1's channel (%s) — the cross-category steal has regressed", got)
+	}
+	if result.ChannelsCreated != 1 {
+		t.Errorf("ChannelsCreated = %d, want 1 (City 2/100 created fresh)", result.ChannelsCreated)
+	}
+	if result.ChannelsReused != 0 {
+		t.Errorf("ChannelsReused = %d, want 0", result.ChannelsReused)
+	}
+
+	// City 1's "100" is untouched — still under City 1's category.
+	if got := snap.findChannel("cat-city1", "100"); got != "ch-city1-100" {
+		t.Errorf("City 1's 100 channel = %q, want ch-city1-100 (must not be moved/removed)", got)
+	}
+	// The new channel is registered under City 2's category.
+	if got := snap.findChannel("cat-city2", "100"); got == "" || got == "ch-city1-100" {
+		t.Errorf("City 2/100 = %q, want a fresh channel under City 2", got)
+	}
+}
+
+// TestApplyAutocreate_ReusesChannelInSameCategory confirms the idempotent path
+// still works: re-running the same template reuses the channel already under
+// that category (rather than creating a duplicate).
+func TestApplyAutocreate_ReusesChannelInSameCategory(t *testing.T) {
+	snap := newTestSnapshot()
+	snap.addCategory("cat-city2", "City 2")
+	snap.addChannel("ch-city2-100", "cat-city2", "100") // already exists under City 2
+
+	tmpl := &channelTemplate{
+		Name: "city 2",
+		Definition: channelDefinition{
+			Category: &categoryDefinition{CategoryName: "City 2"},
+			Channels: []channelEntry{
+				{ChannelName: "100", ChannelType: "text", ControlType: "bot"},
+			},
+		},
+	}
+
+	b := &Bot{}
+	rep := &collectingReporter{}
+	result := b.applyAutocreate(nil, &autocreateActor{UserID: "u1"}, snap, tmpl, nil, nil, "guild-1", rep,
+		applyAutocreateOptions{DryRun: true})
+
+	if result.ChannelsReused != 1 {
+		t.Errorf("ChannelsReused = %d, want 1 (existing City 2/100 reused)", result.ChannelsReused)
+	}
+	if result.ChannelsCreated != 0 {
+		t.Errorf("ChannelsCreated = %d, want 0", result.ChannelsCreated)
+	}
+	if got := result.ChannelIDs["100"]; got != "ch-city2-100" {
+		t.Errorf("reused channel ID = %q, want ch-city2-100", got)
+	}
+}

--- a/processor/internal/discordbot/autocreate_sync.go
+++ b/processor/internal/discordbot/autocreate_sync.go
@@ -218,7 +218,6 @@ type SyncOneRuleResult struct {
 	ChannelsCreated        int
 	ChannelsReused         int
 	ChannelsReset          int
-	ChannelsMoved          int
 	ChannelsRemoved        int // template-orphan channels actually removed
 	ChannelsTemplateOrphan int // template-orphan channels logged as would-remove (no removals flag)
 	ThreadsCreated         int
@@ -330,7 +329,6 @@ func accumulateApplyCounters(res *SyncOneRuleResult, ar applyAutocreateResult) {
 	res.ChannelsCreated += ar.ChannelsCreated
 	res.ChannelsReused += ar.ChannelsReused
 	res.ChannelsReset += ar.ChannelsReset
-	res.ChannelsMoved += ar.ChannelsMoved
 	res.ThreadsCreated += ar.ThreadsCreated
 	res.ThreadsReused += ar.ThreadsReused
 	res.ThreadsReset += ar.ThreadsReset
@@ -825,18 +823,6 @@ func (s *guildSnapshot) findChannelAnyParent(name string) (string, string) {
 		}
 	}
 	return "", ""
-}
-
-// removeChannel drops a channel from the by-parent index. Used after a
-// move so subsequent same-sync lookups under the old parent miss it.
-func (s *guildSnapshot) removeChannel(id, parentID, name string) {
-	if s == nil {
-		return
-	}
-	if byName, ok := s.channelsByParentLowerName[parentID]; ok {
-		delete(byName, normalizeDiscordChannelName(name))
-	}
-	delete(s.channels, id)
 }
 
 // channelExists reports whether the given channel/category ID is in the


### PR DESCRIPTION
## Summary

`!autocreate` was **moving existing channels across categories** instead of creating new ones. Creating a second category (e.g. **City 2**) whose channels share names with an existing category (**City 1** — `100`, `pvp-rank-1`, `xxl`, …) relocated City 1's channels into City 2.

## Root cause

For each templated channel, autocreate looked it up **under the target category** (`snap.findChannel(categoryID, name)`) — correct for idempotent re-runs — but then fell back to `snap.findChannelAnyParent(name)`, a **guild-wide** name lookup, and if a same-named channel existed under a *different* parent it **moved** it into the target category (`ChannelEditComplex{ParentID: categoryID}`).

That fallback's own doc comment shows its origin: a workaround to consolidate "cross-category duplicates from before the snapshot-freshness fix." It assumed same-named channels across categories are stray duplicates — but one `100` channel per city is a normal, intentional layout, so it stole City 1's channels. (With several same-named channels it was also nondeterministic — `findChannelAnyParent` returns whichever parent Go's map iteration hits first.)

## Fix

Remove the cross-parent reclaim entirely: **reuse a channel only when it already lives under the target category; otherwise create a new one.** No guild-wide adoption, no moving. Also removes the now-dead `ChannelsMoved` counter, its summary line, and the orphaned `guildSnapshot.removeChannel` helper.

Result: creating **City 2** now creates fresh `100 / 96-98 / zero / pvp-rank-1 / xxl / xxs` channels under City 2 and leaves City 1's channels in place.

## Testing

Two new regression tests drive `applyAutocreate` in dry-run:
- a shared channel name across categories creates a **fresh** channel and leaves City 1's untouched (sabotage-verified: fails with the old cross-category adopt re-added),
- the same-category reuse path still works (idempotent re-run).

`go build ./... && go vet ./... && go test ./... && golangci-lint run ./...` — all green (45 packages, 0 lint issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
