### PR TITLE
perf: cut processor RSS 6.4x, 6436 MB -> 1000 MB (bucketed rarity ring + dedup fingerprints + tzf DefaultFinder)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -219,7 +219,7 @@ The processor renders DTS templates using `jfberry/raymond` (a fork of `mailgun/
 
 **Queue pressure**: When the render channel is >80% full, tile generation is skipped to reduce backpressure.
 
-**Shutdown ordering** (`ProcessorService.Close` in `cmd/processor/main.go`): webhook workers → render channel (close) → render workers (drain) → dispatcher (stop, which stops its queue and tracker) → static map (close) → duplicates → rate limiter → gym state save → geocoder (close).
+**Shutdown ordering** (`ProcessorService.Close` in `cmd/processor/main.go`): webhook workers → render channel (close) → render workers (drain) → dispatcher (stop, which stops its queue and tracker) → static map (close) → duplicates → weather tracker (stops the cell-eviction sweep) → rate limiter → gym state save → geocoder (close).
 
 ### 6. Message Delivery (Processor)
 

--- a/processor/cmd/processor/main.go
+++ b/processor/cmd/processor/main.go
@@ -1792,6 +1792,10 @@ func (ps *ProcessorService) Close() {
 		ps.enricher.StaticMap.Close()
 	}
 	ps.duplicates.Close()
+	// Weather eviction runs on its own ticker and touches the same maps the
+	// enrichment path reads, so it stops here with the other trackers, once
+	// the webhook and render workers are already quiescent.
+	ps.weather.Close()
 	ps.rateLimiter.Close()
 	// Persist gym state cache for restart
 	if err := ps.gymState.Save(); err != nil {

--- a/processor/cmd/processor/main.go
+++ b/processor/cmd/processor/main.go
@@ -1574,6 +1574,9 @@ func NewProcessorService(cfg *config.Config, stateMgr *state.Manager, database *
 			LocalFirstFetchHOD:      cfg.Weather.LocalFirstFetchHOD,
 			SmartForecast:           cfg.Weather.SmartForecast,
 		}, weatherTracker)
+		// The forecast client keys its own maps by the same cell ids, so it
+		// has to release them when the tracker reclaims a cell.
+		weatherTracker.SetOnEvict(awClient.ForgetCells)
 		enricher.ForecastProvider = awClient
 		log.Infof("AccuWeather forecast enabled with %d API keys", len(cfg.Weather.AccuWeatherAPIKeys))
 	}

--- a/processor/cmd/processor/main.go
+++ b/processor/cmd/processor/main.go
@@ -1379,7 +1379,11 @@ func NewProcessorService(cfg *config.Config, stateMgr *state.Manager, database *
 			cfg.Locale.TimeFormat, geo.SupportedLocales())
 	}
 
-	weatherTracker := tracker.NewWeatherTracker()
+	// Idle expiry has to outlast the configured forecast cadence, or
+	// forecast-only cells get reclaimed between pushes.
+	weatherTracker := tracker.NewWeatherTracker(
+		tracker.WithForecastRefreshInterval(cfg.Weather.ForecastRefreshInterval),
+	)
 	timeLayout := geo.ConvertTimeFormat(cfg.Locale.Time, cfg.Locale.TimeFormat)
 	eventChecker := enrichment.NewPogoEventChecker(timeLayout)
 

--- a/processor/cmd/processor/summary_scheduler_test.go
+++ b/processor/cmd/processor/summary_scheduler_test.go
@@ -46,7 +46,11 @@ func newScheduler(
 ) *SummaryScheduler {
 	t.Helper()
 	s := NewSummaryScheduler(
-		schedulerConfig{Locale: "en"},
+		// Pin the timezone: the test humans sit at lat/lon 0/0, so an empty
+		// DefaultTimezone would resolve to the host's time.Local and make
+		// every fixed-UTC "now" in this file pass or fail depending on where
+		// the suite runs.
+		schedulerConfig{Locale: "en", DefaultTimezone: "UTC"},
 		mgr,
 		tracker.NewSummaryBuffer(""),
 		dispatch,

--- a/processor/internal/geo/timezone.go
+++ b/processor/internal/geo/timezone.go
@@ -10,7 +10,15 @@ var finder tzf.F
 
 func init() {
 	var err error
-	finder, err = tzf.NewFullFinder()
+	// NewDefaultFinder, not NewFullFinder: both wrap the same preindex tile
+	// fast path, but Full decodes tzf-dist's 18 MB full-precision polygon set
+	// where Default decodes the 6.5 MB topology-simplified one. That cost
+	// 140.96 MB of live heap at init in production (4.44% of the total) for
+	// accuracy we cannot use — upstream bounds the simplified boundaries to
+	// ~111 m of the true border, and a pokemon spawn that close to a timezone
+	// line resolves to a neighbouring zone with the same wall clock in every
+	// case a Poracle alert cares about.
+	finder, err = tzf.NewDefaultFinder()
 	if err != nil {
 		panic("failed to initialize timezone finder: " + err.Error())
 	}

--- a/processor/internal/geo/timezone.go
+++ b/processor/internal/geo/timezone.go
@@ -13,11 +13,20 @@ func init() {
 	// NewDefaultFinder, not NewFullFinder: both wrap the same preindex tile
 	// fast path, but Full decodes tzf-dist's 18 MB full-precision polygon set
 	// where Default decodes the 6.5 MB topology-simplified one. That cost
-	// 140.96 MB of live heap at init in production (4.44% of the total) for
-	// accuracy we cannot use — upstream bounds the simplified boundaries to
-	// ~111 m of the true border, and a pokemon spawn that close to a timezone
-	// line resolves to a neighbouring zone with the same wall clock in every
-	// case a Poracle alert cares about.
+	// 140.96 MB of live heap at init in production, 4.44% of the total.
+	//
+	// The trade is real, not free. Upstream bounds the simplified boundaries
+	// to ~111 m of the true border, but a neighbouring zone is not always on
+	// the same wall clock: India/Nepal differ by 15 min, the Arizona line by
+	// an hour for half the year, and China's western border by up to 2.5 h.
+	// A scan of the India/Nepal border alone finds ~65 points inside the band
+	// where the two finders disagree on the offset.
+	//
+	// A spawn or saved user location inside such a band therefore renders
+	// despawn and hatch times, and profile/summary schedules, off by that
+	// offset. The band is ~111 m wide against S2 level-10 weather cells and
+	// typical scan areas, so this is accepted rather than unnoticed: see
+	// TestGetTimezone_SimplifiedBoundaryOffsets for a pinned example.
 	finder, err = tzf.NewDefaultFinder()
 	if err != nil {
 		panic("failed to initialize timezone finder: " + err.Error())

--- a/processor/internal/geo/timezone_test.go
+++ b/processor/internal/geo/timezone_test.go
@@ -115,3 +115,23 @@ func TestResolveTimezone_FallbackChain(t *testing.T) {
 		})
 	}
 }
+
+// TestGetTimezone_SimplifiedBoundaryOffsets documents the accepted cost of
+// NewDefaultFinder's topology-simplified polygons.
+//
+// Within roughly 111 m of a border the simplified boundary can place a point
+// in the neighbouring zone, and that neighbour does not always share the same
+// UTC offset. This point sits inside the India/Nepal band, where the two zones
+// differ by 15 minutes: NewFullFinder resolves it to Asia/Kathmandu, the
+// finder we ship resolves it to Asia/Kolkata.
+//
+// Pinned so the behaviour is a documented trade rather than a surprise, and so
+// a tzf data update that moves the boundary shows up as a test change.
+func TestGetTimezone_SimplifiedBoundaryOffsets(t *testing.T) {
+	const lat, lon = 26.5000, 88.1000
+
+	got := GetTimezone(lat, lon)
+	if got != "Asia/Kolkata" {
+		t.Errorf("GetTimezone(%v, %v) = %q, want %q (simplified-boundary behaviour changed)", lat, lon, got, "Asia/Kolkata")
+	}
+}

--- a/processor/internal/geo/timezone_test.go
+++ b/processor/internal/geo/timezone_test.go
@@ -6,10 +6,11 @@ import (
 
 // TestGetTimezone_KnownCoordinates is a sanity check that the tzf
 // finder backing GetTimezone resolves a representative spread of
-// coordinates correctly. Worth keeping after tzf version bumps —
-// e.g. the v1.0 → v1.2 jump switches NewDefaultFinder for
-// NewFullFinder (FuzzyFinder + accurate Finder fallback) and we
-// want a fast signal if a boundary shifts.
+// coordinates correctly. Worth keeping across tzf version bumps and
+// finder changes — GetTimezone runs NewDefaultFinder, whose
+// topology-simplified polygons trade ~111 m of boundary precision for
+// roughly a fifth of the resident memory, so this is the fast signal
+// if a boundary ever shifts far enough to matter.
 func TestGetTimezone_KnownCoordinates(t *testing.T) {
 	cases := []struct {
 		name     string
@@ -24,12 +25,27 @@ func TestGetTimezone_KnownCoordinates(t *testing.T) {
 		{"Paris", 48.8566, 2.3522, "Europe/Paris"},
 		{"São Paulo", -23.5505, -46.6333, "America/Sao_Paulo"},
 		{"Auckland", -36.8485, 174.7633, "Pacific/Auckland"},
-		// Open ocean now resolves to a nautical etc. zone with
-		// NewFullFinder; NewDefaultFinder (v1.0.x) returned ""
-		// and our UTC fallback kicked in. Pokemon spawns are on
-		// land so this doesn't matter in practice — kept here to
-		// document the version-bump behaviour change.
+		// Open ocean resolves to a nautical Etc zone rather than ""
+		// (tzf v1.0.x returned empty here and our UTC fallback kicked
+		// in). Pokemon spawns are on land so this doesn't matter in
+		// practice — kept to document the behaviour.
 		{"middle of Atlantic", 0, -30, "Etc/GMT+2"},
+
+		// Zones that sit close to a neighbour or carry an unusual offset.
+		// These are the cases most exposed to boundary simplification, so
+		// they are the ones worth pinning across a finder change.
+		{"Phoenix", 33.4484, -112.0740, "America/Phoenix"},
+		{"Indianapolis", 39.7684, -86.1581, "America/Indiana/Indianapolis"},
+		{"Kathmandu", 27.7172, 85.3240, "Asia/Kathmandu"},
+		{"Adelaide", -34.9285, 138.6007, "Australia/Adelaide"},
+		{"Lisbon", 38.7223, -9.1393, "Europe/Lisbon"},
+		{"Madrid", 40.4168, -3.7038, "Europe/Madrid"},
+		{"Berlin", 52.5200, 13.4050, "Europe/Berlin"},
+		{"Moscow", 55.7558, 37.6173, "Europe/Moscow"},
+		{"Anchorage", 61.2181, -149.9003, "America/Anchorage"},
+		{"Honolulu", 21.3069, -157.8583, "Pacific/Honolulu"},
+		{"Singapore", 1.3521, 103.8198, "Asia/Singapore"},
+		{"Mumbai", 19.0760, 72.8777, "Asia/Kolkata"},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/processor/internal/tracker/accuweather.go
+++ b/processor/internal/tracker/accuweather.go
@@ -39,6 +39,11 @@ type AccuWeatherClient struct {
 	cellMutexes   map[string]*sync.Mutex
 	cellLocations map[string]string // cellID -> AccuWeather location key
 	cellForecasts map[string]*forecastState
+	// pendingEvict holds cells the sweep asked to reclaim while a request
+	// was using them. WeatherTracker names a cell exactly once, when it
+	// deletes it, so a deferred eviction is never offered again and has to
+	// be completed here instead.
+	pendingEvict map[string]struct{}
 	// inFlight counts forecast requests currently working on a cell.
 	// EnsureForecast releases aw.mu and then blocks, first on the per-cell
 	// mutex and then on an HTTP call, before re-reading the cell's state.
@@ -83,6 +88,7 @@ func NewAccuWeatherClient(cfg AccuWeatherConfig, tracker *WeatherTracker) *AccuW
 		cellLocations: make(map[string]string),
 		cellForecasts: make(map[string]*forecastState),
 		inFlight:      make(map[string]int),
+		pendingEvict:  make(map[string]struct{}),
 	}
 }
 
@@ -99,13 +105,20 @@ func (aw *AccuWeatherClient) ForgetCells(cellIDs []string) {
 			// A request is mid-flight on this cell. It will re-read the
 			// forecast state after its HTTP call, and a second caller would
 			// find an empty mutex slot and start a concurrent request for the
-			// same cell. The next sweep reclaims it once the request is done.
+			// same cell. Defer the reclaim to whoever releases the last hold.
+			aw.pendingEvict[cellID] = struct{}{}
 			continue
 		}
-		delete(aw.cellMutexes, cellID)
-		delete(aw.cellLocations, cellID)
-		delete(aw.cellForecasts, cellID)
+		aw.forget(cellID)
 	}
+}
+
+// forget drops every per-cell map entry. Caller must hold aw.mu.
+func (aw *AccuWeatherClient) forget(cellID string) {
+	delete(aw.cellMutexes, cellID)
+	delete(aw.cellLocations, cellID)
+	delete(aw.cellForecasts, cellID)
+	delete(aw.pendingEvict, cellID)
 }
 
 // markInFlight records that a forecast request is working on a cell, holding
@@ -115,14 +128,26 @@ func (aw *AccuWeatherClient) markInFlight(cellID string) {
 }
 
 // doneInFlight releases the hold taken by markInFlight.
+// doneInFlight releases the hold taken by markInFlight, completing any
+// eviction that was deferred while the request ran.
+//
+// A cell reactivated during the request is reclaimed here too, costing one
+// extra location lookup the next time it is needed. Consulting the tracker to
+// avoid that would mean taking wt.mu under aw.mu, and the alternative — never
+// reclaiming — is the leak this exists to close.
 func (aw *AccuWeatherClient) doneInFlight(cellID string) {
 	aw.mu.Lock()
 	defer aw.mu.Unlock()
-	if aw.inFlight[cellID] <= 1 {
-		delete(aw.inFlight, cellID)
+
+	if aw.inFlight[cellID] > 1 {
+		aw.inFlight[cellID]--
 		return
 	}
-	aw.inFlight[cellID]--
+	delete(aw.inFlight, cellID)
+
+	if _, deferred := aw.pendingEvict[cellID]; deferred {
+		aw.forget(cellID)
+	}
 }
 
 // storeForecastTimeout records when this cell's forecast next needs

--- a/processor/internal/tracker/accuweather.go
+++ b/processor/internal/tracker/accuweather.go
@@ -39,6 +39,11 @@ type AccuWeatherClient struct {
 	cellMutexes   map[string]*sync.Mutex
 	cellLocations map[string]string // cellID -> AccuWeather location key
 	cellForecasts map[string]*forecastState
+	// inFlight counts forecast requests currently working on a cell.
+	// EnsureForecast releases aw.mu and then blocks, first on the per-cell
+	// mutex and then on an HTTP call, before re-reading the cell's state.
+	// Eviction must not remove that state underneath it.
+	inFlight map[string]int
 }
 
 type forecastState struct {
@@ -77,6 +82,7 @@ func NewAccuWeatherClient(cfg AccuWeatherConfig, tracker *WeatherTracker) *AccuW
 		cellMutexes:   make(map[string]*sync.Mutex),
 		cellLocations: make(map[string]string),
 		cellForecasts: make(map[string]*forecastState),
+		inFlight:      make(map[string]int),
 	}
 }
 
@@ -89,9 +95,44 @@ func (aw *AccuWeatherClient) ForgetCells(cellIDs []string) {
 	aw.mu.Lock()
 	defer aw.mu.Unlock()
 	for _, cellID := range cellIDs {
+		if aw.inFlight[cellID] > 0 {
+			// A request is mid-flight on this cell. It will re-read the
+			// forecast state after its HTTP call, and a second caller would
+			// find an empty mutex slot and start a concurrent request for the
+			// same cell. The next sweep reclaims it once the request is done.
+			continue
+		}
 		delete(aw.cellMutexes, cellID)
 		delete(aw.cellLocations, cellID)
 		delete(aw.cellForecasts, cellID)
+	}
+}
+
+// markInFlight records that a forecast request is working on a cell, holding
+// its state against eviction. Caller must hold aw.mu.
+func (aw *AccuWeatherClient) markInFlight(cellID string) {
+	aw.inFlight[cellID]++
+}
+
+// doneInFlight releases the hold taken by markInFlight.
+func (aw *AccuWeatherClient) doneInFlight(cellID string) {
+	aw.mu.Lock()
+	defer aw.mu.Unlock()
+	if aw.inFlight[cellID] <= 1 {
+		delete(aw.inFlight, cellID)
+		return
+	}
+	aw.inFlight[cellID]--
+}
+
+// storeForecastTimeout records when this cell's forecast next needs
+// refreshing. A nil entry means the cell was evicted while the request was in
+// flight, which is legitimate rather than exceptional.
+func (aw *AccuWeatherClient) storeForecastTimeout(cellID string, forecastTimeout int64) {
+	aw.mu.Lock()
+	defer aw.mu.Unlock()
+	if fs := aw.cellForecasts[cellID]; fs != nil {
+		fs.forecastTimeout = forecastTimeout
 	}
 }
 
@@ -129,6 +170,10 @@ func (aw *AccuWeatherClient) EnsureForecast(cellID string) {
 		cellMu = &sync.Mutex{}
 		aw.cellMutexes[cellID] = cellMu
 	}
+	// Taken before releasing aw.mu so an eviction sweep cannot slip in and
+	// delete this cell's state between here and the re-read below.
+	aw.markInFlight(cellID)
+	defer aw.doneInFlight(cellID)
 	aw.mu.Unlock()
 
 	// Serialize requests per cell
@@ -138,6 +183,13 @@ func (aw *AccuWeatherClient) EnsureForecast(cellID string) {
 	// Double-check after acquiring lock
 	aw.mu.Lock()
 	fs = aw.cellForecasts[cellID]
+	if fs == nil {
+		// Belt and braces: the in-flight hold should keep this alive, so a
+		// nil here means some other path removed it. Abandon rather than
+		// dereference.
+		aw.mu.Unlock()
+		return
+	}
 	if fs.lastForecastLoad == currentHour {
 		aw.mu.Unlock()
 		return
@@ -214,10 +266,7 @@ func (aw *AccuWeatherClient) fetchForecast(cellID string, currentHour int64) {
 	// Calculate next refresh timeout
 	forecastTimeout := aw.calculateForecastTimeout(currentHour)
 
-	aw.mu.Lock()
-	fs := aw.cellForecasts[cellID]
-	fs.forecastTimeout = forecastTimeout
-	aw.mu.Unlock()
+	aw.storeForecastTimeout(cellID, forecastTimeout)
 }
 
 func (aw *AccuWeatherClient) getLocationKey(cellID string) (string, error) {

--- a/processor/internal/tracker/accuweather.go
+++ b/processor/internal/tracker/accuweather.go
@@ -80,6 +80,21 @@ func NewAccuWeatherClient(cfg AccuWeatherConfig, tracker *WeatherTracker) *AccuW
 	}
 }
 
+// ForgetCells releases all per-cell state for the given cells. Wired to
+// WeatherTracker's eviction callback: these maps share the tracker's cell
+// keyspace, so without this a shifted scan area strands one mutex, one
+// location key and one forecastState per abandoned S2 cell for the life of
+// the process.
+func (aw *AccuWeatherClient) ForgetCells(cellIDs []string) {
+	aw.mu.Lock()
+	defer aw.mu.Unlock()
+	for _, cellID := range cellIDs {
+		delete(aw.cellMutexes, cellID)
+		delete(aw.cellLocations, cellID)
+		delete(aw.cellForecasts, cellID)
+	}
+}
+
 // EnsureForecast ensures the given cell has up-to-date forecast data.
 // Called by WeatherTracker.GetWeatherForecast when forecast is enabled.
 func (aw *AccuWeatherClient) EnsureForecast(cellID string) {

--- a/processor/internal/tracker/accuweather.go
+++ b/processor/internal/tracker/accuweather.go
@@ -131,10 +131,16 @@ func (aw *AccuWeatherClient) markInFlight(cellID string) {
 // doneInFlight releases the hold taken by markInFlight, completing any
 // eviction that was deferred while the request ran.
 //
-// A cell reactivated during the request is reclaimed here too, costing one
-// extra location lookup the next time it is needed. Consulting the tracker to
-// avoid that would mean taking wt.mu under aw.mu, and the alternative — never
-// reclaiming — is the leak this exists to close.
+// A deferred eviction can go stale: a successful fetch calls SetHourWeather,
+// which recreates the tracker cell, and a plain webhook can do the same. The
+// tracker is therefore re-checked before reclaiming, so state the request just
+// paid AccuWeather for is not thrown away for a cell that is demonstrably
+// active. Reclaiming it would cost a location lookup and a 12-hour forecast on
+// the next alert, against a 500/day default quota.
+//
+// Reading the tracker here is the same lock order EnsureForecast already uses
+// (aw.mu then wt.mu via hasHourWeather); WeatherTracker never calls into this
+// client while holding wt.mu, since evict releases it before invoking onEvict.
 func (aw *AccuWeatherClient) doneInFlight(cellID string) {
 	aw.mu.Lock()
 	defer aw.mu.Unlock()
@@ -145,9 +151,15 @@ func (aw *AccuWeatherClient) doneInFlight(cellID string) {
 	}
 	delete(aw.inFlight, cellID)
 
-	if _, deferred := aw.pendingEvict[cellID]; deferred {
-		aw.forget(cellID)
+	if _, deferred := aw.pendingEvict[cellID]; !deferred {
+		return
 	}
+	delete(aw.pendingEvict, cellID)
+	if aw.tracker != nil && aw.tracker.hasCell(cellID) {
+		// Came back while the request ran; the eviction no longer applies.
+		return
+	}
+	aw.forget(cellID)
 }
 
 // storeForecastTimeout records when this cell's forecast next needs

--- a/processor/internal/tracker/accuweather_evict_test.go
+++ b/processor/internal/tracker/accuweather_evict_test.go
@@ -58,3 +58,64 @@ func TestAccuWeatherForgetCells(t *testing.T) {
 		t.Error("a live cell was dropped")
 	}
 }
+
+// TestWeatherTrackerEvictReportsEachCellOnce pins that a cell holding both
+// controller and local state is reported to onEvict exactly once, and that the
+// dedup behind that stays linear in the number of cells dropped: a shifted
+// scan area can drop tens of thousands in one sweep, all under wt.mu.
+func TestWeatherTrackerEvictReportsEachCellOnce(t *testing.T) {
+	clock := newTestClock(1_700_000_000)
+	wt := NewWeatherTracker(WithClock(clock.now))
+	defer wt.Close()
+
+	const cells = 5000
+	for i := range cells {
+		id := encounterIDForTest(i)
+		// Both maps, so the naive dedup would have to scan for each one.
+		wt.UpdateFromWebhook(id, 1, clock.now().Unix(), 51.5, -0.1, [4][2]float64{})
+		wt.CheckWeatherOnMonster(id, 51.5, -0.1, 3)
+	}
+
+	var dropped []string
+	wt.SetOnEvict(func(ids []string) { dropped = append(dropped, ids...) })
+
+	clock.advance(48 * time.Hour)
+	wt.evict(clock.now().Unix())
+
+	if len(dropped) != cells {
+		t.Fatalf("onEvict reported %d cells, want %d", len(dropped), cells)
+	}
+	seen := make(map[string]struct{}, len(dropped))
+	for _, id := range dropped {
+		if _, dup := seen[id]; dup {
+			t.Fatalf("cell %s reported more than once", id)
+		}
+		seen[id] = struct{}{}
+	}
+}
+
+// BenchmarkWeatherEvictDropsManyCells covers the sweep that follows a
+// scan-area shift, where one pass drops every cell it holds. The whole loop
+// runs under wt.mu, so its cost is a stall on every webhook path.
+func BenchmarkWeatherEvictDropsManyCells(b *testing.B) {
+	const cells = 10000
+
+	for b.Loop() {
+		b.StopTimer()
+		clock := newTestClock(1_700_000_000)
+		wt := NewWeatherTracker(WithClock(clock.now))
+		for i := range cells {
+			id := encounterIDForTest(i)
+			wt.UpdateFromWebhook(id, 1, clock.now().Unix(), 51.5, -0.1, [4][2]float64{})
+			wt.CheckWeatherOnMonster(id, 51.5, -0.1, 3)
+		}
+		clock.advance(48 * time.Hour)
+		b.StartTimer()
+
+		wt.evict(clock.now().Unix())
+
+		b.StopTimer()
+		wt.Close()
+		b.StartTimer()
+	}
+}

--- a/processor/internal/tracker/accuweather_evict_test.go
+++ b/processor/internal/tracker/accuweather_evict_test.go
@@ -9,20 +9,18 @@ import (
 // dropped, so components keyed by the same cell ids can release their own
 // state instead of each re-deriving liveness.
 func TestWeatherTrackerNotifiesOnEvict(t *testing.T) {
-	wt := NewWeatherTracker()
+	clock := newTestClock(1_700_000_000)
+	wt := NewWeatherTracker(WithClock(clock.now))
 	defer wt.Close()
-
-	clock := time.Unix(1_700_000_000, 0)
-	wt.nowFunc = func() time.Time { return clock }
 
 	var evicted []string
 	wt.SetOnEvict(func(cellIDs []string) { evicted = append(evicted, cellIDs...) })
 
-	wt.UpdateFromWebhook("cell-gone", 1, clock.Unix(), 51.5, -0.1, [4][2]float64{})
+	wt.UpdateFromWebhook("cell-gone", 1, clock.now().Unix(), 51.5, -0.1, [4][2]float64{})
 
-	clock = clock.Add(48 * time.Hour)
-	wt.UpdateFromWebhook("cell-live", 1, clock.Unix(), 51.5, -0.1, [4][2]float64{})
-	wt.evict(clock.Unix())
+	clock.advance(48 * time.Hour)
+	wt.UpdateFromWebhook("cell-live", 1, clock.now().Unix(), 51.5, -0.1, [4][2]float64{})
+	wt.evict(clock.now().Unix())
 
 	if len(evicted) != 1 || evicted[0] != "cell-gone" {
 		t.Fatalf("onEvict got %v, want exactly [cell-gone]", evicted)

--- a/processor/internal/tracker/accuweather_evict_test.go
+++ b/processor/internal/tracker/accuweather_evict_test.go
@@ -1,0 +1,62 @@
+package tracker
+
+import (
+	"testing"
+	"time"
+)
+
+// TestWeatherTrackerNotifiesOnEvict asserts the sweep reports which cells it
+// dropped, so components keyed by the same cell ids can release their own
+// state instead of each re-deriving liveness.
+func TestWeatherTrackerNotifiesOnEvict(t *testing.T) {
+	wt := NewWeatherTracker()
+	defer wt.Close()
+
+	clock := time.Unix(1_700_000_000, 0)
+	wt.nowFunc = func() time.Time { return clock }
+
+	var evicted []string
+	wt.SetOnEvict(func(cellIDs []string) { evicted = append(evicted, cellIDs...) })
+
+	wt.UpdateFromWebhook("cell-gone", 1, clock.Unix(), 51.5, -0.1, [4][2]float64{})
+
+	clock = clock.Add(48 * time.Hour)
+	wt.UpdateFromWebhook("cell-live", 1, clock.Unix(), 51.5, -0.1, [4][2]float64{})
+	wt.evict(clock.Unix())
+
+	if len(evicted) != 1 || evicted[0] != "cell-gone" {
+		t.Fatalf("onEvict got %v, want exactly [cell-gone]", evicted)
+	}
+}
+
+// TestAccuWeatherForgetCells asserts the forecast client releases every
+// per-cell map it owns. cellMutexes, cellLocations and cellForecasts share the
+// WeatherTracker's keyspace but had no delete path at all, so a shifted scan
+// area stranded one mutex, one location key and one forecastState per
+// abandoned S2 cell for the life of the process.
+func TestAccuWeatherForgetCells(t *testing.T) {
+	wt := NewWeatherTracker()
+	defer wt.Close()
+
+	aw := NewAccuWeatherClient(AccuWeatherConfig{}, wt)
+
+	aw.cellMutexes["cell-gone"] = nil
+	aw.cellLocations["cell-gone"] = "12345"
+	aw.cellForecasts["cell-gone"] = &forecastState{}
+	aw.cellLocations["cell-live"] = "67890"
+
+	aw.ForgetCells([]string{"cell-gone"})
+
+	if _, ok := aw.cellMutexes["cell-gone"]; ok {
+		t.Error("cellMutexes still holds the evicted cell")
+	}
+	if _, ok := aw.cellLocations["cell-gone"]; ok {
+		t.Error("cellLocations still holds the evicted cell")
+	}
+	if _, ok := aw.cellForecasts["cell-gone"]; ok {
+		t.Error("cellForecasts still holds the evicted cell")
+	}
+	if _, ok := aw.cellLocations["cell-live"]; !ok {
+		t.Error("a live cell was dropped")
+	}
+}

--- a/processor/internal/tracker/accuweather_evict_test.go
+++ b/processor/internal/tracker/accuweather_evict_test.go
@@ -1,6 +1,7 @@
 package tracker
 
 import (
+	"sync"
 	"testing"
 	"time"
 )
@@ -118,4 +119,62 @@ func BenchmarkWeatherEvictDropsManyCells(b *testing.B) {
 		wt.Close()
 		b.StartTimer()
 	}
+}
+
+// TestForgetCellsSpareInFlightRequests pins the interaction between the
+// eviction sweep and a forecast request already in progress.
+//
+// EnsureForecast releases aw.mu, blocks on the per-cell mutex and then on an
+// HTTP call, and re-reads cellForecasts afterwards. Before eviction existed
+// nothing could remove that entry, so the re-read was safe by construction.
+// Once ForgetCells could delete it mid-request, the re-read became a nil
+// dereference that panics the processor, and deleting the per-cell mutex let a
+// second request for the same cell start against a fresh mutex and run
+// concurrently.
+func TestForgetCellsSpareInFlightRequests(t *testing.T) {
+	wt := NewWeatherTracker()
+	defer wt.Close()
+	aw := NewAccuWeatherClient(AccuWeatherConfig{}, wt)
+
+	const busy, idle = "cell-busy", "cell-idle"
+	for _, id := range []string{busy, idle} {
+		aw.cellMutexes[id] = &sync.Mutex{}
+		aw.cellLocations[id] = "loc-" + id
+		aw.cellForecasts[id] = &forecastState{}
+	}
+
+	// A request is working on `busy` right now.
+	aw.markInFlight(busy)
+
+	aw.ForgetCells([]string{busy, idle})
+
+	if aw.cellForecasts[busy] == nil {
+		t.Error("forecast state for an in-flight cell was evicted; the request will nil-deref on its next re-read")
+	}
+	if aw.cellMutexes[busy] == nil {
+		t.Error("per-cell mutex for an in-flight cell was evicted; a second request would run concurrently")
+	}
+	if aw.cellForecasts[idle] != nil || aw.cellMutexes[idle] != nil || aw.cellLocations[idle] != "" {
+		t.Error("an idle cell was not reclaimed")
+	}
+
+	// Once the request finishes, the cell becomes reclaimable again.
+	aw.doneInFlight(busy)
+	aw.ForgetCells([]string{busy})
+
+	if aw.cellForecasts[busy] != nil || aw.cellMutexes[busy] != nil {
+		t.Error("cell was not reclaimed after its request completed")
+	}
+}
+
+// TestFetchForecastTailToleratesEvictedCell covers the second unguarded
+// re-read: fetchForecast writes the refresh timeout back after its HTTP call,
+// by which point the cell may legitimately be gone.
+func TestFetchForecastTailToleratesEvictedCell(t *testing.T) {
+	wt := NewWeatherTracker()
+	defer wt.Close()
+	aw := NewAccuWeatherClient(AccuWeatherConfig{}, wt)
+
+	// No entry for this cell at all, as if eviction ran during the request.
+	aw.storeForecastTimeout("cell-vanished", 12345)
 }

--- a/processor/internal/tracker/accuweather_evict_test.go
+++ b/processor/internal/tracker/accuweather_evict_test.go
@@ -243,3 +243,48 @@ func TestForgetCellsDoesNotReclaimUnevictedCells(t *testing.T) {
 		t.Error("state for a cell that was never evicted was reclaimed")
 	}
 }
+
+// TestDeferredEvictionSkippedWhenCellCameBack covers a deferred eviction that
+// goes stale while it waits.
+//
+// fetchForecast calls SetHourWeather on success, which recreates the tracker
+// cell and stamps it live. Reclaiming on that basis throws away the location
+// key and the forecast timeout the request just paid AccuWeather for, so the
+// next alert performs a fresh location lookup and a fresh 12-hour forecast:
+// two more requests against a 500/day quota, for a cell that is demonstrably
+// active.
+func TestDeferredEvictionSkippedWhenCellCameBack(t *testing.T) {
+	clock := newTestClock(1_700_000_000)
+	wt := NewWeatherTracker(WithClock(clock.now))
+	defer wt.Close()
+	aw := NewAccuWeatherClient(AccuWeatherConfig{}, wt)
+
+	const cellID = "cell-refreshed"
+	aw.cellMutexes[cellID] = &sync.Mutex{}
+	aw.cellLocations[cellID] = "loc"
+	aw.cellForecasts[cellID] = &forecastState{}
+
+	aw.mu.Lock()
+	aw.markInFlight(cellID)
+	aw.mu.Unlock()
+
+	// The sweep drops the cell and is refused because a request holds it.
+	aw.ForgetCells([]string{cellID})
+
+	// The request succeeds: fetchForecast writes forecast hours, which
+	// recreates the tracker cell, and records the refresh timeout.
+	now := clock.now().Unix()
+	wt.SetHourWeather(cellID, now-(now%3600)+3600, 3)
+	aw.storeForecastTimeout(cellID, now+7200)
+
+	aw.doneInFlight(cellID)
+
+	if aw.cellLocations[cellID] == "" {
+		t.Error("location key discarded for a cell the fetch brought back; next alert re-pays for the lookup")
+	}
+	if fs := aw.cellForecasts[cellID]; fs == nil {
+		t.Error("forecast state discarded for a cell the fetch brought back")
+	} else if fs.forecastTimeout == 0 {
+		t.Error("forecast timeout lost; next alert re-fetches before the configured refresh")
+	}
+}

--- a/processor/internal/tracker/accuweather_evict_test.go
+++ b/processor/internal/tracker/accuweather_evict_test.go
@@ -158,9 +158,9 @@ func TestForgetCellsSpareInFlightRequests(t *testing.T) {
 		t.Error("an idle cell was not reclaimed")
 	}
 
-	// Once the request finishes, the cell becomes reclaimable again.
+	// Releasing the hold completes the deferred eviction; see
+	// TestForgetCellsReclaimsAfterInFlightRequestCompletes.
 	aw.doneInFlight(busy)
-	aw.ForgetCells([]string{busy})
 
 	if aw.cellForecasts[busy] != nil || aw.cellMutexes[busy] != nil {
 		t.Error("cell was not reclaimed after its request completed")
@@ -177,4 +177,69 @@ func TestFetchForecastTailToleratesEvictedCell(t *testing.T) {
 
 	// No entry for this cell at all, as if eviction ran during the request.
 	aw.storeForecastTimeout("cell-vanished", 12345)
+}
+
+// TestForgetCellsReclaimsAfterInFlightRequestCompletes closes the gap left by
+// deferring an eviction: WeatherTracker reports a cell exactly once, at the
+// moment it deletes it, so a cell skipped because a request was in flight is
+// never offered to ForgetCells again.
+//
+// If that request then exits without reactivating the cell (quota exhausted,
+// HTTP or decode failure, no usable forecast), nothing else reclaims it and
+// its mutex, location key and forecast state stay resident for the life of the
+// process. The hold itself has to trigger the reclaim when it is released.
+func TestForgetCellsReclaimsAfterInFlightRequestCompletes(t *testing.T) {
+	wt := NewWeatherTracker()
+	defer wt.Close()
+	aw := NewAccuWeatherClient(AccuWeatherConfig{}, wt)
+
+	const cellID = "cell-abandoned"
+	aw.cellMutexes[cellID] = &sync.Mutex{}
+	aw.cellLocations[cellID] = "loc"
+	aw.cellForecasts[cellID] = &forecastState{}
+
+	aw.mu.Lock()
+	aw.markInFlight(cellID)
+	aw.mu.Unlock()
+
+	// The sweep offers the cell once and is refused.
+	aw.ForgetCells([]string{cellID})
+	if aw.cellForecasts[cellID] == nil {
+		t.Fatal("in-flight cell was evicted")
+	}
+
+	// The request fails and exits. No further sweep will ever name this cell,
+	// so releasing the hold must be what reclaims it.
+	aw.doneInFlight(cellID)
+
+	if aw.cellForecasts[cellID] != nil {
+		t.Error("forecast state leaked after the in-flight request finished")
+	}
+	if aw.cellMutexes[cellID] != nil {
+		t.Error("per-cell mutex leaked after the in-flight request finished")
+	}
+	if aw.cellLocations[cellID] != "" {
+		t.Error("location key leaked after the in-flight request finished")
+	}
+}
+
+// TestForgetCellsDoesNotReclaimUnevictedCells guards the other direction: a
+// request finishing on a cell nobody asked to evict must leave it alone.
+func TestForgetCellsDoesNotReclaimUnevictedCells(t *testing.T) {
+	wt := NewWeatherTracker()
+	defer wt.Close()
+	aw := NewAccuWeatherClient(AccuWeatherConfig{}, wt)
+
+	const cellID = "cell-live"
+	aw.cellLocations[cellID] = "loc"
+	aw.cellForecasts[cellID] = &forecastState{}
+
+	aw.mu.Lock()
+	aw.markInFlight(cellID)
+	aw.mu.Unlock()
+	aw.doneInFlight(cellID)
+
+	if aw.cellForecasts[cellID] == nil || aw.cellLocations[cellID] == "" {
+		t.Error("state for a cell that was never evicted was reclaimed")
+	}
 }

--- a/processor/internal/tracker/accuweather_evict_test.go
+++ b/processor/internal/tracker/accuweather_evict_test.go
@@ -288,3 +288,39 @@ func TestDeferredEvictionSkippedWhenCellCameBack(t *testing.T) {
 		t.Error("forecast timeout lost; next alert re-fetches before the configured refresh")
 	}
 }
+
+// TestEvictDoesNotReportCellsStillHeldByControllerData pins that a cell is
+// reported to onEvict only once it is genuinely gone from the tracker.
+//
+// Local inference and controller data age out independently: a cell can stop
+// receiving boosted-pokemon votes while weather webhooks (or AccuWeather
+// forecast pushes) keep its controller entry fresh. Reporting it because only
+// the local half expired hands a live cell to ForgetCells, which throws away
+// its location key and forecast timeout and makes the next alert re-pay for
+// both.
+func TestEvictDoesNotReportCellsStillHeldByControllerData(t *testing.T) {
+	clock := newTestClock(1_700_000_000)
+	wt := NewWeatherTracker(WithClock(clock.now))
+	defer wt.Close()
+
+	const cellID = "cell-half-idle"
+
+	var reported []string
+	wt.SetOnEvict(func(ids []string) { reported = append(reported, ids...) })
+
+	// Local inference recorded now, then left to go stale.
+	wt.CheckWeatherOnMonster(cellID, 51.5, -0.1, 3)
+
+	// Two days on, controller data is still arriving for the same cell.
+	clock.advance(48 * time.Hour)
+	wt.UpdateFromWebhook(cellID, 2, clock.now().Unix(), 51.5, -0.1, [4][2]float64{})
+
+	wt.evict(clock.now().Unix())
+
+	if len(reported) != 0 {
+		t.Errorf("onEvict reported %v for a cell whose controller data is still live", reported)
+	}
+	if !wt.hasCell(cellID) {
+		t.Error("cell was removed entirely despite fresh controller data")
+	}
+}

--- a/processor/internal/tracker/duplicate.go
+++ b/processor/internal/tracker/duplicate.go
@@ -37,17 +37,10 @@ func (dc *DuplicateCache) Close() {
 // CheckPokemon returns true if this pokemon was already seen (duplicate).
 // Key: {encounter_id}:{verified}:{cp}
 func (dc *DuplicateCache) CheckPokemon(encounterID string, verified bool, cp int, disappearTime int64) bool {
-	verifiedStr := "F"
-	if verified {
-		verifiedStr = "T"
-	}
-	key := fmt.Sprintf("%s%s%d", encounterID, verifiedStr, cp)
+	k := dc.seen.newKey()
+	k.Str(encounterID).Bool(verified).Int(int64(cp))
 
-	if dc.seen.Has(key) {
-		return true // duplicate
-	}
-
-	// Set with TTL based on disappear time
+	// TTL based on disappear time
 	now := time.Now().Unix()
 	var ttl time.Duration
 	if !verified || disappearTime == 0 {
@@ -60,8 +53,7 @@ func (dc *DuplicateCache) CheckPokemon(encounterID string, verified bool, cp int
 		ttl = time.Duration(remaining) * time.Second
 	}
 
-	dc.seen.Add(key, ttl)
-	return false
+	return dc.seen.CheckAndAdd(&k, ttl)
 }
 
 // RaidCacheResult holds info about a previously-seen raid.
@@ -137,94 +129,71 @@ func rsvpChanged(oldRSVPs, newRSVPs []RaidRSVP) bool {
 // movement, so including the fingerprint lets each meaningful leaderboard change
 // through (to reach the edit path) while collapsing repeats of the same state.
 func (dc *DuplicateCache) CheckShowcase(pokestopID string, showcaseExpiry int64, rank1Fingerprint string) bool {
-	key := fmt.Sprintf("%sSC%d:%s", pokestopID, showcaseExpiry, rank1Fingerprint)
-
-	if dc.seen.Has(key) {
-		return true
-	}
+	k := dc.seen.newKey()
+	k.Str(pokestopID).Str("SC").Int(showcaseExpiry).Str(rank1Fingerprint)
 
 	now := time.Now().Unix()
 	remaining := showcaseExpiry - now + 300
 	if remaining <= 0 {
 		remaining = 60
 	}
-	dc.seen.Add(key, time.Duration(remaining)*time.Second)
-	return false
+	return dc.seen.CheckAndAdd(&k, time.Duration(remaining)*time.Second)
 }
 
 func (dc *DuplicateCache) CheckInvasion(pokestopID string, expiration int64) bool {
-	key := fmt.Sprintf("%sI%d", pokestopID, expiration)
-
-	if dc.seen.Has(key) {
-		return true
-	}
+	k := dc.seen.newKey()
+	k.Str(pokestopID).Str("I").Int(expiration)
 
 	now := time.Now().Unix()
 	remaining := expiration - now + 300
 	if remaining <= 0 {
 		remaining = 60
 	}
-	dc.seen.Add(key, time.Duration(remaining)*time.Second)
-	return false
+	return dc.seen.CheckAndAdd(&k, time.Duration(remaining)*time.Second)
 }
 
 // CheckQuest returns true if this quest was already seen (duplicate).
 // Key: {pokestop_id}_{rewards_hash}
 func (dc *DuplicateCache) CheckQuest(pokestopID string, rewardsKey string) bool {
-	key := fmt.Sprintf("%s_%s", pokestopID, rewardsKey)
+	k := dc.seen.newKey()
+	k.Str(pokestopID).Str(rewardsKey)
 
-	if dc.seen.Has(key) {
-		return true
-	}
-
-	dc.seen.Add(key, 90*time.Minute)
-	return false
+	return dc.seen.CheckAndAdd(&k, 90*time.Minute)
 }
 
 // CheckLure returns true if this lure was already seen (duplicate).
 // Key: {pokestop_id}L{lure_expiration}
 func (dc *DuplicateCache) CheckLure(pokestopID string, expiration int64) bool {
-	key := fmt.Sprintf("%sL%d", pokestopID, expiration)
-
-	if dc.seen.Has(key) {
-		return true
-	}
+	k := dc.seen.newKey()
+	k.Str(pokestopID).Str("L").Int(expiration)
 
 	now := time.Now().Unix()
 	remaining := expiration - now + 300
 	if remaining <= 0 {
 		remaining = 60
 	}
-	dc.seen.Add(key, time.Duration(remaining)*time.Second)
-	return false
+	return dc.seen.CheckAndAdd(&k, time.Duration(remaining)*time.Second)
 }
 
 // CheckMaxbattle returns true if this maxbattle was already seen (duplicate).
 // Key: {station_id}M{battle_end}{pokemon_id}
 func (dc *DuplicateCache) CheckMaxbattle(stationID string, battleEnd int64, pokemonID int) bool {
-	key := fmt.Sprintf("%sM%d%d", stationID, battleEnd, pokemonID)
-
-	if dc.seen.Has(key) {
-		return true
-	}
+	k := dc.seen.newKey()
+	k.Str(stationID).Str("M").Int(battleEnd).Int(int64(pokemonID))
 
 	now := time.Now().Unix()
 	remaining := battleEnd - now + 300
 	if remaining <= 0 {
 		remaining = 60
 	}
-	dc.seen.Add(key, time.Duration(remaining)*time.Second)
-	return false
+	return dc.seen.CheckAndAdd(&k, time.Duration(remaining)*time.Second)
 }
 
 // CheckNest returns true if this nest was already seen (duplicate).
 // Key: {nest_id}_{pokemon_id}_{reset_time}
 func (dc *DuplicateCache) CheckNest(nestID int64, pokemonID int, resetTime int64) bool {
-	key := fmt.Sprintf("%d_%d_%d", nestID, pokemonID, resetTime)
-
-	if dc.seen.Has(key) {
-		return true
-	}
+	k := dc.seen.newKey()
+	k.Int(nestID).Int(int64(pokemonID)).Int(resetTime)
 
 	// 14 days from reset_time
 	now := time.Now().Unix()
@@ -232,6 +201,5 @@ func (dc *DuplicateCache) CheckNest(nestID int64, pokemonID int, resetTime int64
 	if remaining <= 0 {
 		remaining = 3600
 	}
-	dc.seen.Add(key, time.Duration(remaining)*time.Second)
-	return false
+	return dc.seen.CheckAndAdd(&k, time.Duration(remaining)*time.Second)
 }

--- a/processor/internal/tracker/duplicate.go
+++ b/processor/internal/tracker/duplicate.go
@@ -9,28 +9,28 @@ import (
 
 // DuplicateCache provides deduplication for webhooks.
 type DuplicateCache struct {
-	cache     *ttlcache.Cache[string, bool]
+	// seen holds the plain "have we handled this?" keys, which dominate the
+	// entry count at scanner throughput. It stores key fingerprints rather
+	// than boxed cache items — see expiringSet.
+	seen *expiringSet
+	// raidCache keeps real values (prior RSVP state) rather than a bit, and
+	// its cardinality is bounded by active raids, so it stays a ttlcache.
 	raidCache *ttlcache.Cache[string, *RaidCacheResult]
 }
 
 // NewDuplicateCache creates a new duplicate detection cache.
 func NewDuplicateCache() *DuplicateCache {
-	cache := ttlcache.New[string, bool](
-		ttlcache.WithTTL[string, bool](90*time.Minute),
-		ttlcache.WithDisableTouchOnHit[string, bool](),
-	)
 	raidCache := ttlcache.New[string, *RaidCacheResult](
 		ttlcache.WithTTL[string, *RaidCacheResult](90*time.Minute),
 		ttlcache.WithDisableTouchOnHit[string, *RaidCacheResult](),
 	)
-	go cache.Start()
 	go raidCache.Start()
-	return &DuplicateCache{cache: cache, raidCache: raidCache}
+	return &DuplicateCache{seen: newExpiringSet(), raidCache: raidCache}
 }
 
 // Close stops all cache eviction goroutines.
 func (dc *DuplicateCache) Close() {
-	dc.cache.Stop()
+	dc.seen.Close()
 	dc.raidCache.Stop()
 }
 
@@ -43,7 +43,7 @@ func (dc *DuplicateCache) CheckPokemon(encounterID string, verified bool, cp int
 	}
 	key := fmt.Sprintf("%s%s%d", encounterID, verifiedStr, cp)
 
-	if dc.cache.Get(key) != nil {
+	if dc.seen.Has(key) {
 		return true // duplicate
 	}
 
@@ -60,7 +60,7 @@ func (dc *DuplicateCache) CheckPokemon(encounterID string, verified bool, cp int
 		ttl = time.Duration(remaining) * time.Second
 	}
 
-	dc.cache.Set(key, true, ttl)
+	dc.seen.Add(key, ttl)
 	return false
 }
 
@@ -139,7 +139,7 @@ func rsvpChanged(oldRSVPs, newRSVPs []RaidRSVP) bool {
 func (dc *DuplicateCache) CheckShowcase(pokestopID string, showcaseExpiry int64, rank1Fingerprint string) bool {
 	key := fmt.Sprintf("%sSC%d:%s", pokestopID, showcaseExpiry, rank1Fingerprint)
 
-	if dc.cache.Get(key) != nil {
+	if dc.seen.Has(key) {
 		return true
 	}
 
@@ -148,14 +148,14 @@ func (dc *DuplicateCache) CheckShowcase(pokestopID string, showcaseExpiry int64,
 	if remaining <= 0 {
 		remaining = 60
 	}
-	dc.cache.Set(key, true, time.Duration(remaining)*time.Second)
+	dc.seen.Add(key, time.Duration(remaining)*time.Second)
 	return false
 }
 
 func (dc *DuplicateCache) CheckInvasion(pokestopID string, expiration int64) bool {
 	key := fmt.Sprintf("%sI%d", pokestopID, expiration)
 
-	if dc.cache.Get(key) != nil {
+	if dc.seen.Has(key) {
 		return true
 	}
 
@@ -164,7 +164,7 @@ func (dc *DuplicateCache) CheckInvasion(pokestopID string, expiration int64) boo
 	if remaining <= 0 {
 		remaining = 60
 	}
-	dc.cache.Set(key, true, time.Duration(remaining)*time.Second)
+	dc.seen.Add(key, time.Duration(remaining)*time.Second)
 	return false
 }
 
@@ -173,11 +173,11 @@ func (dc *DuplicateCache) CheckInvasion(pokestopID string, expiration int64) boo
 func (dc *DuplicateCache) CheckQuest(pokestopID string, rewardsKey string) bool {
 	key := fmt.Sprintf("%s_%s", pokestopID, rewardsKey)
 
-	if dc.cache.Get(key) != nil {
+	if dc.seen.Has(key) {
 		return true
 	}
 
-	dc.cache.Set(key, true, 90*time.Minute)
+	dc.seen.Add(key, 90*time.Minute)
 	return false
 }
 
@@ -186,7 +186,7 @@ func (dc *DuplicateCache) CheckQuest(pokestopID string, rewardsKey string) bool 
 func (dc *DuplicateCache) CheckLure(pokestopID string, expiration int64) bool {
 	key := fmt.Sprintf("%sL%d", pokestopID, expiration)
 
-	if dc.cache.Get(key) != nil {
+	if dc.seen.Has(key) {
 		return true
 	}
 
@@ -195,7 +195,7 @@ func (dc *DuplicateCache) CheckLure(pokestopID string, expiration int64) bool {
 	if remaining <= 0 {
 		remaining = 60
 	}
-	dc.cache.Set(key, true, time.Duration(remaining)*time.Second)
+	dc.seen.Add(key, time.Duration(remaining)*time.Second)
 	return false
 }
 
@@ -204,7 +204,7 @@ func (dc *DuplicateCache) CheckLure(pokestopID string, expiration int64) bool {
 func (dc *DuplicateCache) CheckMaxbattle(stationID string, battleEnd int64, pokemonID int) bool {
 	key := fmt.Sprintf("%sM%d%d", stationID, battleEnd, pokemonID)
 
-	if dc.cache.Get(key) != nil {
+	if dc.seen.Has(key) {
 		return true
 	}
 
@@ -213,7 +213,7 @@ func (dc *DuplicateCache) CheckMaxbattle(stationID string, battleEnd int64, poke
 	if remaining <= 0 {
 		remaining = 60
 	}
-	dc.cache.Set(key, true, time.Duration(remaining)*time.Second)
+	dc.seen.Add(key, time.Duration(remaining)*time.Second)
 	return false
 }
 
@@ -222,7 +222,7 @@ func (dc *DuplicateCache) CheckMaxbattle(stationID string, battleEnd int64, poke
 func (dc *DuplicateCache) CheckNest(nestID int64, pokemonID int, resetTime int64) bool {
 	key := fmt.Sprintf("%d_%d_%d", nestID, pokemonID, resetTime)
 
-	if dc.cache.Get(key) != nil {
+	if dc.seen.Has(key) {
 		return true
 	}
 
@@ -232,6 +232,6 @@ func (dc *DuplicateCache) CheckNest(nestID int64, pokemonID int, resetTime int64
 	if remaining <= 0 {
 		remaining = 3600
 	}
-	dc.cache.Set(key, true, time.Duration(remaining)*time.Second)
+	dc.seen.Add(key, time.Duration(remaining)*time.Second)
 	return false
 }

--- a/processor/internal/tracker/duplicate_test.go
+++ b/processor/internal/tracker/duplicate_test.go
@@ -1,6 +1,8 @@
 package tracker
 
 import (
+	"runtime"
+	"strconv"
 	"testing"
 	"time"
 )
@@ -213,4 +215,57 @@ func TestRsvpChanged(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestDuplicateCacheMemoryPerEntry pins the per-entry cost of the dedup set.
+//
+// The ttlcache this replaced spent ~233 B to remember a single bool: an Item
+// struct, a retained key string, a container/list node and an expiry-heap
+// entry. At scanner throughput the live set runs to millions of keys, which
+// measured 1.42 GB in a production heap profile.
+func TestDuplicateCacheMemoryPerEntry(t *testing.T) {
+	dc := NewDuplicateCache()
+	defer dc.Close()
+
+	const entries = 500_000
+	// Far enough out that nothing expires mid-test.
+	disappear := time.Now().Unix() + 3600
+
+	runtime.GC()
+	var before runtime.MemStats
+	runtime.ReadMemStats(&before)
+
+	for i := range entries {
+		dc.CheckPokemon(encounterIDForTest(i), true, 1500, disappear)
+	}
+
+	runtime.GC()
+	var after runtime.MemStats
+	runtime.ReadMemStats(&after)
+
+	growth := int64(after.HeapAlloc) - int64(before.HeapAlloc)
+	if growth < 0 {
+		growth = 0
+	}
+	perEntry := float64(growth) / entries
+
+	// ttlcache measured ~233 B/entry; a hash set measures ~25 B. 60 B is well
+	// clear of both, so this catches a regression back to boxed entries
+	// without being brittle about map growth slack.
+	const limitPerEntry = 60
+	t.Logf("dedup cache: %.1f B/entry over %d entries (%.1f MB)", perEntry, entries, float64(growth)/(1<<20))
+	if perEntry > limitPerEntry {
+		t.Errorf("dedup cache used %.1f B/entry over %d entries (%.1f MB total), want <= %d B/entry",
+			perEntry, entries, float64(growth)/(1<<20), limitPerEntry)
+	}
+}
+
+// encounterIDForTest builds a golbat-shaped 19-digit encounter id.
+func encounterIDForTest(i int) string {
+	const base = 1_000_000_000_000_000_000
+	return fmtInt(base + i)
+}
+
+func fmtInt(v int) string {
+	return strconv.Itoa(v)
 }

--- a/processor/internal/tracker/expiring_set.go
+++ b/processor/internal/tracker/expiring_set.go
@@ -1,0 +1,135 @@
+package tracker
+
+import (
+	"hash/maphash"
+	"sync"
+	"time"
+)
+
+// expiringSetShards is the number of independently-locked shards. Sweeping
+// takes one shard's lock at a time, so a full sweep of a multi-million-entry
+// set never blocks the webhook path for more than a fraction of the total
+// scan.
+const expiringSetShards = 16
+
+// expiringSweepInterval is how often the background sweeper reclaims expired
+// fingerprints. Reads expire lazily regardless, so this only bounds memory,
+// never correctness.
+const expiringSweepInterval = time.Minute
+
+// expiringSet is a set of key fingerprints with per-entry expiry.
+//
+// It exists because storing dedup keys in a ttlcache cost ~265 B per entry —
+// a boxed item, the retained key string, a container/list node and an
+// expiry-heap entry — to remember a single bit. At scanner throughput the
+// live set runs to millions of keys, which measured 1.42 GB (44.8% of live
+// heap) in a production profile. Hashing the key to a uint64 and storing only
+// its expiry brings that to ~25 B per entry.
+//
+// Keys are fingerprinted, not retained, so a 64-bit collision would read as a
+// false duplicate and drop one alert. Against a live set of ~6M entries that
+// is ~3.3e-13 per insert, or roughly one dropped alert every few decades at
+// production insert rates.
+type expiringSet struct {
+	seed   maphash.Seed
+	shards [expiringSetShards]expiringShard
+	stop   chan struct{}
+	once   sync.Once
+}
+
+type expiringShard struct {
+	mu sync.Mutex
+	// entries maps a key fingerprint to its expiry in unix nanoseconds.
+	// Nanoseconds rather than seconds so a sub-second TTL is not truncated
+	// into the past on write; the value is 8 bytes either way.
+	entries map[uint64]int64
+}
+
+func newExpiringSet() *expiringSet {
+	s := &expiringSet{
+		seed: maphash.MakeSeed(),
+		stop: make(chan struct{}),
+	}
+	for i := range s.shards {
+		s.shards[i].entries = make(map[uint64]int64)
+	}
+	go s.sweepLoop()
+	return s
+}
+
+func (s *expiringSet) fingerprint(key string) uint64 {
+	return maphash.String(s.seed, key)
+}
+
+func (s *expiringSet) shardFor(fp uint64) *expiringShard {
+	return &s.shards[fp%expiringSetShards]
+}
+
+// Has reports whether key is present and unexpired. Entries past their expiry
+// read as absent even when the sweeper has not reclaimed them yet.
+func (s *expiringSet) Has(key string) bool {
+	fp := s.fingerprint(key)
+	sh := s.shardFor(fp)
+
+	sh.mu.Lock()
+	defer sh.mu.Unlock()
+
+	expiry, ok := sh.entries[fp]
+	return ok && expiry > time.Now().UnixNano()
+}
+
+// Add records key for the given ttl, replacing any existing expiry.
+func (s *expiringSet) Add(key string, ttl time.Duration) {
+	fp := s.fingerprint(key)
+	sh := s.shardFor(fp)
+
+	expiry := time.Now().Add(ttl).UnixNano()
+
+	sh.mu.Lock()
+	sh.entries[fp] = expiry
+	sh.mu.Unlock()
+}
+
+// Len returns the number of entries still held, expired or not.
+func (s *expiringSet) Len() int {
+	var n int
+	for i := range s.shards {
+		s.shards[i].mu.Lock()
+		n += len(s.shards[i].entries)
+		s.shards[i].mu.Unlock()
+	}
+	return n
+}
+
+// Close stops the background sweeper. Safe to call more than once.
+func (s *expiringSet) Close() {
+	s.once.Do(func() { close(s.stop) })
+}
+
+func (s *expiringSet) sweepLoop() {
+	ticker := time.NewTicker(expiringSweepInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-s.stop:
+			return
+		case <-ticker.C:
+			s.sweep(time.Now().UnixNano())
+		}
+	}
+}
+
+// sweep drops expired entries, taking one shard lock at a time. now is unix
+// nanoseconds.
+func (s *expiringSet) sweep(now int64) {
+	for i := range s.shards {
+		sh := &s.shards[i]
+		sh.mu.Lock()
+		for fp, expiry := range sh.entries {
+			if expiry <= now {
+				delete(sh.entries, fp)
+			}
+		}
+		sh.mu.Unlock()
+	}
+}

--- a/processor/internal/tracker/expiring_set.go
+++ b/processor/internal/tracker/expiring_set.go
@@ -2,6 +2,7 @@ package tracker
 
 import (
 	"hash/maphash"
+	"strconv"
 	"sync"
 	"time"
 )
@@ -65,6 +66,73 @@ func (s *expiringSet) fingerprint(key string) uint64 {
 
 func (s *expiringSet) shardFor(fp uint64) *expiringShard {
 	return &s.shards[fp%expiringSetShards]
+}
+
+// keyWriter accumulates a dedup key's components directly into a hash, so the
+// key never exists as a string. The old path built one with fmt.Sprintf per
+// webhook purely for maphash to consume and discard.
+//
+// Components are zero-separated. The concatenation this replaced was
+// ambiguous in principle — ("ab","c") and ("a","bc") produced the same key —
+// which the separator removes.
+type keyWriter struct{ h maphash.Hash }
+
+func (k *keyWriter) Str(v string) *keyWriter {
+	_, _ = k.h.WriteString(v)
+	_ = k.h.WriteByte(0)
+	return k
+}
+
+func (k *keyWriter) Int(v int64) *keyWriter {
+	var buf [20]byte
+	_, _ = k.h.Write(strconv.AppendInt(buf[:0], v, 10))
+	_ = k.h.WriteByte(0)
+	return k
+}
+
+func (k *keyWriter) Bool(v bool) *keyWriter {
+	b := byte('F')
+	if v {
+		b = 'T'
+	}
+	_ = k.h.WriteByte(b)
+	_ = k.h.WriteByte(0)
+	return k
+}
+
+// newKey returns a keyWriter seeded for this set. Returned by value and used
+// as a local so it never escapes: taking its address across a function
+// boundary (for example by passing a build callback) makes escape analysis
+// heap-allocate it, which is the allocation this whole path exists to avoid.
+//
+// maphash.Hash must not be copied after first use; this copy happens before
+// any write.
+func (s *expiringSet) newKey() keyWriter {
+	var k keyWriter
+	k.h.SetSeed(s.seed)
+	return k
+}
+
+// CheckAndAdd reports whether the key was already present and unexpired, and
+// records it with ttl when it was not.
+//
+// One hash and one lock acquisition, against the two each that a Has-miss
+// followed by Add cost. It also closes the check-then-act window in the old
+// pairing, where two workers handling the same encounter could both miss and
+// both deliver.
+func (s *expiringSet) CheckAndAdd(k *keyWriter, ttl time.Duration) bool {
+	fp := k.h.Sum64()
+	sh := s.shardFor(fp)
+	now := time.Now()
+
+	sh.mu.Lock()
+	defer sh.mu.Unlock()
+
+	if expiry, ok := sh.entries[fp]; ok && expiry > now.UnixNano() {
+		return true
+	}
+	sh.entries[fp] = now.Add(ttl).UnixNano()
+	return false
 }
 
 // Has reports whether key is present and unexpired. Entries past their expiry

--- a/processor/internal/tracker/expiring_set.go
+++ b/processor/internal/tracker/expiring_set.go
@@ -34,6 +34,7 @@ type expiringSet struct {
 	seed   maphash.Seed
 	shards [expiringSetShards]expiringShard
 	stop   chan struct{}
+	done   chan struct{}
 	once   sync.Once
 }
 
@@ -49,6 +50,7 @@ func newExpiringSet() *expiringSet {
 	s := &expiringSet{
 		seed: maphash.MakeSeed(),
 		stop: make(chan struct{}),
+		done: make(chan struct{}),
 	}
 	for i := range s.shards {
 		s.shards[i].entries = make(map[uint64]int64)
@@ -101,12 +103,20 @@ func (s *expiringSet) Len() int {
 	return n
 }
 
-// Close stops the background sweeper. Safe to call more than once.
+// Close stops the background sweeper and waits for it to exit. Safe to call
+// more than once.
+//
+// The wait matters: sweep holds a shard lock while it scans, so a Close that
+// returned early would leave DuplicateCache.Close's step of the shutdown
+// ordering non-quiescent. mute.Sweeper and snapshots.Sweeper use the same
+// stop/done/once trio.
 func (s *expiringSet) Close() {
 	s.once.Do(func() { close(s.stop) })
+	<-s.done
 }
 
 func (s *expiringSet) sweepLoop() {
+	defer close(s.done)
 	ticker := time.NewTicker(expiringSweepInterval)
 	defer ticker.Stop()
 	for {

--- a/processor/internal/tracker/expiring_set_test.go
+++ b/processor/internal/tracker/expiring_set_test.go
@@ -1,6 +1,9 @@
 package tracker
 
 import (
+	"fmt"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -100,4 +103,110 @@ func TestExpiringSetCloseWaitsForSweeper(t *testing.T) {
 	// Close is idempotent — DuplicateCache.Close may be reached twice during
 	// a shutdown that is itself racing a signal handler.
 	s.Close()
+}
+
+func BenchmarkExpiringSetCheckAndAdd(b *testing.B) {
+	s := newExpiringSet()
+	defer s.Close()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; b.Loop(); i++ {
+		k := s.newKey()
+		k.Str("47281957203847502").Bool(true).Int(1500)
+		s.CheckAndAdd(&k, time.Hour)
+	}
+}
+
+func BenchmarkDuplicateCacheCheckPokemon(b *testing.B) {
+	dc := NewDuplicateCache()
+	defer dc.Close()
+	disappear := time.Now().Unix() + 3600
+
+	// Pre-generate ids so the benchmark measures the dedup path rather than
+	// strconv in the harness.
+	const n = 4096
+	ids := make([]string, n)
+	for i := range ids {
+		ids[i] = encounterIDForTest(i)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; b.Loop(); i++ {
+		dc.CheckPokemon(ids[i%n], true, 1500, disappear)
+	}
+}
+
+// BenchmarkExpiringSetHasThenAdd measures the pattern CheckAndAdd replaced:
+// build the key with fmt.Sprintf, hash it once for Has, then hash it again
+// for Add and take the shard lock a second time. Kept alongside its
+// replacement so the comparison is same-harness rather than across commits.
+func BenchmarkExpiringSetHasThenAdd(b *testing.B) {
+	s := newExpiringSet()
+	defer s.Close()
+
+	const id = "47281957203847502"
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		key := fmt.Sprintf("%s%s%d", id, "T", 1500)
+		if !s.Has(key) {
+			s.Add(key, time.Hour)
+		}
+	}
+}
+
+// TestCheckAndAddIsAtomic pins the check-then-act window that the old
+// Has-miss-then-Add pairing left open: two workers handling the same encounter
+// concurrently could both miss and both deliver. Exactly one caller must see
+// the key as new.
+func TestCheckAndAddIsAtomic(t *testing.T) {
+	s := newExpiringSet()
+	defer s.Close()
+
+	const workers = 64
+	var start sync.WaitGroup
+	var done sync.WaitGroup
+	var firsts atomic.Int64
+
+	start.Add(1)
+	for range workers {
+		done.Add(1)
+		go func() {
+			defer done.Done()
+			start.Wait()
+			k := s.newKey()
+			k.Str("same-encounter").Bool(true).Int(1500)
+			if !s.CheckAndAdd(&k, time.Hour) {
+				firsts.Add(1)
+			}
+		}()
+	}
+	start.Done()
+	done.Wait()
+
+	if got := firsts.Load(); got != 1 {
+		t.Errorf("%d workers saw the key as new, want exactly 1", got)
+	}
+}
+
+// TestKeyWriterSeparatesComponents guards against the ambiguity in the string
+// concatenation this replaced: ("ab","c") and ("a","bc") produced the same key.
+func TestKeyWriterSeparatesComponents(t *testing.T) {
+	s := newExpiringSet()
+	defer s.Close()
+
+	a := s.newKey()
+	a.Str("ab").Str("c")
+	b := s.newKey()
+	b.Str("a").Str("bc")
+
+	if s.CheckAndAdd(&a, time.Hour) {
+		t.Fatal("first key should be new")
+	}
+	if s.CheckAndAdd(&b, time.Hour) {
+		t.Error(`("a","bc") collided with ("ab","c"): components are not separated`)
+	}
 }

--- a/processor/internal/tracker/expiring_set_test.go
+++ b/processor/internal/tracker/expiring_set_test.go
@@ -8,21 +8,26 @@ import (
 // TestDuplicateCacheEntryExpires covers the behaviour the dedup path depends
 // on: once a key's TTL has passed the same webhook must be treated as fresh
 // again, whether or not the sweeper has run.
-func TestDuplicateCacheEntryExpires(t *testing.T) {
-	dc := NewDuplicateCache()
-	defer dc.Close()
+func TestExpiringSetEntryExpires(t *testing.T) {
+	s := newExpiringSet()
+	defer s.Close()
 
-	// disappear_time already in the past clamps the TTL to its 60s floor,
-	// so drive expiry through the set directly with a sub-second TTL.
-	dc.seen.Add("encounter-1", 10*time.Millisecond)
+	// The TTL has to outlast a scheduling hiccup between Add and the
+	// presence check: a GC pause or a loaded runner descheduling this
+	// goroutine would otherwise expire the entry before it is read and fail
+	// the test for reasons that have nothing to do with the code. The expiry
+	// half is safe in the other direction, since over-sleeping cannot
+	// resurrect an entry.
+	const ttl = 250 * time.Millisecond
+	s.Add("encounter-1", ttl)
 
-	if !dc.seen.Has("encounter-1") {
+	if !s.Has("encounter-1") {
 		t.Fatal("key should be present immediately after Add")
 	}
 
-	time.Sleep(30 * time.Millisecond)
+	time.Sleep(ttl + 50*time.Millisecond)
 
-	if dc.seen.Has("encounter-1") {
+	if s.Has("encounter-1") {
 		t.Error("key should read as absent once its TTL has passed, before any sweep")
 	}
 }

--- a/processor/internal/tracker/expiring_set_test.go
+++ b/processor/internal/tracker/expiring_set_test.go
@@ -81,3 +81,23 @@ func TestExpiringSetSpreadsAcrossShards(t *testing.T) {
 		t.Errorf("expected all %d shards populated, got %d", expiringSetShards, populated)
 	}
 }
+
+// TestExpiringSetCloseWaitsForSweeper asserts Close is synchronous: when it
+// returns, the sweep goroutine has actually exited and is no longer holding
+// shard locks. DuplicateCache.Close runs during the documented shutdown
+// ordering's "duplicates" step, which is only meaningfully quiescent if this
+// holds.
+func TestExpiringSetCloseWaitsForSweeper(t *testing.T) {
+	s := newExpiringSet()
+	s.Close()
+
+	select {
+	case <-s.done:
+	default:
+		t.Error("Close returned while sweepLoop was still running")
+	}
+
+	// Close is idempotent — DuplicateCache.Close may be reached twice during
+	// a shutdown that is itself racing a signal handler.
+	s.Close()
+}

--- a/processor/internal/tracker/expiring_set_test.go
+++ b/processor/internal/tracker/expiring_set_test.go
@@ -1,0 +1,78 @@
+package tracker
+
+import (
+	"testing"
+	"time"
+)
+
+// TestDuplicateCacheEntryExpires covers the behaviour the dedup path depends
+// on: once a key's TTL has passed the same webhook must be treated as fresh
+// again, whether or not the sweeper has run.
+func TestDuplicateCacheEntryExpires(t *testing.T) {
+	dc := NewDuplicateCache()
+	defer dc.Close()
+
+	// disappear_time already in the past clamps the TTL to its 60s floor,
+	// so drive expiry through the set directly with a sub-second TTL.
+	dc.seen.Add("encounter-1", 10*time.Millisecond)
+
+	if !dc.seen.Has("encounter-1") {
+		t.Fatal("key should be present immediately after Add")
+	}
+
+	time.Sleep(30 * time.Millisecond)
+
+	if dc.seen.Has("encounter-1") {
+		t.Error("key should read as absent once its TTL has passed, before any sweep")
+	}
+}
+
+// TestExpiringSetSweepReclaimsExpiredEntries asserts the sweeper actually
+// frees entries rather than only hiding them from reads — the whole point of
+// the change is bounded memory, and lazy expiry alone would never reclaim.
+func TestExpiringSetSweepReclaimsExpiredEntries(t *testing.T) {
+	s := newExpiringSet()
+	defer s.Close()
+
+	for i := range 1000 {
+		s.Add(encounterIDForTest(i), time.Hour)
+	}
+	for i := 1000; i < 2000; i++ {
+		s.Add(encounterIDForTest(i), time.Millisecond)
+	}
+
+	if got := s.Len(); got != 2000 {
+		t.Fatalf("expected 2000 entries before sweep, got %d", got)
+	}
+
+	time.Sleep(10 * time.Millisecond)
+	s.sweep(time.Now().UnixNano())
+
+	if got := s.Len(); got != 1000 {
+		t.Errorf("expected the 1000 expired entries to be reclaimed, got %d remaining", got)
+	}
+}
+
+// TestExpiringSetSpreadsAcrossShards guards the sharding: a single-shard set
+// would serialise every dedup check on one mutex at scanner throughput.
+func TestExpiringSetSpreadsAcrossShards(t *testing.T) {
+	s := newExpiringSet()
+	defer s.Close()
+
+	for i := range 10_000 {
+		s.Add(encounterIDForTest(i), time.Hour)
+	}
+
+	populated := 0
+	for i := range s.shards {
+		s.shards[i].mu.Lock()
+		if len(s.shards[i].entries) > 0 {
+			populated++
+		}
+		s.shards[i].mu.Unlock()
+	}
+
+	if populated != expiringSetShards {
+		t.Errorf("expected all %d shards populated, got %d", expiringSetShards, populated)
+	}
+}

--- a/processor/internal/tracker/rarity.go
+++ b/processor/internal/tracker/rarity.go
@@ -82,19 +82,32 @@ type StatsTracker struct {
 	groups  map[int]int        // pokemon_id -> rarity group
 	shiny   map[int]ShinyStats // pokemon_id -> shiny stats (cached)
 
-	// now is the clock, injectable so window expiry can be tested without
-	// sleeping. Defaults to time.Now().Unix.
-	now func() int64
+	// nowFunc is the clock, injectable so window expiry can be tested
+	// without sleeping. Defaults to time.Now. Set once at construction and
+	// never reassigned: recalcLoop reads it from its own goroutine, so a
+	// later write would be a data race.
+	nowFunc func() time.Time
 }
 
 // NewStatsTracker creates a new stats tracker with the given config.
 func NewStatsTracker(cfg StatsConfig) *StatsTracker {
+	return newStatsTrackerWithClock(cfg, time.Now)
+}
+
+// newStatsTrackerWithClock creates a tracker with an injectable clock, used in
+// tests to control the rolling window without wall-clock dependencies.
+// Mirrors newRateCounterWithClock in internal/webhook.
+//
+// The clock is a constructor parameter rather than an exported field because
+// recalcLoop starts here: anything assigned afterwards would be written by the
+// caller while that goroutine reads it.
+func newStatsTrackerWithClock(cfg StatsConfig, nowFunc func() time.Time) *StatsTracker {
 	st := &StatsTracker{
 		cfg:     cfg,
 		buckets: newBucketRing(cfg.WindowHours),
 		groups:  make(map[int]int),
 		shiny:   make(map[int]ShinyStats),
-		now:     func() int64 { return time.Now().Unix() },
+		nowFunc: nowFunc,
 	}
 	go st.recalcLoop()
 	return st
@@ -134,7 +147,7 @@ func (st *StatsTracker) RecordSighting(pokemonID int, ivScanned bool, isShiny bo
 	st.mu.Lock()
 	defer st.mu.Unlock()
 
-	minute := st.now() / 60
+	minute := st.nowFunc().Unix() / 60
 	b := &st.buckets[int(minute%int64(len(st.buckets)))]
 	if b.minute != minute {
 		b.reset(minute)
@@ -214,7 +227,7 @@ type counters struct {
 //
 // Caller must hold at least a read lock.
 func (st *StatsTracker) aggregate() (map[int]*counters, int64) {
-	oldest := st.now()/60 - int64(windowMinutes(st.cfg.WindowHours))
+	oldest := st.nowFunc().Unix()/60 - int64(windowMinutes(st.cfg.WindowHours))
 
 	counts := make(map[int]*counters)
 	var totalAll int64
@@ -241,7 +254,7 @@ func (st *StatsTracker) aggregate() (map[int]*counters, int64) {
 // totalInWindow counts sightings still inside the window without building the
 // per-species aggregate. Caller must hold at least a read lock.
 func (st *StatsTracker) totalInWindow() int64 {
-	oldest := st.now()/60 - int64(windowMinutes(st.cfg.WindowHours))
+	oldest := st.nowFunc().Unix()/60 - int64(windowMinutes(st.cfg.WindowHours))
 	var total int64
 	for i := range st.buckets {
 		if st.buckets[i].minute >= oldest {

--- a/processor/internal/tracker/rarity.go
+++ b/processor/internal/tracker/rarity.go
@@ -47,6 +47,14 @@ type speciesCounts struct {
 // (minute, species) instead of one record per sighting is what keeps this
 // tracker's memory bounded: size is a function of the window length and the
 // number of distinct species, never of webhook throughput.
+//
+// This ring is mechanically the same as webhook.RateCounter's: slot index is
+// (unix/60 % len), a slot whose stored minute differs is stale and reset in
+// place rather than allocated, and reads filter by age instead of sweeping.
+// The two differ in what they hold (per-species counters here, per-type counts
+// there) and in whether the window is configurable, which is why they are not
+// one type today. Keep them in step: a boundary bug found in one is almost
+// certainly present in the other.
 type statsBucket struct {
 	minute  int64 // wall-clock minute this bucket covers; -1 when unused
 	total   int64
@@ -221,13 +229,21 @@ type counters struct {
 	shinyScanned int64
 }
 
+// oldestMinute is the earliest minute still inside the rolling window.
+//
+// One definition so aggregate and totalInWindow cannot answer "is this bucket
+// still in the window?" differently. Caller must hold at least a read lock.
+func (st *StatsTracker) oldestMinute() int64 {
+	return st.nowFunc().Unix()/60 - int64(windowMinutes(st.cfg.WindowHours))
+}
+
 // aggregate sums every bucket still inside the window. Buckets that have
 // fallen out are left alone — they are recycled in place the next time
 // RecordSighting lands on their ring slot.
 //
 // Caller must hold at least a read lock.
 func (st *StatsTracker) aggregate() (map[int]*counters, int64) {
-	oldest := st.nowFunc().Unix()/60 - int64(windowMinutes(st.cfg.WindowHours))
+	oldest := st.oldestMinute()
 
 	counts := make(map[int]*counters)
 	var totalAll int64
@@ -254,7 +270,7 @@ func (st *StatsTracker) aggregate() (map[int]*counters, int64) {
 // totalInWindow counts sightings still inside the window without building the
 // per-species aggregate. Caller must hold at least a read lock.
 func (st *StatsTracker) totalInWindow() int64 {
-	oldest := st.nowFunc().Unix()/60 - int64(windowMinutes(st.cfg.WindowHours))
+	oldest := st.oldestMinute()
 	var total int64
 	for i := range st.buckets {
 		if st.buckets[i].minute >= oldest {

--- a/processor/internal/tracker/rarity.go
+++ b/processor/internal/tracker/rarity.go
@@ -164,8 +164,27 @@ func (st *StatsTracker) GetShinyRate(pokemonID int) float64 {
 	return 0
 }
 
+// defaultRecalcIntervalMins is the fallback cadence when the configured value
+// is missing or nonsensical. Matches the [stats] refresh_interval_mins default.
+const defaultRecalcIntervalMins = 5
+
+// recalcInterval converts the configured refresh interval into a ticker
+// duration, flooring non-positive values.
+//
+// time.NewTicker panics on a non-positive interval, and an explicit
+// `refresh_interval_mins = 0` survives config defaulting because toml decodes
+// over the pre-populated defaults struct. Without the floor that panic fires
+// in recalcLoop's goroutine during startup and takes the processor with it.
+// windowMinutes floors its sibling field for the same reason.
+func recalcInterval(mins int) time.Duration {
+	if mins < 1 {
+		mins = defaultRecalcIntervalMins
+	}
+	return time.Duration(mins) * time.Minute
+}
+
 func (st *StatsTracker) recalcLoop() {
-	interval := time.Duration(st.cfg.RefreshIntervalMins) * time.Minute
+	interval := recalcInterval(st.cfg.RefreshIntervalMins)
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 	for range ticker.C {

--- a/processor/internal/tracker/rarity.go
+++ b/processor/internal/tracker/rarity.go
@@ -35,12 +35,34 @@ type StatsConfig struct {
 	UltraRare           float64
 }
 
-// sighting records a pokemon sighting with its timestamp.
-type sighting struct {
-	pokemonID int
-	timestamp int64
-	ivScanned bool // true if pokemon had IV data (full encounter)
-	shiny     bool // true if confirmed shiny
+// speciesCounts aggregates one species' sightings inside a single time bucket.
+type speciesCounts struct {
+	all   int32
+	iv    int32 // sightings that carried IV data (a full encounter)
+	shiny int32 // IV-scanned sightings confirmed shiny
+}
+
+// statsBucket holds one minute of aggregated sightings. Storing counters per
+// (minute, species) instead of one record per sighting is what keeps this
+// tracker's memory bounded: size is a function of the window length and the
+// number of distinct species, never of webhook throughput.
+type statsBucket struct {
+	minute  int64 // wall-clock minute this bucket covers; -1 when unused
+	total   int64
+	species map[int32]speciesCounts
+}
+
+// reset re-points a bucket at a new minute, dropping whatever it held. The
+// map is cleared rather than reallocated so the ring reaches a steady state
+// and stops allocating entirely.
+func (b *statsBucket) reset(minute int64) {
+	b.minute = minute
+	b.total = 0
+	if b.species == nil {
+		b.species = make(map[int32]speciesCounts)
+		return
+	}
+	clear(b.species)
 }
 
 // ShinyStats holds the stats for a single pokemon.
@@ -53,35 +75,72 @@ type ShinyStats struct {
 // StatsTracker maintains rolling pokemon sighting counts and computes
 // rarity groups and shiny stats within the same time window.
 type StatsTracker struct {
-	mu        sync.RWMutex
-	cfg       StatsConfig
-	sightings []sighting
-	groups    map[int]int        // pokemon_id -> rarity group
-	shiny     map[int]ShinyStats // pokemon_id -> shiny stats (cached)
+	mu      sync.RWMutex
+	cfg     StatsConfig
+	buckets []statsBucket      // ring of per-minute counters covering the window
+	groups  map[int]int        // pokemon_id -> rarity group
+	shiny   map[int]ShinyStats // pokemon_id -> shiny stats (cached)
+
+	// now is the clock, injectable so window expiry can be tested without
+	// sleeping. Defaults to time.Now().Unix.
+	now func() int64
 }
 
 // NewStatsTracker creates a new stats tracker with the given config.
 func NewStatsTracker(cfg StatsConfig) *StatsTracker {
 	st := &StatsTracker{
-		cfg:    cfg,
-		groups: make(map[int]int),
-		shiny:  make(map[int]ShinyStats),
+		cfg:     cfg,
+		buckets: newBucketRing(cfg.WindowHours),
+		groups:  make(map[int]int),
+		shiny:   make(map[int]ShinyStats),
+		now:     func() int64 { return time.Now().Unix() },
 	}
 	go st.recalcLoop()
 	return st
+}
+
+// newBucketRing sizes the ring to cover the whole window inclusively: one
+// bucket per minute plus the current partial minute.
+func newBucketRing(windowHours int) []statsBucket {
+	count := windowMinutes(windowHours) + 1
+	ring := make([]statsBucket, count)
+	for i := range ring {
+		ring[i].minute = -1
+	}
+	return ring
+}
+
+// windowMinutes is the configured rolling window expressed in whole minutes,
+// floored at one so a misconfigured zero still yields a usable ring.
+func windowMinutes(windowHours int) int {
+	if windowHours < 1 {
+		return 1
+	}
+	return windowHours * 60
 }
 
 // RecordSighting records a pokemon sighting. ivScanned indicates whether the
 // pokemon had IV data (a full encounter). isShiny indicates a confirmed shiny.
 func (st *StatsTracker) RecordSighting(pokemonID int, ivScanned bool, isShiny bool) {
 	st.mu.Lock()
-	st.sightings = append(st.sightings, sighting{
-		pokemonID: pokemonID,
-		timestamp: time.Now().Unix(),
-		ivScanned: ivScanned,
-		shiny:     isShiny,
-	})
-	st.mu.Unlock()
+	defer st.mu.Unlock()
+
+	minute := st.now() / 60
+	b := &st.buckets[int(minute%int64(len(st.buckets)))]
+	if b.minute != minute {
+		b.reset(minute)
+	}
+
+	c := b.species[int32(pokemonID)]
+	c.all++
+	if ivScanned {
+		c.iv++
+		if isShiny {
+			c.shiny++
+		}
+	}
+	b.species[int32(pokemonID)] = c
+	b.total++
 }
 
 // GetRarityGroup returns the rarity group for a pokemon.
@@ -114,43 +173,61 @@ func (st *StatsTracker) recalcLoop() {
 	}
 }
 
+// counters is the per-species aggregate over the whole window.
+type counters struct {
+	allScanned   int64
+	ivScanned    int64
+	shinyScanned int64
+}
+
+// aggregate sums every bucket still inside the window. Buckets that have
+// fallen out are left alone — they are recycled in place the next time
+// RecordSighting lands on their ring slot.
+//
+// Caller must hold at least a read lock.
+func (st *StatsTracker) aggregate() (map[int]*counters, int64) {
+	oldest := st.now()/60 - int64(windowMinutes(st.cfg.WindowHours))
+
+	counts := make(map[int]*counters)
+	var totalAll int64
+	for i := range st.buckets {
+		b := &st.buckets[i]
+		if b.minute < oldest {
+			continue
+		}
+		for id, sc := range b.species {
+			c := counts[int(id)]
+			if c == nil {
+				c = &counters{}
+				counts[int(id)] = c
+			}
+			c.allScanned += int64(sc.all)
+			c.ivScanned += int64(sc.iv)
+			c.shinyScanned += int64(sc.shiny)
+		}
+		totalAll += b.total
+	}
+	return counts, totalAll
+}
+
+// totalInWindow counts sightings still inside the window without building the
+// per-species aggregate. Caller must hold at least a read lock.
+func (st *StatsTracker) totalInWindow() int64 {
+	oldest := st.now()/60 - int64(windowMinutes(st.cfg.WindowHours))
+	var total int64
+	for i := range st.buckets {
+		if st.buckets[i].minute >= oldest {
+			total += st.buckets[i].total
+		}
+	}
+	return total
+}
+
 func (st *StatsTracker) recalculate() {
 	st.mu.Lock()
 	defer st.mu.Unlock()
 
-	// Prune sightings outside the window
-	cutoff := time.Now().Unix() - int64(st.cfg.WindowHours)*3600
-	pruned := st.sightings[:0]
-	for _, s := range st.sightings {
-		if s.timestamp >= cutoff {
-			pruned = append(pruned, s)
-		}
-	}
-	st.sightings = pruned
-
-	// Count per species
-	type counters struct {
-		allScanned   int64
-		ivScanned    int64
-		shinyScanned int64
-	}
-	counts := make(map[int]*counters)
-	var totalAll int64
-	for _, s := range st.sightings {
-		c := counts[s.pokemonID]
-		if c == nil {
-			c = &counters{}
-			counts[s.pokemonID] = c
-		}
-		c.allScanned++
-		totalAll++
-		if s.ivScanned {
-			c.ivScanned++
-			if s.shiny {
-				c.shinyScanned++
-			}
-		}
-	}
+	counts, totalAll := st.aggregate()
 
 	// Rarity groups (require minimum sample size)
 	if totalAll >= int64(st.cfg.MinSampleSize) {
@@ -196,7 +273,7 @@ func (st *StatsTracker) recalculate() {
 // Triggers a recalculation if groups are empty but sighting data exists.
 func (st *StatsTracker) ExportGroups() map[int][]int {
 	st.mu.RLock()
-	needsCalc := len(st.groups) == 0 && len(st.sightings) >= st.cfg.MinSampleSize
+	needsCalc := len(st.groups) == 0 && st.totalInWindow() >= int64(st.cfg.MinSampleSize)
 	st.mu.RUnlock()
 
 	if needsCalc {
@@ -245,7 +322,7 @@ func (st *StatsTracker) ExportShinyPossible() map[string]any {
 // Reset clears all sightings and computed stats.
 func (st *StatsTracker) Reset() {
 	st.mu.Lock()
-	st.sightings = nil
+	st.buckets = newBucketRing(st.cfg.WindowHours)
 	st.groups = make(map[int]int)
 	st.shiny = make(map[int]ShinyStats)
 	st.mu.Unlock()

--- a/processor/internal/tracker/rarity.go
+++ b/processor/internal/tracker/rarity.go
@@ -2,6 +2,7 @@ package tracker
 
 import (
 	"maps"
+	"math"
 	"sort"
 	"sync"
 	"time"
@@ -122,6 +123,14 @@ func windowMinutes(windowHours int) int {
 // RecordSighting records a pokemon sighting. ivScanned indicates whether the
 // pokemon had IV data (a full encounter). isShiny indicates a confirmed shiny.
 func (st *StatsTracker) RecordSighting(pokemonID int, ivScanned bool, isShiny bool) {
+	// Bucket keys are int32 to halve the map key width. POST / is
+	// unauthenticated and does not range-check pokemon_id, so an
+	// out-of-range value would wrap to a negative key and surface in the
+	// rarity and shiny exports as a nonsense species. Drop it instead.
+	if pokemonID <= 0 || pokemonID > math.MaxInt32 {
+		return
+	}
+
 	st.mu.Lock()
 	defer st.mu.Unlock()
 

--- a/processor/internal/tracker/rarity_test.go
+++ b/processor/internal/tracker/rarity_test.go
@@ -1,6 +1,7 @@
 package tracker
 
 import (
+	"runtime"
 	"testing"
 )
 
@@ -110,5 +111,101 @@ func TestStatsTrackerReset(t *testing.T) {
 	group = st.GetRarityGroup(25)
 	if group != RarityUnknown {
 		t.Error("Expected unknown rarity after reset")
+	}
+}
+
+// TestStatsTrackerMemoryIsIndependentOfSightingVolume pins the property that
+// makes this tracker safe at scanner throughput: resident memory is a function
+// of (species x time buckets), not of how many sightings were recorded.
+//
+// The per-sighting slice this replaced cost ~27.8 B per recorded sighting, so
+// a busy install (2000 webhooks/sec over an 8h window) held ~1.6 GB here. The
+// bucketed counters hold a bounded number of map entries no matter the volume.
+func TestStatsTrackerMemoryIsIndependentOfSightingVolume(t *testing.T) {
+	cfg := testStatsConfig()
+	cfg.WindowHours = 8
+	st := NewStatsTracker(cfg)
+
+	const sightings = 2_000_000
+	const species = 600
+
+	runtime.GC()
+	var before runtime.MemStats
+	runtime.ReadMemStats(&before)
+
+	for i := range sightings {
+		st.RecordSighting(i%species, i%10 == 0, i%1000 == 0)
+	}
+
+	runtime.GC()
+	var after runtime.MemStats
+	runtime.ReadMemStats(&after)
+
+	growth := int64(after.HeapAlloc) - int64(before.HeapAlloc)
+	if growth < 0 {
+		growth = 0
+	}
+
+	// Per-sighting storage would be ~55 MB for this volume. Bounded counters
+	// stay far under; 30 MB leaves generous headroom for either the ring or
+	// GC noise without letting a linear implementation through.
+	const limit = 30 << 20
+	if growth > limit {
+		t.Errorf("recording %d sightings grew the heap by %.1f MB, want <= %d MB — memory is scaling with sighting count",
+			sightings, float64(growth)/(1<<20), limit>>20)
+	}
+}
+
+// TestStatsTrackerDropsSightingsOutsideWindow covers behaviour the slice-based
+// tracker had but never tested: sightings older than window_hours stop counting.
+func TestStatsTrackerDropsSightingsOutsideWindow(t *testing.T) {
+	cfg := testStatsConfig()
+	cfg.WindowHours = 1
+	st := NewStatsTracker(cfg)
+
+	now := int64(1_700_000_000)
+	st.now = func() int64 { return now }
+
+	for range 500 {
+		st.RecordSighting(25, false, false)
+	}
+	st.recalculate()
+	if got := st.GetRarityGroup(25); got == RarityUnknown {
+		t.Fatal("expected a rarity group while the sightings are inside the window")
+	}
+
+	// Step past the window. Nothing new is recorded, so every bucket is stale.
+	now += 2 * 3600
+	st.recalculate()
+
+	if got := st.GetRarityGroup(25); got != RarityUnknown {
+		t.Errorf("expected RarityUnknown after the window elapsed, got %d", got)
+	}
+}
+
+// TestStatsTrackerRingRecyclesStaleBuckets guards the wrap-around: a bucket
+// reused a full window later must not carry its previous occupant's counts.
+func TestStatsTrackerRingRecyclesStaleBuckets(t *testing.T) {
+	cfg := testStatsConfig()
+	cfg.WindowHours = 1
+	st := NewStatsTracker(cfg)
+
+	now := int64(1_700_000_000)
+	st.now = func() int64 { return now }
+
+	for range 300 {
+		st.RecordSighting(25, false, false)
+	}
+
+	// Same ring slot, one full window later.
+	now += int64(len(st.buckets)) * 60
+	st.RecordSighting(150, false, false)
+	st.recalculate()
+
+	if got := st.GetRarityGroup(25); got != RarityUnknown {
+		t.Errorf("pokemon 25 should have aged out of the ring, got group %d", got)
+	}
+	if got := st.GetRarityGroup(150); got == RarityUnknown {
+		t.Error("pokemon 150 was just recorded and should have a group")
 	}
 }

--- a/processor/internal/tracker/rarity_test.go
+++ b/processor/internal/tracker/rarity_test.go
@@ -158,7 +158,13 @@ func TestStatsTrackerMemoryIsIndependentOfSightingVolume(t *testing.T) {
 }
 
 // TestStatsTrackerDropsSightingsOutsideWindow covers behaviour the slice-based
-// tracker had but never tested: sightings older than window_hours stop counting.
+// tracker had but never tested: sightings older than window_hours stop
+// counting.
+//
+// Note this holds only because testStatsConfig sets MinSampleSize 0. With a
+// production min_sample_size the drained window is below the threshold and
+// recalculate leaves the previous groups in place instead — see
+// TestStatsTrackerKeepsStaleGroupsBelowMinSampleSize, which pins that.
 func TestStatsTrackerDropsSightingsOutsideWindow(t *testing.T) {
 	cfg := testStatsConfig()
 	cfg.WindowHours = 1
@@ -272,4 +278,41 @@ func TestStatsTrackerClockIsRaceFree(t *testing.T) {
 		clock.advance(time.Minute)
 	}
 	<-done
+}
+
+// TestStatsTrackerKeepsStaleGroupsBelowMinSampleSize pins what actually
+// happens with a production min_sample_size when the window drains: the
+// groups update is skipped entirely (totalAll < MinSampleSize), so the last
+// computed groups persist rather than reverting to RarityUnknown.
+//
+// This is inherited behaviour, not a regression, and it is the reason an
+// operator can see stale rarity groups after an overnight scanner outage. It
+// is pinned here so the sibling test's name is not mistaken for the whole
+// contract.
+func TestStatsTrackerKeepsStaleGroupsBelowMinSampleSize(t *testing.T) {
+	cfg := testStatsConfig()
+	cfg.WindowHours = 1
+	cfg.MinSampleSize = 10
+
+	clock := newTestClock(1_700_000_000)
+	st := newStatsTrackerWithClock(cfg, clock.now)
+
+	for range 500 {
+		st.RecordSighting(25, false, false)
+	}
+	st.recalculate()
+
+	before := st.GetRarityGroup(25)
+	if before == RarityUnknown {
+		t.Fatal("expected a rarity group while the sightings are inside the window")
+	}
+
+	// Drain the window. totalAll is now 0, below MinSampleSize, so the
+	// groups map is left untouched.
+	clock.advance(2 * time.Hour)
+	st.recalculate()
+
+	if got := st.GetRarityGroup(25); got != before {
+		t.Errorf("group changed to %d after the window drained; below min_sample_size the previous groups are expected to persist (was %d)", got, before)
+	}
 }

--- a/processor/internal/tracker/rarity_test.go
+++ b/processor/internal/tracker/rarity_test.go
@@ -226,3 +226,29 @@ func TestRecalcIntervalFloorsNonPositive(t *testing.T) {
 		t.Errorf("recalcInterval(5) = %v, want 5m", got)
 	}
 }
+
+// TestStatsTrackerRejectsOutOfRangePokemonID guards the int32 narrowing.
+// POST / is unauthenticated and does not range-check pokemon_id, so a garbage
+// value would wrap to a negative species key and show up in the rarity and
+// shiny exports as a nonsense pokemon.
+func TestStatsTrackerRejectsOutOfRangePokemonID(t *testing.T) {
+	cfg := testStatsConfig()
+	st := NewStatsTracker(cfg)
+
+	const bogus = int(1)<<31 + 25 // wraps to -2147483623 under int32()
+
+	for range 100 {
+		st.RecordSighting(bogus, false, false)
+		st.RecordSighting(-5, false, false)
+	}
+	st.RecordSighting(25, false, false)
+	st.recalculate()
+
+	for group, ids := range st.ExportGroups() {
+		for _, id := range ids {
+			if id != 25 {
+				t.Errorf("out-of-range pokemon id leaked into rarity group %d as %d", group, id)
+			}
+		}
+	}
+}

--- a/processor/internal/tracker/rarity_test.go
+++ b/processor/internal/tracker/rarity_test.go
@@ -3,6 +3,7 @@ package tracker
 import (
 	"runtime"
 	"testing"
+	"time"
 )
 
 func testStatsConfig() StatsConfig {
@@ -207,5 +208,21 @@ func TestStatsTrackerRingRecyclesStaleBuckets(t *testing.T) {
 	}
 	if got := st.GetRarityGroup(150); got == RarityUnknown {
 		t.Error("pokemon 150 was just recorded and should have a group")
+	}
+}
+
+// TestRecalcIntervalFloorsNonPositive guards the boot path: time.NewTicker
+// panics on a non-positive interval, and an explicit `refresh_interval_mins = 0`
+// in [stats] survives config defaulting (toml decodes over the pre-populated
+// defaults struct), so an unrecoverable panic would fire in recalcLoop's
+// goroutine before the processor finished starting.
+func TestRecalcIntervalFloorsNonPositive(t *testing.T) {
+	for _, mins := range []int{0, -1, -60} {
+		if got := recalcInterval(mins); got <= 0 {
+			t.Errorf("recalcInterval(%d) = %v, want a positive duration", mins, got)
+		}
+	}
+	if got := recalcInterval(5); got != 5*time.Minute {
+		t.Errorf("recalcInterval(5) = %v, want 5m", got)
 	}
 }

--- a/processor/internal/tracker/rarity_test.go
+++ b/processor/internal/tracker/rarity_test.go
@@ -162,10 +162,8 @@ func TestStatsTrackerMemoryIsIndependentOfSightingVolume(t *testing.T) {
 func TestStatsTrackerDropsSightingsOutsideWindow(t *testing.T) {
 	cfg := testStatsConfig()
 	cfg.WindowHours = 1
-	st := NewStatsTracker(cfg)
-
-	now := int64(1_700_000_000)
-	st.now = func() int64 { return now }
+	clock := newTestClock(1_700_000_000)
+	st := newStatsTrackerWithClock(cfg, clock.now)
 
 	for range 500 {
 		st.RecordSighting(25, false, false)
@@ -176,7 +174,7 @@ func TestStatsTrackerDropsSightingsOutsideWindow(t *testing.T) {
 	}
 
 	// Step past the window. Nothing new is recorded, so every bucket is stale.
-	now += 2 * 3600
+	clock.advance(2 * time.Hour)
 	st.recalculate()
 
 	if got := st.GetRarityGroup(25); got != RarityUnknown {
@@ -189,17 +187,15 @@ func TestStatsTrackerDropsSightingsOutsideWindow(t *testing.T) {
 func TestStatsTrackerRingRecyclesStaleBuckets(t *testing.T) {
 	cfg := testStatsConfig()
 	cfg.WindowHours = 1
-	st := NewStatsTracker(cfg)
-
-	now := int64(1_700_000_000)
-	st.now = func() int64 { return now }
+	clock := newTestClock(1_700_000_000)
+	st := newStatsTrackerWithClock(cfg, clock.now)
 
 	for range 300 {
 		st.RecordSighting(25, false, false)
 	}
 
 	// Same ring slot, one full window later.
-	now += int64(len(st.buckets)) * 60
+	clock.advance(time.Duration(len(st.buckets)) * time.Minute)
 	st.RecordSighting(150, false, false)
 	st.recalculate()
 
@@ -251,4 +247,29 @@ func TestStatsTrackerRejectsOutOfRangePokemonID(t *testing.T) {
 			}
 		}
 	}
+}
+
+// TestStatsTrackerClockIsRaceFree pins that the injected clock can be read by
+// the recalc path while the test advances it. recalcLoop starts inside the
+// constructor, so a clock handed over afterwards (or a plain captured variable
+// mutated by the test) is an unsynchronized read from another goroutine. It
+// stays quiet only while the refresh ticker is too slow to fire in a test's
+// lifetime; anyone shortening it turns this into a -race failure.
+func TestStatsTrackerClockIsRaceFree(t *testing.T) {
+	clock := newTestClock(1_700_000_000)
+	st := newStatsTrackerWithClock(testStatsConfig(), clock.now)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for range 200 {
+			st.RecordSighting(25, false, false)
+			st.recalculate()
+		}
+	}()
+
+	for range 200 {
+		clock.advance(time.Minute)
+	}
+	<-done
 }

--- a/processor/internal/tracker/testclock_test.go
+++ b/processor/internal/tracker/testclock_test.go
@@ -1,0 +1,23 @@
+package tracker
+
+import (
+	"sync/atomic"
+	"time"
+)
+
+// testClock is a race-free injectable clock. Tests that hand a clock to a
+// constructor which starts background goroutines cannot use a plain captured
+// variable: advancing it would race the goroutine's read.
+type testClock struct{ unix atomic.Int64 }
+
+func newTestClock(unix int64) *testClock {
+	c := &testClock{}
+	c.unix.Store(unix)
+	return c
+}
+
+func (c *testClock) now() time.Time { return time.Unix(c.unix.Load(), 0) }
+
+func (c *testClock) advance(d time.Duration) { c.unix.Add(int64(d / time.Second)) }
+
+func (c *testClock) set(unix int64) { c.unix.Store(unix) }

--- a/processor/internal/tracker/testclock_test.go
+++ b/processor/internal/tracker/testclock_test.go
@@ -19,5 +19,3 @@ func newTestClock(unix int64) *testClock {
 func (c *testClock) now() time.Time { return time.Unix(c.unix.Load(), 0) }
 
 func (c *testClock) advance(d time.Duration) { c.unix.Add(int64(d / time.Second)) }
-
-func (c *testClock) set(unix int64) { c.unix.Store(unix) }

--- a/processor/internal/tracker/weather.go
+++ b/processor/internal/tracker/weather.go
@@ -170,17 +170,45 @@ func GetWeatherCellID(lat, lon float64) string {
 	return strconv.FormatUint(uint64(cellID), 10)
 }
 
+// touchController returns the cell's controller state, creating it when
+// absent, and stamps liveness.
+//
+// Every write path must go through this rather than inlining the
+// create-if-missing block: eviction decides on lastSeen, so a path that
+// stores data without stamping reads back correctly for a full idle window
+// and then has its cells silently swept.
+//
+// Caller must hold wt.mu.
+func (wt *WeatherTracker) touchController(cellID string) *controllerCellData {
+	cd, ok := wt.controllerData[cellID]
+	if !ok {
+		cd = &controllerCellData{hourWeather: make(map[int64]int)}
+		wt.controllerData[cellID] = cd
+	}
+	cd.lastSeen = wt.nowFunc().Unix()
+	return cd
+}
+
+// touchLocal is touchController's counterpart for locally inferred state.
+//
+// Caller must hold wt.mu.
+func (wt *WeatherTracker) touchLocal(cellID string) *localCellData {
+	ld, ok := wt.localData[cellID]
+	if !ok {
+		ld = &localCellData{}
+		wt.localData[cellID] = ld
+	}
+	ld.lastSeen = wt.nowFunc().Unix()
+	return ld
+}
+
 // UpdateFromWebhook updates weather state from a direct weather webhook.
 // Emits a change event if the weather has changed from the previous hour.
 func (wt *WeatherTracker) UpdateFromWebhook(cellID string, condition int, timestamp int64, lat, lon float64, polygon [4][2]float64) {
 	wt.mu.Lock()
 	defer wt.mu.Unlock()
 
-	cd, ok := wt.controllerData[cellID]
-	if !ok {
-		cd = &controllerCellData{hourWeather: make(map[int64]int)}
-		wt.controllerData[cellID] = cd
-	}
+	cd := wt.touchController(cellID)
 
 	hourTimestamp := timestamp - (timestamp % 3600)
 	previousHourTimestamp := hourTimestamp - 3600
@@ -197,12 +225,6 @@ func (wt *WeatherTracker) UpdateFromWebhook(cellID string, condition int, timest
 
 	cd.hourWeather[hourTimestamp] = condition
 	cd.lastCurrentWeatherCheck = timestamp
-	// lastSeen drives eviction, which runs on the local clock — so it must
-	// be stamped with receipt time, not the webhook's `updated` field.
-	// Replayed logs and Golbat clock skew both carry event times that are
-	// arbitrarily old (or future), and honouring them here would either make
-	// a live cell instantly evictable or pin a dead one forever.
-	cd.lastSeen = wt.nowFunc().Unix()
 
 	if changed {
 		// Send non-blocking
@@ -313,13 +335,7 @@ func (wt *WeatherTracker) SetHourWeather(cellID string, hourTimestamp int64, con
 	wt.mu.Lock()
 	defer wt.mu.Unlock()
 
-	cd, ok := wt.controllerData[cellID]
-	if !ok {
-		cd = &controllerCellData{hourWeather: make(map[int64]int)}
-		wt.controllerData[cellID] = cd
-	}
-	cd.hourWeather[hourTimestamp] = condition
-	cd.lastSeen = wt.nowFunc().Unix()
+	wt.touchController(cellID).hourWeather[hourTimestamp] = condition
 }
 
 // hasHourWeather checks if weather data exists for a specific hour in a cell.
@@ -346,18 +362,8 @@ func (wt *WeatherTracker) CheckWeatherOnMonster(cellID string, lat, lon float64,
 	wt.mu.Lock()
 	defer wt.mu.Unlock()
 
-	// Ensure data structures exist
-	if wt.localData[cellID] == nil {
-		wt.localData[cellID] = &localCellData{}
-	}
-	if wt.controllerData[cellID] == nil {
-		wt.controllerData[cellID] = &controllerCellData{hourWeather: make(map[int64]int)}
-	}
-
-	local := wt.localData[cellID]
-	controller := wt.controllerData[cellID]
-	local.lastSeen = now
-	controller.lastSeen = now
+	local := wt.touchLocal(cellID)
+	controller := wt.touchController(cellID)
 
 	// Only process if more than 30 seconds into the hour and monster has weather
 	if now <= currentHour+30 || monsterWeather == 0 {

--- a/processor/internal/tracker/weather.go
+++ b/processor/internal/tracker/weather.go
@@ -55,9 +55,13 @@ const (
 	// literally; the extra hour is what absorbs the skew.
 	weatherHistoryHours = 2
 
-	// weatherCellIdleSecs is how long a cell survives without a write before
-	// its state is dropped. Longer than the AccuWeather forecast refresh
-	// (8h by default) so an actively-forecast cell is never reclaimed.
+	// weatherCellIdleSecs is the default idle window: how long a cell
+	// survives without a write before its state is dropped. Comfortably
+	// longer than the default 8h AccuWeather forecast refresh.
+	//
+	// This is only the floor. forecast_refresh_interval is operator-settable
+	// with no clamp, so WithForecastRefreshInterval raises the window when
+	// the configured refresh would outlast it — see cellIdleSecs.
 	weatherCellIdleSecs = 24 * 3600
 
 	// weatherEvictInterval is the sweep cadence.
@@ -76,13 +80,43 @@ type WeatherTracker struct {
 	// so idle expiry is testable without sleeping. Defaults to time.Now.
 	nowFunc func() time.Time
 
+	// cellIdleSecs is how long a cell survives without a write. Sized at
+	// construction so it always outlasts the configured forecast refresh.
+	cellIdleSecs int64
+
 	stop chan struct{}
 	done chan struct{}
 	once sync.Once
 }
 
+// WeatherOption configures a WeatherTracker at construction.
+type WeatherOption func(*WeatherTracker)
+
+// WithForecastRefreshInterval sizes cell idle expiry against the AccuWeather
+// refresh cadence, in hours.
+//
+// A cell whose only writes are forecast pushes is otherwise reclaimed whenever
+// the configured refresh outlasts the idle window, taking
+// lastCurrentWeatherCheck and the previous-hour entry with it — so the next
+// real weather webhook sees hasPrevious=false and swallows a genuine change.
+// Deriving the window here keeps that invariant true by construction rather
+// than relying on the operator staying under an undocumented ceiling.
+//
+// Two refresh periods, so a single missed or delayed push does not strand the
+// cell either.
+func WithForecastRefreshInterval(hours int) WeatherOption {
+	return func(wt *WeatherTracker) {
+		if hours <= 0 {
+			return
+		}
+		if want := int64(hours) * 3600 * 2; want > wt.cellIdleSecs {
+			wt.cellIdleSecs = want
+		}
+	}
+}
+
 // NewWeatherTracker creates a new weather tracker.
-func NewWeatherTracker() *WeatherTracker {
+func NewWeatherTracker(opts ...WeatherOption) *WeatherTracker {
 	wt := &WeatherTracker{
 		controllerData: make(map[string]*controllerCellData),
 		localData:      make(map[string]*localCellData),
@@ -90,6 +124,10 @@ func NewWeatherTracker() *WeatherTracker {
 		nowFunc:        time.Now,
 		stop:           make(chan struct{}),
 		done:           make(chan struct{}),
+		cellIdleSecs:   weatherCellIdleSecs,
+	}
+	for _, opt := range opts {
+		opt(wt)
 	}
 	go wt.evictionLoop()
 	return wt
@@ -133,7 +171,7 @@ func (wt *WeatherTracker) evictionLoop() {
 func (wt *WeatherTracker) evict(now int64) {
 	currentHour := now - (now % 3600)
 	oldestHour := currentHour - weatherHistoryHours*3600
-	idleBefore := now - weatherCellIdleSecs
+	idleBefore := now - wt.cellIdleSecs
 
 	wt.mu.Lock()
 	defer wt.mu.Unlock()

--- a/processor/internal/tracker/weather.go
+++ b/processor/internal/tracker/weather.go
@@ -28,13 +28,31 @@ type localCellData struct {
 	weatherFromBoost     [8]int
 	currentHourTimestamp int64
 	monsterWeather       int
+	lastSeen             int64 // unix seconds of the last write; drives eviction
 }
 
 // controllerCellData holds weather data from weather webhooks.
 type controllerCellData struct {
 	lastCurrentWeatherCheck int64
 	hourWeather             map[int64]int // hourTimestamp -> condition
+	lastSeen                int64         // unix seconds of the last write; drives eviction
 }
+
+const (
+	// weatherHistoryHours is how far back hourly entries stay reachable.
+	// UpdateFromWebhook compares against the previous hour and
+	// ExportCellWeather filters to currentHour-3600, so nothing older is
+	// readable and nothing older is kept.
+	weatherHistoryHours = 1
+
+	// weatherCellIdleSecs is how long a cell survives without a write before
+	// its state is dropped. Longer than the AccuWeather forecast refresh
+	// (8h by default) so an actively-forecast cell is never reclaimed.
+	weatherCellIdleSecs = 24 * 3600
+
+	// weatherEvictInterval is the sweep cadence.
+	weatherEvictInterval = 10 * time.Minute
+)
 
 // WeatherTracker manages per-S2-cell weather state.
 // Port of weatherData.js.
@@ -47,10 +65,54 @@ type WeatherTracker struct {
 
 // NewWeatherTracker creates a new weather tracker.
 func NewWeatherTracker() *WeatherTracker {
-	return &WeatherTracker{
+	wt := &WeatherTracker{
 		controllerData: make(map[string]*controllerCellData),
 		localData:      make(map[string]*localCellData),
 		changes:        make(chan WeatherChange, 100),
+	}
+	go wt.evictionLoop()
+	return wt
+}
+
+func (wt *WeatherTracker) evictionLoop() {
+	ticker := time.NewTicker(weatherEvictInterval)
+	defer ticker.Stop()
+	for range ticker.C {
+		wt.evict(time.Now().Unix())
+	}
+}
+
+// evict drops per-cell state that can no longer be read.
+//
+// Two things grow here. Per cell, hourWeather gained an entry every hour and
+// nothing removed them, so a long-lived process accumulated entries
+// proportional to (cells x uptime hours) — the actual leak. Separately, a cell
+// that stops being scanned kept its struct forever, so a shifted scan area
+// stranded state indefinitely.
+func (wt *WeatherTracker) evict(now int64) {
+	currentHour := now - (now % 3600)
+	oldestHour := currentHour - weatherHistoryHours*3600
+	idleBefore := now - weatherCellIdleSecs
+
+	wt.mu.Lock()
+	defer wt.mu.Unlock()
+
+	for cellID, cd := range wt.controllerData {
+		if cd.lastSeen < idleBefore {
+			delete(wt.controllerData, cellID)
+			continue
+		}
+		for ts := range cd.hourWeather {
+			if ts < oldestHour {
+				delete(cd.hourWeather, ts)
+			}
+		}
+	}
+
+	for cellID, ld := range wt.localData {
+		if ld.lastSeen < idleBefore {
+			delete(wt.localData, cellID)
+		}
 	}
 }
 
@@ -94,6 +156,7 @@ func (wt *WeatherTracker) UpdateFromWebhook(cellID string, condition int, timest
 
 	cd.hourWeather[hourTimestamp] = condition
 	cd.lastCurrentWeatherCheck = timestamp
+	cd.lastSeen = timestamp
 
 	if changed {
 		// Send non-blocking
@@ -210,6 +273,7 @@ func (wt *WeatherTracker) SetHourWeather(cellID string, hourTimestamp int64, con
 		wt.controllerData[cellID] = cd
 	}
 	cd.hourWeather[hourTimestamp] = condition
+	cd.lastSeen = time.Now().Unix()
 }
 
 // hasHourWeather checks if weather data exists for a specific hour in a cell.
@@ -246,6 +310,8 @@ func (wt *WeatherTracker) CheckWeatherOnMonster(cellID string, lat, lon float64,
 
 	local := wt.localData[cellID]
 	controller := wt.controllerData[cellID]
+	local.lastSeen = now
+	controller.lastSeen = now
 
 	// Only process if more than 30 seconds into the hour and monster has weather
 	if now <= currentHour+30 || monsterWeather == 0 {
@@ -330,4 +396,24 @@ func (wt *WeatherTracker) CheckWeatherOnMonster(cellID string, lat, lon float64,
 			}
 		}
 	}
+}
+
+// hourCount returns how many hourly entries a cell holds.
+func (wt *WeatherTracker) hourCount(cellID string) int {
+	wt.mu.RLock()
+	defer wt.mu.RUnlock()
+	cd := wt.controllerData[cellID]
+	if cd == nil {
+		return 0
+	}
+	return len(cd.hourWeather)
+}
+
+// hasCell reports whether any state is held for a cell.
+func (wt *WeatherTracker) hasCell(cellID string) bool {
+	wt.mu.RLock()
+	defer wt.mu.RUnlock()
+	_, c := wt.controllerData[cellID]
+	_, l := wt.localData[cellID]
+	return c || l
 }

--- a/processor/internal/tracker/weather.go
+++ b/processor/internal/tracker/weather.go
@@ -75,6 +75,10 @@ type WeatherTracker struct {
 	// nowFunc is the clock used for cell liveness and eviction. Injectable
 	// so idle expiry is testable without sleeping. Defaults to time.Now.
 	nowFunc func() time.Time
+
+	stop chan struct{}
+	done chan struct{}
+	once sync.Once
 }
 
 // NewWeatherTracker creates a new weather tracker.
@@ -84,16 +88,38 @@ func NewWeatherTracker() *WeatherTracker {
 		localData:      make(map[string]*localCellData),
 		changes:        make(chan WeatherChange, 100),
 		nowFunc:        time.Now,
+		stop:           make(chan struct{}),
+		done:           make(chan struct{}),
 	}
 	go wt.evictionLoop()
 	return wt
 }
 
+// Close stops the eviction loop and waits for it to exit. Safe to call more
+// than once.
+//
+// Mirrors the stop/done/once trio used by mute.Sweeper, snapshots.Sweeper and
+// expiringSet, so the loop can take its place in ProcessorService.Close's
+// shutdown ordering rather than outliving the process's other components.
+func (wt *WeatherTracker) Close() {
+	if wt == nil {
+		return
+	}
+	wt.once.Do(func() { close(wt.stop) })
+	<-wt.done
+}
+
 func (wt *WeatherTracker) evictionLoop() {
+	defer close(wt.done)
 	ticker := time.NewTicker(weatherEvictInterval)
 	defer ticker.Stop()
-	for range ticker.C {
-		wt.evict(wt.nowFunc().Unix())
+	for {
+		select {
+		case <-wt.stop:
+			return
+		case <-ticker.C:
+			wt.evict(wt.nowFunc().Unix())
+		}
 	}
 }
 

--- a/processor/internal/tracker/weather.go
+++ b/processor/internal/tracker/weather.go
@@ -1,6 +1,7 @@
 package tracker
 
 import (
+	"slices"
 	"strconv"
 	"sync"
 	"time"
@@ -83,6 +84,11 @@ type WeatherTracker struct {
 	// cellIdleSecs is how long a cell survives without a write. Sized at
 	// construction so it always outlasts the configured forecast refresh.
 	cellIdleSecs int64
+
+	// onEvict is notified with the cell ids a sweep dropped, so components
+	// keyed by the same cell ids can release their own per-cell state
+	// instead of each re-deriving liveness. Called without wt.mu held.
+	onEvict func(cellIDs []string)
 
 	stop chan struct{}
 	done chan struct{}
@@ -174,11 +180,12 @@ func (wt *WeatherTracker) evict(now int64) {
 	idleBefore := now - wt.cellIdleSecs
 
 	wt.mu.Lock()
-	defer wt.mu.Unlock()
 
+	var dropped []string
 	for cellID, cd := range wt.controllerData {
 		if cd.lastSeen < idleBefore {
 			delete(wt.controllerData, cellID)
+			dropped = append(dropped, cellID)
 			continue
 		}
 		for ts := range cd.hourWeather {
@@ -191,8 +198,31 @@ func (wt *WeatherTracker) evict(now int64) {
 	for cellID, ld := range wt.localData {
 		if ld.lastSeen < idleBefore {
 			delete(wt.localData, cellID)
+			if _, stillControlled := wt.controllerData[cellID]; !stillControlled {
+				// Already reported above if it had controller state too.
+				if !slices.Contains(dropped, cellID) {
+					dropped = append(dropped, cellID)
+				}
+			}
 		}
 	}
+
+	onEvict := wt.onEvict
+	wt.mu.Unlock()
+
+	// Called outside the lock: the callback belongs to another component and
+	// must not be able to deadlock the sweep by reaching back in.
+	if onEvict != nil && len(dropped) > 0 {
+		onEvict(dropped)
+	}
+}
+
+// SetOnEvict registers a callback invoked after each sweep with the cell ids
+// that were dropped. Call before the tracker starts seeing traffic.
+func (wt *WeatherTracker) SetOnEvict(fn func(cellIDs []string)) {
+	wt.mu.Lock()
+	wt.onEvict = fn
+	wt.mu.Unlock()
 }
 
 // Changes returns the channel that emits weather change events.

--- a/processor/internal/tracker/weather.go
+++ b/processor/internal/tracker/weather.go
@@ -40,10 +40,20 @@ type controllerCellData struct {
 
 const (
 	// weatherHistoryHours is how far back hourly entries stay reachable.
-	// UpdateFromWebhook compares against the previous hour and
-	// ExportCellWeather filters to currentHour-3600, so nothing older is
-	// readable and nothing older is kept.
-	weatherHistoryHours = 1
+	//
+	// Readers look back one hour, but they do it from two different clocks:
+	// ExportCellWeather measures from wall clock, while UpdateFromWebhook
+	// derives its previous-hour key from the webhook's own `updated` field.
+	// Under a Golbat backlog the event clock lags the wall clock, so a
+	// webhook stamped late in hour N can arrive once the sweep has already
+	// advanced to N+1 and pruned the hour N-1 entry it needs to compare
+	// against. That would read as hasPrevious=false and silently swallow a
+	// genuine weather change.
+	//
+	// Two hours is therefore one hour of reader lookback plus one hour of
+	// slack for event-time lag. Do not lower this to match the reader
+	// literally; the extra hour is what absorbs the skew.
+	weatherHistoryHours = 2
 
 	// weatherCellIdleSecs is how long a cell survives without a write before
 	// its state is dropped. Longer than the AccuWeather forecast refresh

--- a/processor/internal/tracker/weather.go
+++ b/processor/internal/tracker/weather.go
@@ -71,6 +71,10 @@ type WeatherTracker struct {
 	controllerData map[string]*controllerCellData
 	localData      map[string]*localCellData
 	changes        chan WeatherChange
+
+	// nowFunc is the clock used for cell liveness and eviction. Injectable
+	// so idle expiry is testable without sleeping. Defaults to time.Now.
+	nowFunc func() time.Time
 }
 
 // NewWeatherTracker creates a new weather tracker.
@@ -79,6 +83,7 @@ func NewWeatherTracker() *WeatherTracker {
 		controllerData: make(map[string]*controllerCellData),
 		localData:      make(map[string]*localCellData),
 		changes:        make(chan WeatherChange, 100),
+		nowFunc:        time.Now,
 	}
 	go wt.evictionLoop()
 	return wt
@@ -88,7 +93,7 @@ func (wt *WeatherTracker) evictionLoop() {
 	ticker := time.NewTicker(weatherEvictInterval)
 	defer ticker.Stop()
 	for range ticker.C {
-		wt.evict(time.Now().Unix())
+		wt.evict(wt.nowFunc().Unix())
 	}
 }
 
@@ -166,7 +171,12 @@ func (wt *WeatherTracker) UpdateFromWebhook(cellID string, condition int, timest
 
 	cd.hourWeather[hourTimestamp] = condition
 	cd.lastCurrentWeatherCheck = timestamp
-	cd.lastSeen = timestamp
+	// lastSeen drives eviction, which runs on the local clock — so it must
+	// be stamped with receipt time, not the webhook's `updated` field.
+	// Replayed logs and Golbat clock skew both carry event times that are
+	// arbitrarily old (or future), and honouring them here would either make
+	// a live cell instantly evictable or pin a dead one forever.
+	cd.lastSeen = wt.nowFunc().Unix()
 
 	if changed {
 		// Send non-blocking
@@ -191,7 +201,7 @@ func (wt *WeatherTracker) GetCurrentWeatherInCell(cellID string) int {
 	wt.mu.RLock()
 	defer wt.mu.RUnlock()
 
-	now := time.Now().Unix()
+	now := wt.nowFunc().Unix()
 	currentHour := now - (now % 3600)
 
 	cd := wt.controllerData[cellID]
@@ -219,7 +229,7 @@ func (wt *WeatherTracker) GetWeatherForecast(cellID string) WeatherForecast {
 	wt.mu.RLock()
 	defer wt.mu.RUnlock()
 
-	now := time.Now().Unix()
+	now := wt.nowFunc().Unix()
 	currentHour := now - (now % 3600)
 	nextHour := currentHour + 3600
 
@@ -251,7 +261,7 @@ func (wt *WeatherTracker) ExportCellWeather(cellID string) map[int64]int {
 	wt.mu.RLock()
 	defer wt.mu.RUnlock()
 
-	now := time.Now().Unix()
+	now := wt.nowFunc().Unix()
 	currentHour := now - (now % 3600)
 
 	result := make(map[int64]int)
@@ -283,7 +293,7 @@ func (wt *WeatherTracker) SetHourWeather(cellID string, hourTimestamp int64, con
 		wt.controllerData[cellID] = cd
 	}
 	cd.hourWeather[hourTimestamp] = condition
-	cd.lastSeen = time.Now().Unix()
+	cd.lastSeen = wt.nowFunc().Unix()
 }
 
 // hasHourWeather checks if weather data exists for a specific hour in a cell.
@@ -303,7 +313,7 @@ func (wt *WeatherTracker) hasHourWeather(cellID string, hourTimestamp int64) boo
 // weather changes via vote-based inference.
 // Port of weatherData.js:68-123.
 func (wt *WeatherTracker) CheckWeatherOnMonster(cellID string, lat, lon float64, monsterWeather int) {
-	now := time.Now().Unix()
+	now := wt.nowFunc().Unix()
 	currentHour := now - (now % 3600)
 	previousHour := currentHour - 3600
 

--- a/processor/internal/tracker/weather.go
+++ b/processor/internal/tracker/weather.go
@@ -1,7 +1,6 @@
 package tracker
 
 import (
-	"slices"
 	"strconv"
 	"sync"
 	"time"
@@ -196,11 +195,15 @@ func (wt *WeatherTracker) evict(now int64) {
 
 	wt.mu.Lock()
 
-	var dropped []string
+	// A cell can hold both controller and local state, so membership is
+	// tracked in a set rather than scanned. One sweep after a scan-area
+	// shift can drop tens of thousands of cells, and this whole loop runs
+	// under the write lock that every webhook needs.
+	droppedSet := make(map[string]struct{})
 	for cellID, cd := range wt.controllerData {
 		if cd.lastSeen < idleBefore {
 			delete(wt.controllerData, cellID)
-			dropped = append(dropped, cellID)
+			droppedSet[cellID] = struct{}{}
 			continue
 		}
 		for ts := range cd.hourWeather {
@@ -213,12 +216,15 @@ func (wt *WeatherTracker) evict(now int64) {
 	for cellID, ld := range wt.localData {
 		if ld.lastSeen < idleBefore {
 			delete(wt.localData, cellID)
-			if _, stillControlled := wt.controllerData[cellID]; !stillControlled {
-				// Already reported above if it had controller state too.
-				if !slices.Contains(dropped, cellID) {
-					dropped = append(dropped, cellID)
-				}
-			}
+			droppedSet[cellID] = struct{}{}
+		}
+	}
+
+	var dropped []string
+	if len(droppedSet) > 0 {
+		dropped = make([]string, 0, len(droppedSet))
+		for cellID := range droppedSet {
+			dropped = append(dropped, cellID)
 		}
 	}
 

--- a/processor/internal/tracker/weather.go
+++ b/processor/internal/tracker/weather.go
@@ -77,8 +77,9 @@ type WeatherTracker struct {
 	localData      map[string]*localCellData
 	changes        chan WeatherChange
 
-	// nowFunc is the clock used for cell liveness and eviction. Injectable
-	// so idle expiry is testable without sleeping. Defaults to time.Now.
+	// nowFunc is the clock used for cell liveness and eviction. Set once at
+	// construction via WithClock and never reassigned: evictionLoop reads it
+	// from its own goroutine, so a later write would be a data race.
 	nowFunc func() time.Time
 
 	// cellIdleSecs is how long a cell survives without a write. Sized at
@@ -97,6 +98,20 @@ type WeatherTracker struct {
 
 // WeatherOption configures a WeatherTracker at construction.
 type WeatherOption func(*WeatherTracker)
+
+// WithClock replaces the tracker's clock.
+//
+// An option rather than an assignable field: NewWeatherTracker starts
+// evictionLoop before returning, and that goroutine reads nowFunc, so a clock
+// handed over afterwards is an unsynchronized write. StatsTracker takes its
+// clock at construction for the same reason.
+func WithClock(nowFunc func() time.Time) WeatherOption {
+	return func(wt *WeatherTracker) {
+		if nowFunc != nil {
+			wt.nowFunc = nowFunc
+		}
+	}
+}
 
 // WithForecastRefreshInterval sizes cell idle expiry against the AccuWeather
 // refresh cadence, in hours.

--- a/processor/internal/tracker/weather.go
+++ b/processor/internal/tracker/weather.go
@@ -216,7 +216,16 @@ func (wt *WeatherTracker) evict(now int64) {
 	for cellID, ld := range wt.localData {
 		if ld.lastSeen < idleBefore {
 			delete(wt.localData, cellID)
-			droppedSet[cellID] = struct{}{}
+			// Only report a cell once BOTH halves are gone. The two age out
+			// independently: local inference can go quiet while weather
+			// webhooks or forecast pushes keep the controller entry fresh.
+			// Reporting on the local half alone hands a live cell to the
+			// eviction callback, which discards its AccuWeather location key
+			// and forecast timeout. The controller loop above has already
+			// removed any idle controller entry, so a hit here means fresh.
+			if _, stillControlled := wt.controllerData[cellID]; !stillControlled {
+				droppedSet[cellID] = struct{}{}
+			}
 		}
 	}
 

--- a/processor/internal/tracker/weather_test.go
+++ b/processor/internal/tracker/weather_test.go
@@ -104,22 +104,51 @@ func TestWeatherTrackerEvictsHoursOutsideRetention(t *testing.T) {
 
 // TestWeatherTrackerEvictsIdleCells asserts whole cells are reclaimed once
 // they stop being scanned, so a shifted scan area does not strand them.
+//
+// Idleness is measured from when we last *received* something for the cell,
+// so the clock is driven forward here rather than backdating the webhook.
 func TestWeatherTrackerEvictsIdleCells(t *testing.T) {
 	wt := NewWeatherTracker()
 
-	now := int64(1_700_000_000)
-	stale := now - 48*3600
+	clock := time.Unix(1_700_000_000, 0)
+	wt.nowFunc = func() time.Time { return clock }
 
-	wt.UpdateFromWebhook("cell-stale", 1, stale, 51.5, -0.1, [4][2]float64{})
-	wt.UpdateFromWebhook("cell-fresh", 1, now, 51.5, -0.1, [4][2]float64{})
+	wt.UpdateFromWebhook("cell-stale", 1, clock.Unix(), 51.5, -0.1, [4][2]float64{})
 
-	wt.evict(now)
+	// Two days pass; only one cell keeps receiving webhooks.
+	clock = clock.Add(48 * time.Hour)
+	wt.UpdateFromWebhook("cell-fresh", 1, clock.Unix(), 51.5, -0.1, [4][2]float64{})
+
+	wt.evict(clock.Unix())
 
 	if wt.hasCell("cell-stale") {
-		t.Error("a cell untouched for 48h should be evicted entirely")
+		t.Error("a cell that received nothing for 48h should be evicted entirely")
 	}
 	if !wt.hasCell("cell-fresh") {
-		t.Error("a cell touched this hour must be kept")
+		t.Error("a cell that just received a webhook must be kept")
+	}
+}
+
+// TestWeatherTrackerReplayedWebhookIsNotInstantlyIdle pins that cell liveness
+// tracks receipt time, not the webhook's own `updated` field. Replaying
+// logs/webhooks.log is a documented workflow, and Golbat clock skew has the
+// same shape: a webhook whose event time is days old still means the cell is
+// live right now. Stamping event time made such a cell evictable on the very
+// next sweep, discarding the previous-hour state that later genuine changes
+// compare against.
+func TestWeatherTrackerReplayedWebhookIsNotInstantlyIdle(t *testing.T) {
+	wt := NewWeatherTracker()
+
+	clock := time.Unix(1_700_000_000, 0)
+	wt.nowFunc = func() time.Time { return clock }
+
+	// A replayed webhook: event time three days in the past, received now.
+	wt.UpdateFromWebhook("cell-replay", 1, clock.Add(-72*time.Hour).Unix(), 51.5, -0.1, [4][2]float64{})
+
+	wt.evict(clock.Unix())
+
+	if !wt.hasCell("cell-replay") {
+		t.Error("a cell whose webhook carried an old event time was evicted; liveness must follow receipt time")
 	}
 }
 

--- a/processor/internal/tracker/weather_test.go
+++ b/processor/internal/tracker/weather_test.go
@@ -56,3 +56,64 @@ func TestWeatherTrackerInference(t *testing.T) {
 		// May not trigger if within first 30 seconds of the hour - that's OK
 	}
 }
+
+// TestWeatherTrackerEvictsHoursOutsideRetention covers the actual leak:
+// controllerCellData.hourWeather gained one entry per cell per hour and
+// nothing ever removed them, so a long-lived process accumulated entries
+// proportional to (cells x uptime hours).
+func TestWeatherTrackerEvictsHoursOutsideRetention(t *testing.T) {
+	wt := NewWeatherTracker()
+
+	now := int64(1_700_000_000)
+	currentHour := now - (now % 3600)
+	cellID := "cell-retention"
+
+	// Six hours of history, the current hour, and a forecast hour ahead.
+	for h := int64(6); h >= 1; h-- {
+		wt.SetHourWeather(cellID, currentHour-h*3600, 1)
+	}
+	wt.SetHourWeather(cellID, currentHour, 2)
+	wt.SetHourWeather(cellID, currentHour+3600, 3)
+
+	wt.evict(now)
+
+	got := wt.hourCount(cellID)
+	// Readers never look further back than the previous hour, so the
+	// keepers are: previous, current, forecast.
+	if got != 3 {
+		t.Errorf("expected 3 retained hours (previous, current, forecast), got %d", got)
+	}
+	if !wt.hasHourWeather(cellID, currentHour) {
+		t.Error("current hour must survive eviction")
+	}
+	if !wt.hasHourWeather(cellID, currentHour+3600) {
+		t.Error("forecast hour must survive eviction — AccuWeather writes it ahead of time")
+	}
+	if !wt.hasHourWeather(cellID, currentHour-3600) {
+		t.Error("previous hour must survive eviction — UpdateFromWebhook compares against it")
+	}
+	if wt.hasHourWeather(cellID, currentHour-2*3600) {
+		t.Error("hours older than the previous hour are unreachable and must be dropped")
+	}
+}
+
+// TestWeatherTrackerEvictsIdleCells asserts whole cells are reclaimed once
+// they stop being scanned, so a shifted scan area does not strand them.
+func TestWeatherTrackerEvictsIdleCells(t *testing.T) {
+	wt := NewWeatherTracker()
+
+	now := int64(1_700_000_000)
+	stale := now - 48*3600
+
+	wt.UpdateFromWebhook("cell-stale", 1, stale, 51.5, -0.1, [4][2]float64{})
+	wt.UpdateFromWebhook("cell-fresh", 1, now, 51.5, -0.1, [4][2]float64{})
+
+	wt.evict(now)
+
+	if wt.hasCell("cell-stale") {
+		t.Error("a cell untouched for 48h should be evicted entirely")
+	}
+	if !wt.hasCell("cell-fresh") {
+		t.Error("a cell touched this hour must be kept")
+	}
+}

--- a/processor/internal/tracker/weather_test.go
+++ b/processor/internal/tracker/weather_test.go
@@ -187,3 +187,20 @@ func TestWeatherTrackerKeepsHistoryForBackloggedWebhooks(t *testing.T) {
 		t.Error("no WeatherChange emitted: eviction dropped the previous-hour entry the backlogged webhook needed")
 	}
 }
+
+// TestWeatherTrackerCloseStopsEvictionLoop asserts the eviction loop
+// participates in shutdown like every other background reclaim loop in the
+// codebase. Without it, each tracker permanently leaks a goroutine and a
+// ticker, and pins its maps against GC.
+func TestWeatherTrackerCloseStopsEvictionLoop(t *testing.T) {
+	wt := NewWeatherTracker()
+	wt.Close()
+
+	select {
+	case <-wt.done:
+	default:
+		t.Error("Close returned while the eviction loop was still running")
+	}
+
+	wt.Close() // idempotent
+}

--- a/processor/internal/tracker/weather_test.go
+++ b/processor/internal/tracker/weather_test.go
@@ -204,3 +204,52 @@ func TestWeatherTrackerCloseStopsEvictionLoop(t *testing.T) {
 
 	wt.Close() // idempotent
 }
+
+// TestWeatherTrackerEveryWritePathStampsLiveness pins the invariant that keeps
+// eviction honest: any path that writes cell state must also mark the cell
+// live. A write path that stores data without stamping reads back correctly
+// for a day and then has its cells silently swept, which is close to
+// undiagnosable in production.
+func TestWeatherTrackerEveryWritePathStampsLiveness(t *testing.T) {
+	// Mid-hour so CheckWeatherOnMonster clears its "30s into the hour" gate.
+	base := time.Unix(1_700_000_000, 0).Truncate(time.Hour).Add(30 * time.Minute)
+
+	writes := map[string]func(wt *WeatherTracker, cellID string){
+		"UpdateFromWebhook": func(wt *WeatherTracker, cellID string) {
+			wt.UpdateFromWebhook(cellID, 1, wt.nowFunc().Unix(), 51.5, -0.1, [4][2]float64{})
+		},
+		"SetHourWeather": func(wt *WeatherTracker, cellID string) {
+			now := wt.nowFunc().Unix()
+			wt.SetHourWeather(cellID, now-(now%3600), 1)
+		},
+		"CheckWeatherOnMonster": func(wt *WeatherTracker, cellID string) {
+			wt.CheckWeatherOnMonster(cellID, 51.5, -0.1, 3)
+		},
+	}
+
+	for name, write := range writes {
+		t.Run(name, func(t *testing.T) {
+			wt := NewWeatherTracker()
+			defer wt.Close()
+
+			clock := base
+			wt.nowFunc = func() time.Time { return clock }
+
+			write(wt, "cell-a")
+
+			// Just inside the idle window: the write must have kept it alive.
+			clock = base.Add(weatherCellIdleSecs*time.Second - time.Hour)
+			wt.evict(clock.Unix())
+			if !wt.hasCell("cell-a") {
+				t.Fatalf("%s did not stamp liveness: cell evicted while still inside the idle window", name)
+			}
+
+			// Past the idle window with no further writes.
+			clock = base.Add(weatherCellIdleSecs*time.Second + time.Hour)
+			wt.evict(clock.Unix())
+			if wt.hasCell("cell-a") {
+				t.Errorf("cell survived past the idle window with no further writes")
+			}
+		})
+	}
+}

--- a/processor/internal/tracker/weather_test.go
+++ b/processor/internal/tracker/weather_test.go
@@ -253,3 +253,33 @@ func TestWeatherTrackerEveryWritePathStampsLiveness(t *testing.T) {
 		})
 	}
 }
+
+// TestWeatherTrackerIdleWindowCoversForecastRefresh pins that a cell whose
+// only writes are AccuWeather forecast pushes survives between refreshes.
+//
+// forecast_refresh_interval is operator-settable in hours with no clamp. An
+// operator rationing AccuWeather quota can set it above the idle threshold, at
+// which point the sweep reclaims forecast-only cells between pushes and throws
+// away lastCurrentWeatherCheck and the previous-hour entry. The next real
+// weather webhook then finds hasPrevious=false and a genuine change emits no
+// alert.
+func TestWeatherTrackerIdleWindowCoversForecastRefresh(t *testing.T) {
+	const refreshHours = 30 // deliberately longer than the 24h default idle
+
+	wt := NewWeatherTracker(WithForecastRefreshInterval(refreshHours))
+	defer wt.Close()
+
+	clock := time.Unix(1_700_000_000, 0)
+	wt.nowFunc = func() time.Time { return clock }
+
+	now := clock.Unix()
+	wt.SetHourWeather("cell-forecast", now-(now%3600), 1)
+
+	// One refresh period later, just before the next push would land.
+	clock = clock.Add(refreshHours*time.Hour - time.Hour)
+	wt.evict(clock.Unix())
+
+	if !wt.hasCell("cell-forecast") {
+		t.Error("forecast-only cell was evicted before its next refresh could arrive")
+	}
+}

--- a/processor/internal/tracker/weather_test.go
+++ b/processor/internal/tracker/weather_test.go
@@ -27,6 +27,7 @@ func TestGetWeatherCellID(t *testing.T) {
 
 func TestWeatherTrackerDirectUpdate(t *testing.T) {
 	wt := NewWeatherTracker()
+	defer wt.Close()
 
 	cellID := "test_cell"
 	wt.UpdateFromWebhook(cellID, 3, 1700000000, 51.5, -0.1, [4][2]float64{})
@@ -39,6 +40,7 @@ func TestWeatherTrackerDirectUpdate(t *testing.T) {
 
 func TestWeatherTrackerInference(t *testing.T) {
 	wt := NewWeatherTracker()
+	defer wt.Close()
 
 	cellID := "test_cell"
 
@@ -64,6 +66,7 @@ func TestWeatherTrackerInference(t *testing.T) {
 // proportional to (cells x uptime hours).
 func TestWeatherTrackerEvictsHoursOutsideRetention(t *testing.T) {
 	wt := NewWeatherTracker()
+	defer wt.Close()
 
 	now := int64(1_700_000_000)
 	currentHour := now - (now % 3600)
@@ -159,6 +162,7 @@ func TestWeatherTrackerReplayedWebhookIsNotInstantlyIdle(t *testing.T) {
 // genuine weather change into no alert at all.
 func TestWeatherTrackerKeepsHistoryForBackloggedWebhooks(t *testing.T) {
 	wt := NewWeatherTracker()
+	defer wt.Close()
 
 	now := time.Now().Unix()
 	currentHour := now - (now % 3600)
@@ -192,6 +196,7 @@ func TestWeatherTrackerKeepsHistoryForBackloggedWebhooks(t *testing.T) {
 // ticker, and pins its maps against GC.
 func TestWeatherTrackerCloseStopsEvictionLoop(t *testing.T) {
 	wt := NewWeatherTracker()
+	defer wt.Close()
 	wt.Close()
 
 	select {

--- a/processor/internal/tracker/weather_test.go
+++ b/processor/internal/tracker/weather_test.go
@@ -108,18 +108,17 @@ func TestWeatherTrackerEvictsHoursOutsideRetention(t *testing.T) {
 // Idleness is measured from when we last *received* something for the cell,
 // so the clock is driven forward here rather than backdating the webhook.
 func TestWeatherTrackerEvictsIdleCells(t *testing.T) {
-	wt := NewWeatherTracker()
+	clock := newTestClock(1_700_000_000)
+	wt := NewWeatherTracker(WithClock(clock.now))
+	defer wt.Close()
 
-	clock := time.Unix(1_700_000_000, 0)
-	wt.nowFunc = func() time.Time { return clock }
-
-	wt.UpdateFromWebhook("cell-stale", 1, clock.Unix(), 51.5, -0.1, [4][2]float64{})
+	wt.UpdateFromWebhook("cell-stale", 1, clock.now().Unix(), 51.5, -0.1, [4][2]float64{})
 
 	// Two days pass; only one cell keeps receiving webhooks.
-	clock = clock.Add(48 * time.Hour)
-	wt.UpdateFromWebhook("cell-fresh", 1, clock.Unix(), 51.5, -0.1, [4][2]float64{})
+	clock.advance(48 * time.Hour)
+	wt.UpdateFromWebhook("cell-fresh", 1, clock.now().Unix(), 51.5, -0.1, [4][2]float64{})
 
-	wt.evict(clock.Unix())
+	wt.evict(clock.now().Unix())
 
 	if wt.hasCell("cell-stale") {
 		t.Error("a cell that received nothing for 48h should be evicted entirely")
@@ -137,15 +136,14 @@ func TestWeatherTrackerEvictsIdleCells(t *testing.T) {
 // next sweep, discarding the previous-hour state that later genuine changes
 // compare against.
 func TestWeatherTrackerReplayedWebhookIsNotInstantlyIdle(t *testing.T) {
-	wt := NewWeatherTracker()
-
-	clock := time.Unix(1_700_000_000, 0)
-	wt.nowFunc = func() time.Time { return clock }
+	clock := newTestClock(1_700_000_000)
+	wt := NewWeatherTracker(WithClock(clock.now))
+	defer wt.Close()
 
 	// A replayed webhook: event time three days in the past, received now.
-	wt.UpdateFromWebhook("cell-replay", 1, clock.Add(-72*time.Hour).Unix(), 51.5, -0.1, [4][2]float64{})
+	wt.UpdateFromWebhook("cell-replay", 1, clock.now().Add(-72*time.Hour).Unix(), 51.5, -0.1, [4][2]float64{})
 
-	wt.evict(clock.Unix())
+	wt.evict(clock.now().Unix())
 
 	if !wt.hasCell("cell-replay") {
 		t.Error("a cell whose webhook carried an old event time was evicted; liveness must follow receipt time")
@@ -229,24 +227,22 @@ func TestWeatherTrackerEveryWritePathStampsLiveness(t *testing.T) {
 
 	for name, write := range writes {
 		t.Run(name, func(t *testing.T) {
-			wt := NewWeatherTracker()
+			clock := newTestClock(base.Unix())
+			wt := NewWeatherTracker(WithClock(clock.now))
 			defer wt.Close()
-
-			clock := base
-			wt.nowFunc = func() time.Time { return clock }
 
 			write(wt, "cell-a")
 
 			// Just inside the idle window: the write must have kept it alive.
-			clock = base.Add(weatherCellIdleSecs*time.Second - time.Hour)
-			wt.evict(clock.Unix())
+			clock.advance(weatherCellIdleSecs*time.Second - time.Hour)
+			wt.evict(clock.now().Unix())
 			if !wt.hasCell("cell-a") {
 				t.Fatalf("%s did not stamp liveness: cell evicted while still inside the idle window", name)
 			}
 
 			// Past the idle window with no further writes.
-			clock = base.Add(weatherCellIdleSecs*time.Second + time.Hour)
-			wt.evict(clock.Unix())
+			clock.advance(2 * time.Hour)
+			wt.evict(clock.now().Unix())
 			if wt.hasCell("cell-a") {
 				t.Errorf("cell survived past the idle window with no further writes")
 			}
@@ -266,18 +262,16 @@ func TestWeatherTrackerEveryWritePathStampsLiveness(t *testing.T) {
 func TestWeatherTrackerIdleWindowCoversForecastRefresh(t *testing.T) {
 	const refreshHours = 30 // deliberately longer than the 24h default idle
 
-	wt := NewWeatherTracker(WithForecastRefreshInterval(refreshHours))
+	clock := newTestClock(1_700_000_000)
+	wt := NewWeatherTracker(WithForecastRefreshInterval(refreshHours), WithClock(clock.now))
 	defer wt.Close()
 
-	clock := time.Unix(1_700_000_000, 0)
-	wt.nowFunc = func() time.Time { return clock }
-
-	now := clock.Unix()
+	now := clock.now().Unix()
 	wt.SetHourWeather("cell-forecast", now-(now%3600), 1)
 
 	// One refresh period later, just before the next push would land.
-	clock = clock.Add(refreshHours*time.Hour - time.Hour)
-	wt.evict(clock.Unix())
+	clock.advance(refreshHours*time.Hour - time.Hour)
+	wt.evict(clock.now().Unix())
 
 	if !wt.hasCell("cell-forecast") {
 		t.Error("forecast-only cell was evicted before its next refresh could arrive")

--- a/processor/internal/tracker/weather_test.go
+++ b/processor/internal/tracker/weather_test.go
@@ -2,6 +2,7 @@ package tracker
 
 import (
 	"testing"
+	"time"
 )
 
 func TestGetWeatherCellID(t *testing.T) {
@@ -78,10 +79,11 @@ func TestWeatherTrackerEvictsHoursOutsideRetention(t *testing.T) {
 	wt.evict(now)
 
 	got := wt.hourCount(cellID)
-	// Readers never look further back than the previous hour, so the
-	// keepers are: previous, current, forecast.
-	if got != 3 {
-		t.Errorf("expected 3 retained hours (previous, current, forecast), got %d", got)
+	// Readers look back one hour; retention keeps two so a backlogged
+	// webhook's event-time lookback still lands (see weatherHistoryHours).
+	// Keepers: currentHour-2, previous, current, forecast.
+	if got != 4 {
+		t.Errorf("expected 4 retained hours (two of history, current, forecast), got %d", got)
 	}
 	if !wt.hasHourWeather(cellID, currentHour) {
 		t.Error("current hour must survive eviction")
@@ -92,8 +94,11 @@ func TestWeatherTrackerEvictsHoursOutsideRetention(t *testing.T) {
 	if !wt.hasHourWeather(cellID, currentHour-3600) {
 		t.Error("previous hour must survive eviction — UpdateFromWebhook compares against it")
 	}
-	if wt.hasHourWeather(cellID, currentHour-2*3600) {
-		t.Error("hours older than the previous hour are unreachable and must be dropped")
+	if !wt.hasHourWeather(cellID, currentHour-2*3600) {
+		t.Error("the backlog-slack hour must survive eviction")
+	}
+	if wt.hasHourWeather(cellID, currentHour-3*3600) {
+		t.Error("hours beyond the retention window are unreachable and must be dropped")
 	}
 }
 
@@ -115,5 +120,41 @@ func TestWeatherTrackerEvictsIdleCells(t *testing.T) {
 	}
 	if !wt.hasCell("cell-fresh") {
 		t.Error("a cell touched this hour must be kept")
+	}
+}
+
+// TestWeatherTrackerKeepsHistoryForBackloggedWebhooks pins the interaction
+// between eviction (which prunes by processor wall clock) and
+// UpdateFromWebhook (which reads the previous hour keyed by the webhook's own
+// event time). When Golbat backlogs, a webhook stamped late in the previous
+// hour arrives after the sweep has already advanced, and the entry it needs
+// for the previous-hour comparison must still be there. Losing it turns a
+// genuine weather change into no alert at all.
+func TestWeatherTrackerKeepsHistoryForBackloggedWebhooks(t *testing.T) {
+	wt := NewWeatherTracker()
+
+	now := time.Now().Unix()
+	currentHour := now - (now % 3600)
+	eventHour := currentHour - 3600    // the backlogged webhook's own hour
+	comparisonHour := eventHour - 3600 // the entry UpdateFromWebhook compares against
+	cellID := "cell-backlog"
+
+	wt.SetHourWeather(cellID, comparisonHour, 1)
+	wt.SetHourWeather(cellID, eventHour, 1)
+
+	// The sweep runs on wall clock, already past the event's hour.
+	wt.evict(now)
+
+	// Backlogged webhook: stamped 59 minutes into eventHour, delivered now,
+	// reporting a different condition than comparisonHour held.
+	wt.UpdateFromWebhook(cellID, 2, eventHour+3540, 51.5, -0.1, [4][2]float64{})
+
+	select {
+	case change := <-wt.Changes():
+		if change.GameplayCondition != 2 || change.OldGameplayCondition != 1 {
+			t.Errorf("got change %d->%d, want 1->2", change.OldGameplayCondition, change.GameplayCondition)
+		}
+	default:
+		t.Error("no WeatherChange emitted: eviction dropped the previous-hour entry the backlogged webhook needed")
 	}
 }

--- a/processor/internal/webhook/rate.go
+++ b/processor/internal/webhook/rate.go
@@ -12,6 +12,10 @@ import (
 // and one for per-minute per-type maps. The slot index is (unix/60 % 60), so
 // each slot covers exactly one calendar minute. Slots are overwritten when a
 // new minute arrives, giving automatic O(1) decay with no background goroutine.
+//
+// tracker.StatsTracker runs the same mechanism over a configurable window for
+// per-species counts. The wrap-recycling and stale-slot invariants are shared,
+// so a boundary bug found here is almost certainly present there too.
 type RateCounter struct {
 	mu sync.Mutex
 


### PR DESCRIPTION
## Summary

A production install running ~2400 pokemon webhooks/sec sat at **6436.5 MB RSS on `develop`, climbing until it OOM'd**. On this branch the same box holds **~1000 MB, steady**, through a community day at the same rate. That is a **6.4x cut in resident memory**, and 9.1x in live heap.

A heap profile showed why: 3777.80 MB of live heap, **92% of it in two structures on the pokemon path**. Both scale with webhook rate rather than with users or tracking rules, so they grow on their own with no config change.

Four fixes, one commit each. Three of them are the same mistake in different clothes: keeping raw per-event material when only an aggregate was ever read back.

Same host, `inuse_space`, before and after:

```
develop (3777.80MB total)              this branch (416.50MB total)
1838.64MB 48.67%  RecordSighting         3.04MB  0.73%  RecordSighting
1643.72MB 43.51%  CheckPokemon         299.70MB 71.96%  expiringSet.Add
 140.91MB  3.73%  geo.init.0            28.66MB  6.88%  geo.init.0
```

## 1. Rarity: per-sighting slice → bucketed counter ring

`StatsTracker.RecordSighting` appended a 24-byte `sighting` record per pokemon webhook — **before** the duplicate check (`pokemon.go:55` vs `:67`), so duplicates counted too — and kept `window_hours` of them. At 2400/sec over the default 8h window that is ~70M records.

Those records were only ever read to produce **per-species counts** in `recalculate()`. So store the counts: a ring of per-minute buckets, each `map[int32]{all, iv, shiny}`. Size now depends on distinct species and window length, never on throughput.

The second half of the bug is what made it fatal. Pruning used `pruned := st.sightings[:0]`, which reuses the backing array, and **Go slices never shrink capacity**. The high-water mark was therefore permanent: every spawn surge ratcheted the floor up and it only came back on restart. That also explains the overnight growth pattern in the profiles, where `RecordSighting` grew 25% while the dedup cache (which really evicts) grew 15%.

Window granularity moves from one second to one minute. The clock is now injectable so window expiry is testable without sleeping.

## 2. Dedup: `ttlcache[string, bool]` → sharded fingerprint map

`DuplicateCache` spent **265 B per entry** (measured) to remember one bit: a heap-allocated `Item`, the retained key string, a `container/list` node, and an `expirationQueue` entry. The old profile shows the shape plainly — 267.51 MB of nothing but list nodes, and 146 MB of nothing but the `fmt.Sprintf` that built keys the cache then held onto.

The new `expiringSet` (`internal/tracker/expiring_set.go`) hashes the key with `maphash` and stores only its expiry, in a map sharded 16 ways. **37.8 B/entry**: 126.4 MB → 18.0 MB over 500k entries in a standalone benchmark.

**Key derivation and TTLs are deliberately untouched.** Every `Check*` method builds the same key string (CP still in the pokemon key) and passes the same TTL, so dedup semantics are identical. Reads expire lazily exactly as `ttlcache` did. A background sweeper reclaims expired entries **one shard at a time**, because a full unsharded scan of a multi-million-entry map measured 89 ms and would have traded memory for a latency spike on the webhook path.

`raidCache` stays on `ttlcache` — it stores real values (prior RSVP state) rather than a bit, and its cardinality is bounded by active raids.

Two behaviour notes. Keys are fingerprinted rather than retained, so a 64-bit collision reads as a false duplicate and drops one alert; at ~6M live entries that is ~3.3e-13 per insert, roughly one every few decades at 2400/sec. And expiry is stored in unix **nanoseconds**, not seconds, because seconds truncate a sub-second TTL into the past on write. The expiry test caught that one.

## 3. tzf: `NewFullFinder()` → `NewDefaultFinder()`

`geo.init.0` decoded tzf-dist's **18 MB full-precision** polygon set at startup. `NewDefaultFinder` decodes the **6.5 MB topology-simplified** set and shares the same preindex tile fast path. Measured against `tzf v1.2.5` / `tzf-dist v0.0.2026-c-fix1` in isolation: **163.0 MB → 33.6 MB**. In-process: **140.91 MB → 28.66 MB**.

The cost is boundary precision. Upstream bounds simplified boundaries to **~111 m** of the true border, so a spawn that close to a timezone line resolves to a neighbouring zone. The coordinate guard goes from 9 cases to 21, adding zones that sit close to a neighbour or carry an unusual offset (Phoenix, Indianapolis, Kathmandu, Adelaide, Lisbon/Madrid, Anchorage, Honolulu, Mumbai). All 21 resolve identically before and after the swap.

## 4. Weather: cells were never evicted

`grep -c 'delete(' internal/tracker/weather.go` returned **0**. Two things grew. `controllerCellData.hourWeather` gained an entry per cell per hour and kept it forever, unreadable past the previous hour (`UpdateFromWebhook` only compares against `currentHour-3600`, and `ExportCellWeather` filters to the same). Separately, a cell that stopped being scanned kept its struct indefinitely, so a shifted scan area stranded state.

A sweep on a 10-minute ticker now drops hourly entries behind the retention floor and reclaims cells untouched for 24h. The idle window is deliberately longer than the 8h AccuWeather refresh so an actively-forecast cell is never reclaimed, and `lastSeen` is stamped **before** the early return in `CheckWeatherOnMonster` so any scanned cell stays alive. Forecast hours written ahead by `SetHourWeather` are preserved.

This one is too slow to show up in a snapshot profile, so it rests on its tests rather than on the numbers below.

## Measurements

A/B'd against a shadow instance on a second VPS taking the same Golbat firehose, with an empty database and no tokens. Traffic parity was confirmed from `/metrics` over a 60s window: **2425.9 pokemon/sec on both**, ratio 1.00 across pokemon, invasion and raid.

Production, same host, before and after:

| | `develop` | this branch |
|---|---:|---:|
| `process_resident_memory_bytes` | 6436.5 MB | **~1000 MB** |
| `go_memstats_heap_inuse_bytes` | 5520.8 MB | 590-680 MB |
| `go_memstats_next_gc_bytes` | 7497.9 MB | ~811 MB |
| `inuse_space` total | 3777.80 MB | 416.50 MB |

`next_gc` at 7497.9 MB is the `GOGC=100` doubling made explicit: no collection until the heap reached 7.5 GB, so every byte of live heap removed takes about two bytes of RSS ceiling with it.

The after figures are at steady state, not a lucky sample. RSS held between 999.0 MB and 1012.3 MB across readings from 2.7h to 3.5h uptime at a flat 2419.7 pokemon/sec, and `expiringSet.Add` read 299.70 MB in two profiles 50 minutes apart. `RecordSighting` is still filling toward the 8h window and should settle in the single-digit MB.

One property worth stating rather than discovering later: Go maps do not shrink on `delete`, so `expiringSet` is bounded by peak occupancy rather than current. At constant traffic that is the same number. A sustained spike would raise the floor until restart, in the same way the old rarity slice did, though at roughly a seventh of the bytes per entry. If that turns out to matter in practice, the sweeper is the natural place to rebuild an undersized shard.

## Also included

`fix(test): pin summary scheduler tests to UTC` — an unrelated pre-existing failure the gate surfaced. The test humans sit at lat/lon 0/0, so `isScheduleActive` falls back to the host's `time.Local` when `schedulerConfig.DefaultTimezone` is empty, while every `now` in the file is a fixed UTC instant. `TestSummaryScheduler_Tick_FiresWhenScheduleMatches` and `..._RespectsScheduleWindow` therefore passed on a UTC runner and failed under any real local offset. Verified green under UTC, America/New_York, Asia/Tokyo and Australia/Sydney.

## Test

Each new test was written before its implementation and verified to fail against the old code, or against a deliberately sabotaged version where it guards pre-existing behaviour:

- `TestStatsTrackerMemoryIsIndependentOfSightingVolume` — 51.6 MB for 2M sightings on `develop`, against a 30 MB budget
- `TestStatsTrackerDropsSightingsOutsideWindow`, `TestStatsTrackerRingRecyclesStaleBuckets` — window expiry and ring wrap-around, neither of which the slice implementation ever had
- `TestDuplicateCacheMemoryPerEntry` — 265.0 B/entry on `develop`, against a 60 B budget
- `TestDuplicateCacheEntryExpires`, `TestExpiringSetSweepReclaimsExpiredEntries`, `TestExpiringSetSpreadsAcrossShards`
- `TestWeatherTrackerEvictsHoursOutsideRetention`, `TestWeatherTrackerEvictsIdleCells`
- `TestGetTimezone_KnownCoordinates` widened from 9 to 21 cases

Gate green: `go build ./... && go vet ./... && go test -count=1 ./... && golangci-lint run ./...` (0 issues).

## Open question for the maintainer

Dedup is now the largest single consumer by a wide margin — 299.70 MB, 72% of live heap — and it catches **2.3 duplicates/sec out of 2425.9 received, or 0.09%**. The flat 3600s TTL for unverified webhooks (`duplicate.go:57`) is the biggest remaining lever on it, and the pokemon key includes CP, so one spawn occupies at least two entries (the wild sighting at `cp=0`, then the encounter). Both were left alone here on purpose, since they are dedup-correctness calls rather than memory ones. Happy to follow up if either should change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
