### PR TITLE
fix: !lure multi-type tracking + autocreate silent command failures

### DIFF
--- a/processor/internal/bot/argmatch.go
+++ b/processor/internal/bot/argmatch.go
@@ -76,10 +76,10 @@ func NewArgMatcher(bundle *i18n.Bundle, gd *gamedata.GameData, resolver *Pokemon
 
 		// Lure types — accept pogo-translations keys lure_501..lure_506
 		// (resources/gamelocale/) in addition to the legacy arg.* keys.
-		// The lure_N values are added last so they take precedence over
-		// arg.normal if they ever collide in the user's language.
+		// "normal" is the plain Lure Module (501); 0 is reserved for the
+		// "any lure" DB sentinel and must never come from a name match.
 		lures := make(map[string]int)
-		lures[strings.ToLower(tr.T("arg.normal"))] = 0
+		lures[strings.ToLower(tr.T("arg.normal"))] = 501
 		lures[strings.ToLower(tr.T("arg.glacial"))] = 502
 		lures[strings.ToLower(tr.T("arg.mossy"))] = 503
 		lures[strings.ToLower(tr.T("arg.magnetic"))] = 504
@@ -383,6 +383,16 @@ func (am *ArgMatcher) Match(tokens []string, params []ParamDef, lang string) *Pa
 				}
 			}
 		}
+		if param.Type == ParamLureType {
+			for i, tok := range tokens {
+				if consumed[i] {
+					continue
+				}
+				if am.tryLureType(tok, lang, result) {
+					consumed[i] = true
+				}
+			}
+		}
 		if param.Type == ParamPokemonName {
 			for i, tok := range tokens {
 				if consumed[i] {
@@ -428,8 +438,8 @@ var matchPriorities = []ParamType{
 	ParamKeyword,
 	ParamTeam,
 	ParamGender,
-	ParamLureType,
-	// ParamTypeName and ParamPokemonName handled separately (collect all matches)
+	// ParamLureType, ParamTypeName and ParamPokemonName handled separately
+	// (collect all matches)
 }
 
 func (am *ArgMatcher) tryMatch(tok string, param ParamDef, lang string, result *ParsedArgs) bool {
@@ -726,10 +736,10 @@ func (am *ArgMatcher) tryGender(tok, lang string, result *ParsedArgs) bool {
 	return false
 }
 
-// tryLureType matches lure type names.
+// tryLureType matches a lure type name and adds its ID to result.LureTypes.
 func (am *ArgMatcher) tryLureType(tok, lang string, result *ParsedArgs) bool {
 	if id, ok := am.lookupInLangMaps(tok, lang, am.lureMap); ok {
-		result.LureType = id
+		result.LureTypes = append(result.LureTypes, id)
 		return true
 	}
 	return false

--- a/processor/internal/bot/argmatch_test.go
+++ b/processor/internal/bot/argmatch_test.go
@@ -301,13 +301,34 @@ func TestArgMatchLureType(t *testing.T) {
 	params := []ParamDef{{Type: ParamLureType}}
 
 	result := am.Match([]string{"glacial"}, params, "en")
-	if result.LureType != 502 {
-		t.Errorf("lure = %d, want 502", result.LureType)
+	if len(result.LureTypes) != 1 || result.LureTypes[0] != 502 {
+		t.Errorf("lure = %v, want [502]", result.LureTypes)
 	}
 
 	result = am.Match([]string{"mossy"}, params, "en")
-	if result.LureType != 503 {
-		t.Errorf("lure = %d, want 503", result.LureType)
+	if len(result.LureTypes) != 1 || result.LureTypes[0] != 503 {
+		t.Errorf("lure = %v, want [503]", result.LureTypes)
+	}
+
+	// "normal" is the plain Lure Module (501), not the 0 "any" sentinel.
+	result = am.Match([]string{"normal"}, params, "en")
+	if len(result.LureTypes) != 1 || result.LureTypes[0] != 501 {
+		t.Errorf("lure = %v, want [501]", result.LureTypes)
+	}
+
+	// Multiple lure names in one command all collect.
+	result = am.Match([]string{"normal", "glacial", "mossy", "magnetic", "sparkly"}, params, "en")
+	want := []int{501, 502, 503, 504, 506}
+	if len(result.LureTypes) != len(want) {
+		t.Fatalf("lure = %v, want %v", result.LureTypes, want)
+	}
+	for i, id := range want {
+		if result.LureTypes[i] != id {
+			t.Errorf("lure[%d] = %d, want %d", i, result.LureTypes[i], id)
+		}
+	}
+	if len(result.Unrecognized) != 0 {
+		t.Errorf("unrecognized = %v, want none", result.Unrecognized)
 	}
 }
 

--- a/processor/internal/bot/commands/lure.go
+++ b/processor/internal/bot/commands/lure.go
@@ -63,17 +63,21 @@ func (c *LureCommand) Run(ctx *bot.CommandContext, args []string) []bot.Reply {
 		return []bot.Reply{*overrideReply}
 	}
 
-	// Collect lure IDs
-	lureIDs := []int{}
-	if parsed.LureType != 0 || parsed.HasKeyword("arg.everything") {
-		if parsed.HasKeyword("arg.everything") {
-			lureIDs = append(lureIDs, 0) // 0 = any lure
-		} else {
-			lureIDs = append(lureIDs, parsed.LureType)
+	// Collect lure IDs — one tracking rule per named type, or the 0
+	// sentinel (any lure) for the everything keyword.
+	var lureIDs []int
+	switch {
+	case parsed.HasKeyword("arg.everything"):
+		lureIDs = []int{0}
+	case len(parsed.LureTypes) > 0:
+		seen := make(map[int]bool)
+		for _, id := range parsed.LureTypes {
+			if !seen[id] {
+				seen[id] = true
+				lureIDs = append(lureIDs, id)
+			}
 		}
-	} else if parsed.LureType == 0 && !parsed.HasKeyword("arg.everything") {
-		// Check if a lure type name matched with ID 0 (normal)
-		// If no lure type at all, show error
+	default:
 		return []bot.Reply{{React: "🙅", Text: tr.T("msg.no_lure_type")}}
 	}
 

--- a/processor/internal/bot/commands/lure_test.go
+++ b/processor/internal/bot/commands/lure_test.go
@@ -79,6 +79,73 @@ func TestLure_Glacial(t *testing.T) {
 	assert.NotEqual(t, 0, rows[0].LureID, "glacial should have a specific lure ID")
 }
 
+// "normal" is a real lure type (Lure Module, 501) — it must create a
+// specific-type rule, not collide with the 0 "any lure" sentinel and
+// error out with "No lure type specified".
+func TestLure_Normal(t *testing.T) {
+	ctx := lureCtx(t)
+	replies := runLure(t, ctx, "normal")
+
+	require.NotEmpty(t, replies)
+	assert.Equal(t, "✅", replies[0].React, "reply: %s", replies[0].Text)
+
+	rows, _ := ctx.Tracking.Lures.SelectByIDProfile("user1", 1)
+	require.Len(t, rows, 1)
+	assert.Equal(t, 501, rows[0].LureID)
+}
+
+// Multiple lure types in one command create one rule per type. Before
+// LureTypes collected all matches, only the first name was consumed and
+// the rest were rejected as "Unrecognized".
+func TestLure_MultipleTypes(t *testing.T) {
+	ctx := lureCtx(t)
+	replies := runLure(t, ctx, "normal glacial mossy magnetic sparkly clean")
+
+	require.NotEmpty(t, replies)
+	assert.Equal(t, "✅", replies[0].React, "reply: %s", replies[0].Text)
+
+	rows, _ := ctx.Tracking.Lures.SelectByIDProfile("user1", 1)
+	require.Len(t, rows, 5)
+	gotIDs := make(map[int]bool)
+	for _, r := range rows {
+		gotIDs[r.LureID] = true
+		assert.Equal(t, 1, r.Clean&1, "clean bit should be set on lure %d", r.LureID)
+	}
+	for _, want := range []int{501, 502, 503, 504, 506} {
+		assert.True(t, gotIDs[want], "missing rule for lure %d (got %v)", want, gotIDs)
+	}
+}
+
+// Repeated lure names collapse to a single rule rather than duplicate
+// inserts for the same type.
+func TestLure_DuplicateTypesDeduped(t *testing.T) {
+	ctx := lureCtx(t)
+	replies := runLure(t, ctx, "glacial glacial")
+
+	require.NotEmpty(t, replies)
+	assert.Equal(t, "✅", replies[0].React, "reply: %s", replies[0].Text)
+
+	rows, _ := ctx.Tracking.Lures.SelectByIDProfile("user1", 1)
+	require.Len(t, rows, 1)
+	assert.Equal(t, 502, rows[0].LureID)
+}
+
+// Removing one named type only deletes that type's rule.
+func TestLure_RemoveOneOfMany(t *testing.T) {
+	ctx := lureCtx(t)
+	runLure(t, ctx, "normal glacial")
+	rows, _ := ctx.Tracking.Lures.SelectByIDProfile("user1", 1)
+	require.Len(t, rows, 2)
+
+	replies := runLure(t, ctx, "remove normal")
+	require.NotEmpty(t, replies)
+	assert.Equal(t, "✅", replies[0].React, "reply: %s", replies[0].Text)
+
+	rows, _ = ctx.Tracking.Lures.SelectByIDProfile("user1", 1)
+	require.Len(t, rows, 1)
+	assert.Equal(t, 502, rows[0].LureID, "glacial rule should survive")
+}
+
 // `!lure <type> edit` must set Clean bit 2 (db.IsEdit). Without
 // arg.edit in lureParams the matcher would warn "unrecognized" and
 // the edit flag would never propagate, defeating the EditKey wiring

--- a/processor/internal/bot/commands/tracked_test.go
+++ b/processor/internal/bot/commands/tracked_test.go
@@ -1,0 +1,46 @@
+package commands
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/pokemon/poracleng/processor/internal/db"
+	"github.com/pokemon/poracleng/processor/internal/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fillAllTrackingStores populates every store the tracked command queries;
+// a nil store interface would panic on SelectByIDProfile.
+func fillAllTrackingStores(ts *store.TrackingStores) {
+	ts.Monsters = store.NewMockTrackingStore[db.MonsterTrackingAPI](store.MonsterGetUID, store.MonsterSetUID)
+	ts.Raids = store.NewMockTrackingStore[db.RaidTrackingAPI](store.RaidGetUID, store.RaidSetUID)
+	ts.Eggs = store.NewMockTrackingStore[db.EggTrackingAPI](store.EggGetUID, store.EggSetUID)
+	ts.Quests = store.NewMockTrackingStore[db.QuestTrackingAPI](store.QuestGetUID, store.QuestSetUID)
+	ts.Invasions = store.NewMockTrackingStore[db.InvasionTrackingAPI](store.InvasionGetUID, store.InvasionSetUID)
+	ts.Gyms = store.NewMockTrackingStore[db.GymTrackingAPI](store.GymGetUID, store.GymSetUID)
+	ts.Nests = store.NewMockTrackingStore[db.NestTrackingAPI](store.NestGetUID, store.NestSetUID)
+	ts.Forts = store.NewMockTrackingStore[db.FortTrackingAPI](store.FortGetUID, store.FortSetUID)
+	ts.Maxbattles = store.NewMockTrackingStore[db.MaxbattleTrackingAPI](store.MaxbattleGetUID, store.MaxbattleSetUID)
+}
+
+// A lure rule created via !lure must show up in the !tracked listing.
+func TestTracked_ShowsLures(t *testing.T) {
+	ctx := lureCtx(t)
+	fillAllTrackingStores(ctx.Tracking)
+
+	replies := runLure(t, ctx, "everything clean")
+	require.NotEmpty(t, replies)
+	require.Equal(t, "✅", replies[0].React, "lure command failed: %s", replies[0].Text)
+
+	tracked := &TrackedCommand{}
+	trackedReplies := tracked.Run(ctx, nil)
+	require.NotEmpty(t, trackedReplies)
+	var all strings.Builder
+	for _, r := range trackedReplies {
+		all.WriteString(r.Text)
+		all.WriteByte('\n')
+	}
+	assert.Contains(t, all.String(), "Lures", "lure section missing from !tracked")
+	assert.NotContains(t, all.String(), "not tracking any lures")
+}

--- a/processor/internal/bot/params.go
+++ b/processor/internal/bot/params.go
@@ -70,8 +70,9 @@ type ParsedArgs struct {
 	Pokemon []ResolvedPokemon
 	// Type IDs matched by name
 	Types []int
-	// Lure type ID (0=any/unset, 501-506)
-	LureType int
+	// Lure type IDs matched by name (501-506). "any" is expressed via the
+	// everything keyword, never by a name match, so 0 never appears here.
+	LureTypes []int
 	// Raid levels matched by name (e.g. "legendary" → [5])
 	RaidLevels []int
 	// PVP filters by league key: "great" → {Best:1, Worst:5, MinCP:0}

--- a/processor/internal/discordbot/autocreate.go
+++ b/processor/internal/discordbot/autocreate.go
@@ -670,11 +670,30 @@ func (b *Bot) applyAutocreate(
 	return result
 }
 
+// reportCommandFailures surfaces failed command replies (🙅 react) through
+// the reporter. Both autocreate paths need this: the bulk runner discards
+// replies entirely, and the interactive path's synthetic reply message has
+// no message ID, so the failure react can never be attached. Without this
+// a broken command in a template (typo, unrecognized filter) runs silently.
+func reportCommandFailures(rep reporter, expanded string, replies []bot.Reply) {
+	for _, r := range replies {
+		if r.React != "🙅" {
+			continue
+		}
+		text := r.Text
+		if text == "" {
+			text = "command failed"
+		}
+		rep.Warn(fmt.Sprintf("❌ %s: %s", expanded, text))
+	}
+}
+
 // runOneAutocreateCommand parses one !-prefixed command string and
 // executes it through the shared registry as the named target. Used by
 // both the per-channel and per-thread command-execution loops.
-// rep is used to surface unknown-command warnings in both interactive and
-// bulk paths (the bulk path has no Discord channel to send to directly).
+// rep is used to surface unknown-command and failed-command warnings in
+// both interactive and bulk paths (the bulk path has no Discord channel
+// to send to directly).
 func (b *Bot) runOneAutocreateCommand(s *discordgo.Session, actor *autocreateActor, rep reporter, guildID, targetID, targetName, targetType, expanded string) {
 	parsed := b.Parser.Parse(b.Cfg.Discord.Prefix + expanded)
 	for _, pc := range parsed {
@@ -745,16 +764,29 @@ func (b *Bot) runOneAutocreateCommand(s *discordgo.Session, actor *autocreateAct
 		}
 
 		replies := handler.Run(ctx, pc.Args)
-		// For the interactive path (actor has a ChannelID) send replies back
-		// to the originating channel. For the bulk path (no ChannelID) there
-		// is no Discord message to reference, so replies are discarded here —
-		// the reporter collects all user-visible output instead.
+		reportCommandFailures(rep, expanded, replies)
+		// For the interactive path (actor has a ChannelID) send the
+		// remaining (non-failure) replies back to the originating channel —
+		// failures were already surfaced with command context via the
+		// reporter above. For the bulk path (no ChannelID) there is no
+		// Discord message to reference, so replies are discarded here — the
+		// reporter collects all user-visible output instead.
 		if actor.ChannelID != "" {
+			var rest []bot.Reply
+			for _, r := range replies {
+				if r.React == "🙅" {
+					continue
+				}
+				rest = append(rest, r)
+			}
+			if len(rest) == 0 {
+				continue
+			}
 			synth := &discordgo.MessageCreate{Message: &discordgo.Message{
 				ChannelID: actor.ChannelID,
 				Author:    &discordgo.User{ID: actor.UserID, Username: actor.UserName},
 			}}
-			b.sendReplies(s, synth, replies)
+			b.sendReplies(s, synth, rest)
 		}
 	}
 }

--- a/processor/internal/discordbot/autocreate_command_test.go
+++ b/processor/internal/discordbot/autocreate_command_test.go
@@ -1,0 +1,52 @@
+package discordbot
+
+import (
+	"testing"
+
+	"github.com/pokemon/poracleng/processor/internal/bot"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A failed template command (🙅 react) must surface through the reporter —
+// the bulk path has no Discord channel, and the interactive path's
+// synthetic reply message can't carry reacts, so without this the failure
+// is completely invisible to the operator.
+func TestReportCommandFailures(t *testing.T) {
+	rep := &collectingReporter{}
+	reportCommandFailures(rep, "lure normal glacial mossy", []bot.Reply{
+		{React: "🙅", Text: "Unrecognized: glacial, mossy"},
+	})
+	require.Len(t, rep.warns, 1)
+	assert.Contains(t, rep.warns[0], "lure normal glacial mossy")
+	assert.Contains(t, rep.warns[0], "Unrecognized: glacial, mossy")
+}
+
+func TestReportCommandFailures_SuccessStaysQuiet(t *testing.T) {
+	rep := &collectingReporter{}
+	reportCommandFailures(rep, "lure everything clean", []bot.Reply{
+		{React: "✅", Text: "Tracking: any lure"},
+		{React: "👌"},
+	})
+	assert.Empty(t, rep.warns)
+}
+
+// Some commands fail with a bare react and no text (e.g. store errors);
+// the reporter line still has to appear.
+func TestReportCommandFailures_NoText(t *testing.T) {
+	rep := &collectingReporter{}
+	reportCommandFailures(rep, "lure everything", []bot.Reply{{React: "🙅"}})
+	require.Len(t, rep.warns, 1)
+	assert.Contains(t, rep.warns[0], "lure everything")
+}
+
+// The escaped spelling "\U0001f645" is the same rune as "🙅" — both must
+// be caught.
+func TestReportCommandFailures_EscapedReact(t *testing.T) {
+	rep := &collectingReporter{}
+	reportCommandFailures(rep, "lure everything", []bot.Reply{
+		{React: "\U0001f645", Text: "This alert type is disabled"},
+	})
+	require.Len(t, rep.warns, 1)
+	assert.Contains(t, rep.warns[0], "disabled")
+}

--- a/processor/internal/discordbot/bot.go
+++ b/processor/internal/discordbot/bot.go
@@ -753,16 +753,22 @@ func (b *Bot) handleDiscordCommand(s *discordgo.Session, m *discordgo.MessageCre
 }
 
 func (b *Bot) sendReplies(s *discordgo.Session, m *discordgo.MessageCreate, replies []bot.Reply) {
-	// Reference the original message so responses show as replies
-	ref := &discordgo.MessageReference{
-		MessageID: m.ID,
-		ChannelID: m.ChannelID,
-		GuildID:   m.GuildID,
+	// Reference the original message so responses show as replies.
+	// Synthetic messages (e.g. autocreate command runs) have no ID —
+	// nothing to react to or reference, and Discord rejects a
+	// message_reference with an empty message_id, so plain sends only.
+	var ref *discordgo.MessageReference
+	if m.ID != "" {
+		ref = &discordgo.MessageReference{
+			MessageID: m.ID,
+			ChannelID: m.ChannelID,
+			GuildID:   m.GuildID,
+		}
 	}
 
 	for _, reply := range replies {
 		// React
-		if reply.React != "" {
+		if reply.React != "" && m.ID != "" {
 			s.MessageReactionAdd(m.ChannelID, m.ID, reply.React)
 		}
 
@@ -808,7 +814,9 @@ func (b *Bot) sendReplies(s *discordgo.Session, m *discordgo.MessageCreate, repl
 				if i == 0 && msgRef != nil {
 					msgSend.Reference = msgRef
 				}
-				s.ChannelMessageSendComplex(targetChannel, msgSend)
+				if _, err := s.ChannelMessageSendComplex(targetChannel, msgSend); err != nil {
+					log.Warnf("discord bot: send reply: %v", err)
+				}
 			}
 		}
 


### PR DESCRIPTION
## Summary

Two bugs found via an `!autocreate` template running `lure normal glacial mossy magnetic sparkly clean`:

### `!lure` couldn't track multiple types (or `normal` at all)

- `ParamLureType` was in the arg matcher's match-at-most-one-token priority list, so only the first lure name was consumed — the rest were rejected as `Unrecognized: glacial, mossy, magnetic, sparkly`. Lure types now collect like pokemon/type names (`ParsedArgs.LureTypes []int`), and `!lure` creates one tracking rule per named type (deduped).
- `normal` mapped to lure ID **0**, colliding with both the command's "unset" sentinel and the DB's "any lure" meaning — `!lure normal` alone always errored with "No lure type specified". It now maps to **501** (Lure Module), consistent with the `lure_501` pogo-translations name that already mapped there. This also fixes slash `/lure lure_type:Normal`, which failed the same way.

### autocreate swallowed command failures entirely

The failing lure command above produced no error output from `!autocreate`, even though the handler returned a 🙅 failure reply. Delivery was broken three ways:

1. the react targeted the synthetic reply message, which has **no message ID** — API call failed, error ignored
2. the reply text carried a `message_reference` with an empty `message_id` (discordgo's `MessageReference.MessageID` has no `omitempty`), which Discord rejects with a 400 — send error discarded
3. the bulk-sync path discards replies by design in favour of the reporter, but failures were never fed into the reporter

Failed replies now surface through the reporter with command context (`❌ lure normal …: Unrecognized: …`) on both interactive and bulk paths, excluded from the inline send to avoid double-reporting. `sendReplies` is synthetic-message-safe (skips react/reference when the message has no ID) so non-failure replies from autocreate commands now reach the channel too, and the previously ignored `ChannelMessageSendComplex` error is logged.

## Test plan

- New regression tests: multi-type `!lure` (5 rules, clean bit), `normal` → 501, repeated-name dedupe, `remove normal` only deleting the normal rule, first `TrackedCommand` coverage (lure rules listed in `!tracked`), and 4 cases for `reportCommandFailures` (incl. the `\U0001f645` escaped spelling of 🙅)
- Full gate green from `processor/`: `go build`, `go vet`, `go test -count=1 ./...` (45 packages), `golangci-lint run` (0 issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)