### PR TITLE
fix: five pre-existing P2s from the PR #188 review batch

### DIFF
--- a/processor/internal/api/huma_dts_reads.go
+++ b/processor/internal/api/huma_dts_reads.go
@@ -142,7 +142,11 @@ func RegisterDTSDeleteTemplate(api huma.API, ts dtsTemplateReader) {
 		Description: "Removes the DTS entry identified by the type/platform/language/id query keys from memory and disk. Unknown keys yield 404; readonly fallback entries (and other store rejections) yield 403.",
 		Security:    []map[string][]string{{"poracleSecret": {}}},
 	}, func(_ context.Context, in *dtsDeleteTemplateInput) (*statusOKOutput, error) {
-		if in.Type == "" || in.Platform == "" || in.ID == "" {
+		// Platform is required except for platform-agnostic types (e.g.
+		// help), whose entries carry an empty platform — mirroring the save
+		// endpoint's exemption so a saved override can also be deleted.
+		if in.Type == "" || in.ID == "" ||
+			(in.Platform == "" && !dts.IsPlatformAgnosticType(in.Type)) {
 			return nil, huma.Error400BadRequest("type, platform, and id query parameters are required")
 		}
 		if err := ts.DeleteEntry(in.Type, in.Platform, in.Language, in.ID); err != nil {

--- a/processor/internal/api/huma_dts_reads_test.go
+++ b/processor/internal/api/huma_dts_reads_test.go
@@ -468,3 +468,33 @@ func TestHumaButtonActions_NilRegistry503(t *testing.T) {
 		t.Fatalf("status = %d, want 503; body: %s", w.Code, w.Body.String())
 	}
 }
+
+// Platform-agnostic types (help) save overrides with an empty platform —
+// the DELETE endpoint must accept the same key shape instead of rejecting
+// it with 400 before DeleteEntry is reached.
+func TestHumaDTSDeleteTemplate_PlatformAgnosticEmptyPlatform(t *testing.T) {
+	r, api := newDTSTestAPI(t)
+	RegisterDTSDeleteTemplate(api, &stubTemplateReader{})
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/dts/templates?type=help&id=1", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 for platform-agnostic delete; body: %s", w.Code, w.Body.String())
+	}
+}
+
+// Non-agnostic types still require platform.
+func TestHumaDTSDeleteTemplate_NonAgnosticStillRequiresPlatform(t *testing.T) {
+	r, api := newDTSTestAPI(t)
+	RegisterDTSDeleteTemplate(api, &stubTemplateReader{})
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/dts/templates?type=monster&id=1", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 when platform missing for monster; body: %s", w.Code, w.Body.String())
+	}
+}

--- a/processor/internal/api/testdata/openapi.golden.json
+++ b/processor/internal/api/testdata/openapi.golden.json
@@ -5479,6 +5479,12 @@
                 },
                 "pvp_ranking_league": {
                   "description": "PVP league CP cap (the stored int IS the cap): 0 | 500 | 1500 | 2500. Omit (or 0) for IV-mode tracking with no PVP filter (stored as 0 = none/IV mode). Returned as null when at its wildcard.",
+                  "enum": [
+                    0,
+                    500,
+                    1500,
+                    2500
+                  ],
                   "format": "int64",
                   "type": [
                     "integer",
@@ -5791,6 +5797,12 @@
                 },
                 "pvp_ranking_league": {
                   "description": "PVP league CP cap (the stored int IS the cap): 0 | 500 | 1500 | 2500. Omit (or 0) for IV-mode tracking with no PVP filter (stored as 0 = none/IV mode). Returned as null when at its wildcard.",
+                  "enum": [
+                    0,
+                    500,
+                    1500,
+                    2500
+                  ],
                   "format": "int64",
                   "type": [
                     "integer",
@@ -6103,6 +6115,12 @@
                 },
                 "pvp_ranking_league": {
                   "description": "PVP league CP cap (the stored int IS the cap): 0 | 500 | 1500 | 2500. Omit (or 0) for IV-mode tracking with no PVP filter (stored as 0 = none/IV mode). Returned as null when at its wildcard.",
+                  "enum": [
+                    0,
+                    500,
+                    1500,
+                    2500
+                  ],
                   "format": "int64",
                   "type": [
                     "integer",
@@ -8201,6 +8219,12 @@
                 },
                 "pvp_ranking_league": {
                   "description": "PVP league CP cap (the stored int IS the cap): 0 | 500 | 1500 | 2500. Omit (or 0) for IV-mode tracking with no PVP filter (stored as 0 = none/IV mode). Returned as null when at its wildcard.",
+                  "enum": [
+                    0,
+                    500,
+                    1500,
+                    2500
+                  ],
                   "format": "int64",
                   "type": [
                     "integer",
@@ -10184,6 +10208,12 @@
                 },
                 "pvp_ranking_league": {
                   "description": "PVP league CP cap (the stored int IS the cap): 0 | 500 | 1500 | 2500. Omit (or 0) for IV-mode tracking with no PVP filter (stored as 0 = none/IV mode). Returned as null when at its wildcard.",
+                  "enum": [
+                    0,
+                    500,
+                    1500,
+                    2500
+                  ],
                   "format": "int64",
                   "type": [
                     "integer",
@@ -11187,6 +11217,12 @@
           },
           "pvp_ranking_league": {
             "description": "PVP league CP cap (the stored int IS the cap): 0 | 500 | 1500 | 2500. Omit (or 0) for IV-mode tracking with no PVP filter (stored as 0 = none/IV mode). Returned as null when at its wildcard.",
+            "enum": [
+              0,
+              500,
+              1500,
+              2500
+            ],
             "format": "int64",
             "type": [
               "integer",

--- a/processor/internal/api/v2_mutes.go
+++ b/processor/internal/api/v2_mutes.go
@@ -125,9 +125,14 @@ func validateMuteValue(deps *TrackingDeps, human *store.Human, scope, value stri
 	}
 	switch scope {
 	case mute.ScopePokemon, mute.ScopeTracking:
-		if n, err := strconv.Atoi(value); err != nil || n <= 0 {
+		n, err := strconv.Atoi(value)
+		if err != nil || n <= 0 {
 			return "", huma.Error422UnprocessableEntity("value for scope '" + scope + "' must be a positive integer")
 		}
+		// Canonicalise ("025" → "25"): the matcher and the DELETE lookup
+		// compare ScopeValue against strconv-formatted IDs, so a verbatim
+		// non-canonical value would create a mute that never fires.
+		return strconv.Itoa(n), nil
 	case mute.ScopeArea:
 		// Prefer AreaLogic (community-aware, like the bot); fall back to the
 		// live state's fences — production trackingDeps carries no AreaLogic,

--- a/processor/internal/api/v2_mutes_test.go
+++ b/processor/internal/api/v2_mutes_test.go
@@ -371,3 +371,23 @@ func TestV2Mutes_Create_Area_StateMgrFallback(t *testing.T) {
 		t.Fatalf("area mute does not match after StateMgr validation")
 	}
 }
+
+// Numeric mute values must be canonicalised before storage: "025" passes
+// Atoi validation but the matcher compares ScopeValue against the
+// canonical decimal string ("25"), so a verbatim-stored "025" creates a
+// mute that never suppresses anything.
+func TestV2Mutes_Create_CanonicalisesNumericValue(t *testing.T) {
+	r, mutes := newV2MutesTestAPI(t)
+	w := v2DoReq(t, r, http.MethodPost, "/api/v2/humans/u1/mutes",
+		`{"scope":"pokemon","value":"025"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	item := v2DecodeBody(t, w)["mute"].(map[string]any)
+	if item["value"] != "25" {
+		t.Fatalf("expected canonical value \"25\", got %v", item["value"])
+	}
+	if !mutes.Match("u1", mute.Event{PokemonID: 25}, time.Now().Unix()) {
+		t.Fatalf("store does not match pokemon 25 — value stored verbatim instead of canonicalised")
+	}
+}

--- a/processor/internal/api/v2_pokemon.go
+++ b/processor/internal/api/v2_pokemon.go
@@ -55,7 +55,7 @@ type v2PokemonRule struct {
 	Size    *int `json:"size,omitempty" nullable:"true" doc:"Minimum size tier. Omit to match any size (stored as -1 = any). Returned as null when at its wildcard."`
 	MaxSize *int `json:"max_size,omitempty" nullable:"true" doc:"Maximum size tier (1-5). Omit to impose no upper bound (stored as 5 = the top tier, i.e. no upper bound). Returned as null when at its wildcard."`
 
-	PVPRankingLeague    *int `json:"pvp_ranking_league,omitempty" nullable:"true" doc:"PVP league CP cap (the stored int IS the cap): 0 | 500 | 1500 | 2500. Omit (or 0) for IV-mode tracking with no PVP filter (stored as 0 = none/IV mode). Returned as null when at its wildcard."`
+	PVPRankingLeague    *int `json:"pvp_ranking_league,omitempty" nullable:"true" enum:"0,500,1500,2500" doc:"PVP league CP cap (the stored int IS the cap): 0 | 500 | 1500 | 2500. Omit (or 0) for IV-mode tracking with no PVP filter (stored as 0 = none/IV mode). Returned as null when at its wildcard."`
 	PVPRankingBest      *int `json:"pvp_ranking_best,omitempty" nullable:"true" doc:"Best (lowest, 1-based) PVP rank to alert on. Omit to start from rank 1 (stored as 1 = best possible rank). Returned as null when at its wildcard."`
 	PVPRankingWorst     *int `json:"pvp_ranking_worst,omitempty" nullable:"true" doc:"Worst (highest) PVP rank to alert on. Omit to impose no upper rank limit (stored as 4096 = no upper rank limit sentinel; PVP ranks never exceed it). Returned as null when at its wildcard."`
 	PVPRankingMinCP     *int `json:"pvp_ranking_min_cp,omitempty" nullable:"true" doc:"PVP CP floor. Omit to impose no floor (stored as 0 = no floor). Returned as null when at its wildcard."`

--- a/processor/internal/api/v2_pokemon_test.go
+++ b/processor/internal/api/v2_pokemon_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -756,4 +757,29 @@ func TestV2RuleEnvelope_SchemaIncludesUID(t *testing.T) {
 // itoa is a tiny helper to keep paths readable.
 func itoa(v int64) string {
 	return strconv.FormatInt(v, 10)
+}
+
+// pvp_ranking_league documents a closed value set (0|500|1500|2500) but used
+// to accept any integer — a league like 42 was persisted yet indexed under a
+// key the PVP matcher never traverses, so the rule could never alert.
+func TestV2Pokemon_RejectsInvalidPVPLeague(t *testing.T) {
+	r, _, _, restore := newV2PokemonTestAPI(t)
+	defer restore()
+	w := v2DoReq(t, r, http.MethodPost, "/api/v2/humans/u1/tracking/pokemon",
+		`[{"pokemon_id":25,"pvp_ranking_league":42,"pvp_ranking_worst":10}]`)
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("expected 422 for league 42, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestV2Pokemon_AcceptsValidPVPLeagues(t *testing.T) {
+	r, _, _, restore := newV2PokemonTestAPI(t)
+	defer restore()
+	for _, league := range []int{500, 1500, 2500} {
+		w := v2DoReq(t, r, http.MethodPost, "/api/v2/humans/u1/tracking/pokemon",
+			fmt.Sprintf(`[{"pokemon_id":25,"pvp_ranking_league":%d,"pvp_ranking_worst":10}]`, league))
+		if w.Code != http.StatusOK {
+			t.Fatalf("league %d should be accepted, got %d: %s", league, w.Code, w.Body.String())
+		}
+	}
 }

--- a/processor/internal/bot/commands/track.go
+++ b/processor/internal/bot/commands/track.go
@@ -87,11 +87,13 @@ func (c *TrackCommand) Run(ctx *bot.CommandContext, args []string) []bot.Reply {
 	}
 
 	// Reject bare "!track everything" with no meaningful filters for non-admins.
-	// Filters like IV, CP, level, PVP league, type, or gender meaningfully narrow results.
-	// "shiny" alone doesn't — almost everything can be shiny.
+	// Filters like IV, CP, level, PVP league, type, gender, or costume
+	// meaningfully narrow results. "shiny" alone doesn't — almost everything
+	// can be shiny.
 	if parsed.HasKeyword("arg.everything") && !ctx.IsAdmin {
 		hasFilters := len(parsed.Singles) > 0 || len(parsed.Ranges) > 0 ||
-			len(parsed.Types) > 0 || parsed.Gender != 0 || len(parsed.PVP) > 0
+			len(parsed.Types) > 0 || parsed.Gender != 0 || len(parsed.PVP) > 0 ||
+			costume != 9000
 		if !hasFilters {
 			return []bot.Reply{{React: "🙅", Text: tr.T("msg.track.everything_no_filters")}}
 		}

--- a/processor/internal/bot/commands/track_test.go
+++ b/processor/internal/bot/commands/track_test.go
@@ -789,3 +789,37 @@ func TestParsePVP_MegaKeywords(t *testing.T) {
 		}
 	}
 }
+
+// --- everything + costume ---
+
+// `!track everything costume:N` is a genuinely narrowing filter (matching
+// supports costume constraints on the ID-0 catch-all rule), so the bare-
+// everything guard must count it — it used to consult only
+// Singles/Ranges/Types/Gender/PVP and reject the command for non-admins.
+func TestTrack_EverythingWithCostume_Allowed(t *testing.T) {
+	ctx := trackCtx(t)
+	ctx.Config.Tracking.EverythingFlagPermissions = "allow-any"
+	ctx.IsAdmin = false
+
+	replies := runTrack(t, ctx, "everything costume:5")
+
+	require.NotEmpty(t, replies)
+	assert.Equal(t, "✅", replies[0].React, "reply: %s", replies[0].Text)
+
+	rows, _ := ctx.Tracking.Monsters.SelectByIDProfile("user1", 1)
+	require.NotEmpty(t, rows)
+	assert.Equal(t, 5, rows[0].Costume, "costume filter should be stored")
+}
+
+// Bare `!track everything` (no narrowing filters) must still be rejected
+// for non-admins.
+func TestTrack_EverythingBare_StillRejected(t *testing.T) {
+	ctx := trackCtx(t)
+	ctx.Config.Tracking.EverythingFlagPermissions = "allow-any"
+	ctx.IsAdmin = false
+
+	replies := runTrack(t, ctx, "everything")
+
+	require.NotEmpty(t, replies)
+	assert.Equal(t, "🙅", replies[0].React, "bare everything should be rejected: %s", replies[0].Text)
+}

--- a/processor/internal/dts/editor_test.go
+++ b/processor/internal/dts/editor_test.go
@@ -409,3 +409,52 @@ func TestLogSummaryHelpShadowingAdvisory(t *testing.T) {
 		})
 	}
 }
+
+// A user override that shadows a readonly fallback (same entry key — the
+// documented workflow for platform-agnostic types like help) must be
+// deletable. DeleteEntry used to scan forward and bail with "readonly" on
+// the fallback before ever reaching the override.
+func TestDeleteEntryPrefersUserOverrideOverReadonlyFallback(t *testing.T) {
+	tmp := t.TempDir()
+
+	// User override shadowing the fallback's key (help entries carry an
+	// empty platform).
+	if err := os.WriteFile(filepath.Join(tmp, "dts.json"), []byte(`[
+		{"type": "help", "id": "1", "platform": "", "language": "", "template": {"content": "user override"}}
+	]`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	fallbackDir := filepath.Join(tmp, "fallback")
+	if err := os.MkdirAll(fallbackDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(fallbackDir, "dts.json"), []byte(`[
+		{"type": "help", "id": "1", "platform": "", "language": "", "template": {"content": "bundled fallback"}}
+	]`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	ts, err := LoadTemplates(tmp, fallbackDir)
+	if err != nil {
+		t.Fatalf("LoadTemplates: %v", err)
+	}
+
+	if err := ts.DeleteEntry("help", "", "", "1"); err != nil {
+		t.Fatalf("DeleteEntry should remove the user override, got: %v", err)
+	}
+
+	// The readonly fallback must survive and become visible again.
+	list := ts.FilteredEntries("help", "", "", "1")
+	if len(list) != 1 {
+		t.Fatalf("expected the fallback to remain, got %d entries", len(list))
+	}
+	if !list[0].Readonly {
+		t.Errorf("surviving entry should be the readonly fallback")
+	}
+
+	// Deleting again must now report readonly (only the fallback matches).
+	if err := ts.DeleteEntry("help", "", "", "1"); err == nil || !strings.Contains(err.Error(), "readonly") {
+		t.Fatalf("second delete should hit the readonly fallback, got: %v", err)
+	}
+}

--- a/processor/internal/dts/templates.go
+++ b/processor/internal/dts/templates.go
@@ -1295,23 +1295,37 @@ func (ts *TemplateStore) DeleteEntry(filterType, filterPlatform, filterLanguage,
 	target := DTSEntry{Type: filterType, Platform: filterPlatform, Language: filterLanguage, ID: jsonID(filterID)}
 	targetKey := entryKey(&target)
 
+	// Prefer the last non-readonly match: a user override shares its key
+	// with the readonly fallback it shadows (the documented workflow for
+	// platform-agnostic types), so a forward first-match scan would bail
+	// with "readonly" before ever reaching the override. Only report
+	// readonly when every matching entry is a fallback.
 	var sourceFile string
 	found := false
-	for i := range ts.entries {
+	readonlyMatch := (*DTSEntry)(nil)
+	for i := len(ts.entries) - 1; i >= 0; i-- {
 		e := &ts.entries[i]
-		if entryKey(e) == targetKey {
-			if e.Readonly {
-				ts.mu.Unlock()
-				return fmt.Errorf("template %s/%s/%s/%s is readonly", e.Type, e.Platform, e.ID, e.Language)
-			}
-			sourceFile = e.sourceFile
-			ts.entries = append(ts.entries[:i], ts.entries[i+1:]...)
-			ts.cache = make(map[string]*raymond.Template)
-			ts.sourceCache = make(map[string]string)
-			ts.tileUsage = make(map[string]bool)
-			found = true
-			break
+		if entryKey(e) != targetKey {
+			continue
 		}
+		if e.Readonly {
+			if readonlyMatch == nil {
+				readonlyMatch = e
+			}
+			continue
+		}
+		sourceFile = e.sourceFile
+		ts.entries = append(ts.entries[:i], ts.entries[i+1:]...)
+		ts.cache = make(map[string]*raymond.Template)
+		ts.sourceCache = make(map[string]string)
+		ts.tileUsage = make(map[string]bool)
+		found = true
+		break
+	}
+	if !found && readonlyMatch != nil {
+		e := readonlyMatch
+		ts.mu.Unlock()
+		return fmt.Errorf("template %s/%s/%s/%s is readonly", e.Type, e.Platform, e.ID, e.Language)
 	}
 
 	configDir := ts.configDir

--- a/processor/internal/store/tracking_test.go
+++ b/processor/internal/store/tracking_test.go
@@ -8,7 +8,6 @@ import (
 
 func TestMonstersInsertWithOverride(t *testing.T) {
 	dbx := openTestDB(t)
-	defer dbx.Close()
 	s := NewTrackingStores(dbx)
 	uid, err := s.Monsters.Insert(&db.MonsterTrackingAPI{
 		ID: "u1", ProfileNo: 0, PokemonID: 25,

--- a/processor/internal/store/user_locations_sql.go
+++ b/processor/internal/store/user_locations_sql.go
@@ -59,7 +59,18 @@ func (s *SQLHumanStore) UpdateLocation(id, label string, lat, lon float64) error
 		return err
 	}
 	if n == 0 {
-		return fmt.Errorf("%w: %q for user %q", ErrLocationNotFound, label, id)
+		// MySQL reports rows *changed*, not matched (the DSN doesn't set
+		// CLIENT_FOUND_ROWS): re-submitting the current coordinates affects
+		// zero rows even though the row exists. Distinguish the no-op update
+		// from a genuinely missing label before reporting not-found.
+		var exists int
+		if err := s.db.Get(&exists,
+			`SELECT COUNT(*) FROM user_locations WHERE id = ? AND LOWER(label) = LOWER(?)`, id, label); err != nil {
+			return err
+		}
+		if exists == 0 {
+			return fmt.Errorf("%w: %q for user %q", ErrLocationNotFound, label, id)
+		}
 	}
 	return nil
 }

--- a/processor/internal/store/user_locations_sql_test.go
+++ b/processor/internal/store/user_locations_sql_test.go
@@ -12,6 +12,11 @@ import (
 // openTestDB connects to the test MySQL instance via PORACLENG_TEST_DSN and
 // creates the tables needed for user-location tests. Skips the test if the
 // env var is unset or the connection fails.
+//
+// Callers must NOT `defer db.Close()`: deferred closes run before
+// t.Cleanup callbacks, so the row-deleting cleanup registered here would
+// silently fail against a closed connection and leak rows into the next
+// test. The cleanup closes the connection itself.
 func openTestDB(t *testing.T) *sqlx.DB {
 	t.Helper()
 	dsn := os.Getenv("PORACLENG_TEST_DSN")
@@ -100,7 +105,6 @@ func mustExec(t *testing.T, db *sqlx.DB, query string, args ...any) {
 
 func TestUserLocationsSQL_RoundTrip(t *testing.T) {
 	dbx := openTestDB(t)
-	defer dbx.Close()
 	s := &SQLHumanStore{db: dbx}
 
 	if _, err := s.AddLocation(UserLocation{ID: "u1", Label: "Home", Latitude: 51.5, Longitude: -0.1}); err != nil {
@@ -135,7 +139,6 @@ func TestUserLocationsSQL_RoundTrip(t *testing.T) {
 
 func TestCountLocationReferences(t *testing.T) {
 	dbx := openTestDB(t)
-	defer dbx.Close()
 	s := &SQLHumanStore{db: dbx}
 
 	mustExec(t, dbx, `INSERT INTO monsters (id, profile_no, pokemon_id, override_location_label) VALUES ('u1', 0, 25, 'Home'), ('u1', 0, 26, 'Home')`)
@@ -202,7 +205,6 @@ func TestFilterPermittedAreas_CaseInsensitive(t *testing.T) {
 
 func TestPruneOverrideAreas_StripsDisallowed(t *testing.T) {
 	dbx := openTestDB(t)
-	defer dbx.Close()
 	s := &SQLHumanStore{db: dbx}
 
 	mustExec(t, dbx, `INSERT INTO monsters (id, profile_no, pokemon_id, override_areas) VALUES
@@ -229,5 +231,28 @@ func TestPruneOverrideAreas_StripsDisallowed(t *testing.T) {
 	}
 	if rows[1].OverrideAreas != "" {
 		t.Fatalf("pokemon 26: expected NULL after empty pruning, got %q", rows[1].OverrideAreas)
+	}
+}
+
+// A PUT that re-submits a location's current coordinates must succeed.
+// MySQL reports rows *changed* (not matched) for UPDATE without
+// CLIENT_FOUND_ROWS, so a no-op update affects zero rows even though the
+// row exists — which UpdateLocation used to misread as not-found (404).
+func TestUserLocationsSQL_UpdateUnchangedCoordinates(t *testing.T) {
+	dbx := openTestDB(t)
+	s := NewSQLHumanStore(dbx)
+
+	if _, err := s.AddLocation(UserLocation{ID: "u1", Label: "PutNoop", Latitude: 51.5, Longitude: -0.12}); err != nil {
+		t.Fatalf("AddLocation: %v", err)
+	}
+
+	// Same coordinates — zero rows changed, but the row exists.
+	if err := s.UpdateLocation("u1", "putnoop", 51.5, -0.12); err != nil {
+		t.Fatalf("UpdateLocation with unchanged coordinates should succeed, got: %v", err)
+	}
+
+	// A genuinely missing label must still report not-found.
+	if err := s.UpdateLocation("u1", "nowhere", 1, 2); err == nil {
+		t.Fatal("UpdateLocation on missing label should fail")
 	}
 }


### PR DESCRIPTION
## Summary

Fixes items 4–8 of @Mygod's second review batch on #188 — all pre-existing on develop, all verified before fixing, one commit per fix with a failing-first regression test:

1. **Locations PUT 404 on unchanged coordinates** (`store/user_locations_sql.go`) — MySQL reports rows *changed*, not matched, so a no-op update read as not-found. Now distinguished with an existence check. Also fixes a test-harness leak found while reproducing: `defer dbx.Close()` ran before `t.Cleanup`, silently breaking the row cleanup and leaking rows between tests (the store's MySQL-backed tests are now leak-free across consecutive runs).
2. **Mute values stored verbatim** (`api/v2_mutes.go`) — `"025"` passed validation but never matched the canonical-decimal comparison in the matcher or DELETE lookup. Numeric values are canonicalised on store, matching the bot path.
3. **Platform-agnostic DTS overrides undeletable** (`api/huma_dts_reads.go` + `dts/templates.go`) — two stacked blockers: the DELETE endpoint rejected the empty platform the save endpoint accepts, and `DeleteEntry`'s forward scan bailed "readonly" on the shadowed fallback before reaching the user's override. Delete now mirrors the save exemption and prefers the last non-readonly match.
4. **`!track everything costume:X` rejected for non-admins** (`bot/commands/track.go`) — the bare-everything guard didn't count the resolved costume as a narrowing filter, though matching fully supports costume-constrained catch-all rules.
5. **`pvp_ranking_league` accepted arbitrary ints** (`api/v2_pokemon.go`) — league 42 persisted into an index the matcher never traverses (a rule that can never alert). Now a schema enum {0, 500, 1500, 2500}, like the sibling gender field; OpenAPI golden regenerated.

Item 1 of the batch (PUT delete-then-insert atomicity) is deliberately separate — it lands next as a migration dropping the two leftover tracking UNIQUE keys plus app-level PUT identity validation.

## Test plan

- New regression tests per fix (each confirmed red before the fix), incl. a real-MySQL reproduction of the rows-changed 404
- Full gate green from `processor/`: `go build`, `go vet`, `go test -count=1 ./...` (with `PORACLENG_TEST_DSN` set so the MySQL-backed store tests run), `golangci-lint run` (0 issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)