### PR TITLE
fix: v2 PUT identity validation + drop legacy invasion/lures unique keys

### DIFF
--- a/processor/internal/api/v2_invasion_test.go
+++ b/processor/internal/api/v2_invasion_test.go
@@ -485,3 +485,51 @@ func TestV2Invasion_RoundTrip_EverythingMode(t *testing.T) {
 		t.Fatalf("round-trip drifted the everything-mode rule: %+v", rows)
 	}
 }
+
+// A PUT whose body is an exact duplicate of a DIFFERENT rule must 409
+// before anything is deleted. On databases carrying the legacy invasion
+// unique key this exact flow used to delete the addressed rule and then
+// fail the insert with a duplicate-key error — deterministic data loss.
+func TestV2Invasion_PutDuplicateOfOtherRule_Conflict(t *testing.T) {
+	r, is, _, restore := newV2InvasionTestAPI(t)
+	defer restore()
+
+	// Rule A: grass grunts. Rule B: water grunts.
+	w := v2DoReq(t, r, http.MethodPost, "/api/v2/humans/u1/tracking/invasion",
+		`[{"type_id":11},{"type_id":3}]`)
+	created := v2RulesArray(t, v2DecodeBody(t, w), "created")
+	if len(created) != 2 {
+		t.Fatalf("expected 2 created rules, got %d", len(created))
+	}
+	uidB := int64(created[1]["uid"].(float64))
+
+	// PUT B with a body identical to A.
+	w = v2DoReq(t, r, http.MethodPut, "/api/v2/humans/u1/tracking/invasion/"+itoa(uidB), `{"type_id":11}`)
+	if w.Code != http.StatusConflict {
+		t.Fatalf("expected 409 for duplicate-of-other-rule PUT, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Nothing may have been deleted: both rules intact.
+	if rows := is.AllRows(); len(rows) != 2 {
+		t.Fatalf("expected both rules to survive the rejected PUT, got %d: %+v", len(rows), rows)
+	}
+}
+
+// A PUT that keeps the addressed rule's own identity (tweaking only
+// updatable fields) must NOT conflict with itself.
+func TestV2Invasion_PutSelfReplace_NoConflict(t *testing.T) {
+	r, is, _, restore := newV2InvasionTestAPI(t)
+	defer restore()
+
+	w := v2DoReq(t, r, http.MethodPost, "/api/v2/humans/u1/tracking/invasion", `[{"type_id":11}]`)
+	uid := int64(v2RulesArray(t, v2DecodeBody(t, w), "created")[0]["uid"].(float64))
+
+	w = v2DoReq(t, r, http.MethodPut, "/api/v2/humans/u1/tracking/invasion/"+itoa(uid), `{"type_id":11,"distance":750}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("self-identity PUT should succeed, got %d: %s", w.Code, w.Body.String())
+	}
+	rows := is.AllRows()
+	if len(rows) != 1 || rows[0].Distance != 750 {
+		t.Fatalf("replace did not apply: %+v", rows)
+	}
+}

--- a/processor/internal/api/v2_tracking.go
+++ b/processor/internal/api/v2_tracking.go
@@ -11,6 +11,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/pokemon/poracleng/processor/internal/bot"
+	"github.com/pokemon/poracleng/processor/internal/db"
 	"github.com/pokemon/poracleng/processor/internal/i18n"
 	"github.com/pokemon/poracleng/processor/internal/store"
 )
@@ -434,6 +435,28 @@ func v2HandlePut[Req any, T any](deps *TrackingDeps, typ v2TrackingType[Req, T],
 	row, terr := typ.Translate(deps, human.ID, profileNo, oc, &in.Body)
 	if terr != nil {
 		return nil, terr
+	}
+
+	// App-level identity validation, mirroring the insert path's
+	// DiffAndClassify semantics: a body that is an exact duplicate of a
+	// DIFFERENT rule is rejected before anything is deleted. Constraint
+	// management is deliberately application-side in this schema (no DB
+	// transactions); without this check, the delete-then-insert below could
+	// destroy the addressed rule when the insert collides — deterministic
+	// data loss on databases still carrying the legacy invasion/lures
+	// unique keys, a silent duplicate on the keyless tables.
+	existing, err := typ.scopedRows(deps, human.ID, profileNo)
+	if err != nil {
+		return nil, huma.Error500InternalServerError("database error")
+	}
+	for i := range existing {
+		if typ.GetUID(&existing[i]) == in.UID {
+			continue
+		}
+		if noMatch, isDup, _, _ := db.DiffTracking(&existing[i], &row); !noMatch && isDup {
+			return nil, huma.Error409Conflict(fmt.Sprintf(
+				"an identical rule already exists (uid %d)", typ.GetUID(&existing[i])))
+		}
 	}
 
 	// Full replace = delete the old uid, insert the fully-specified body (new uid).

--- a/processor/internal/db/migrations/000008_drop_tracking_unique_keys.down.sql
+++ b/processor/internal/db/migrations/000008_drop_tracking_unique_keys.down.sql
@@ -1,0 +1,17 @@
+-- Re-add the legacy unique keys. NOTE: this fails if duplicate rows were
+-- created while the keys were absent; deduplicate manually before rolling
+-- back.
+
+SET @has_idx := (SELECT COUNT(*) FROM information_schema.statistics
+	WHERE table_schema = DATABASE() AND table_name = 'invasion' AND index_name = 'invasion_tracking');
+SET @ddl := IF(@has_idx = 0, 'ALTER TABLE `invasion` ADD UNIQUE KEY `invasion_tracking` (`id`,`profile_no`,`gender`,`grunt_type`)', 'SELECT 1');
+PREPARE stmt FROM @ddl;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @has_idx := (SELECT COUNT(*) FROM information_schema.statistics
+	WHERE table_schema = DATABASE() AND table_name = 'lures' AND index_name = 'lure_tracking');
+SET @ddl := IF(@has_idx = 0, 'ALTER TABLE `lures` ADD UNIQUE KEY `lure_tracking` (`id`,`profile_no`,`lure_id`)', 'SELECT 1');
+PREPARE stmt FROM @ddl;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;

--- a/processor/internal/db/migrations/000008_drop_tracking_unique_keys.up.sql
+++ b/processor/internal/db/migrations/000008_drop_tracking_unique_keys.up.sql
@@ -1,0 +1,26 @@
+-- Drop the two legacy UNIQUE keys left on tracking tables. Schema policy is
+-- app-managed integrity (the FK constraints were stripped for the same
+-- reason; DiffAndClassify/ApplyDiff dedupe inserts, and the v2 PUT path
+-- validates identity collisions). These keys were carried over from the
+-- legacy Knex schema and made the v2 PUT delete-then-insert destructive:
+-- an insert colliding with another rule's key failed AFTER the delete
+-- committed, permanently destroying the addressed rule.
+--
+-- Conditional via information_schema + PREPARE so the migration succeeds
+-- on adopted legacy databases where the index name may differ or the key
+-- may already be absent (plain DROP INDEX would error and leave the
+-- migration dirty).
+
+SET @has_idx := (SELECT COUNT(*) FROM information_schema.statistics
+	WHERE table_schema = DATABASE() AND table_name = 'invasion' AND index_name = 'invasion_tracking');
+SET @ddl := IF(@has_idx > 0, 'ALTER TABLE `invasion` DROP INDEX `invasion_tracking`', 'SELECT 1');
+PREPARE stmt FROM @ddl;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @has_idx := (SELECT COUNT(*) FROM information_schema.statistics
+	WHERE table_schema = DATABASE() AND table_name = 'lures' AND index_name = 'lure_tracking');
+SET @ddl := IF(@has_idx > 0, 'ALTER TABLE `lures` DROP INDEX `lure_tracking`', 'SELECT 1');
+PREPARE stmt FROM @ddl;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;


### PR DESCRIPTION
## Summary

Fixes item 1 (P1) of @Mygod's second review batch on #188 — the v2 PUT delete-then-insert data-loss path.

**The deterministic case**: `invasion` and `lures` still carried UNIQUE keys transcribed from the legacy Knex schema (`(id, profile_no, gender, grunt_type)` / `(id, profile_no, lure_id)`). A `PUT` whose body collided with a *different* rule's identity deleted the addressed rule, then failed the insert with a duplicate-key error — permanent, repeatable data loss from an ordinary API call. The eight keyless tables had the mirror-image gap: the same PUT silently created a functional duplicate.

**The fix follows the schema's actual policy** — integrity is deliberately app-managed (FK constraints were stripped for exactly this reason; the insert path already dedupes via `DiffAndClassify`). Rather than introducing DB transactions:

1. `v2HandlePut` now validates the translated body's identity against the target's other rules (`db.DiffTracking`, the same match-key machinery the insert path uses) **before deleting anything** — an exact duplicate of a different rule returns 409 with the conflicting uid. Self-identity replaces are unaffected. This protects all eleven tracking types uniformly.
2. Migration `000008` drops the two leftover unique keys, finishing the constraint removal and aligning invasion/lures with the other eight tables. It's conditional (information_schema + PREPARE), so it's idempotent and tolerant of adopted legacy schemas where the key may be absent or named differently; the down migration re-adds the keys (with the standard dedupe-first caveat).

Verified against MariaDB 11.8: up → idempotent re-up → down → up, with index state checked at each step.

## Test plan

- `TestV2Invasion_PutDuplicateOfOtherRule_Conflict` — red before the fix (PUT succeeded; on a keyed DB it destroyed the rule), green after; asserts 409 and that both rules survive
- `TestV2Invasion_PutSelfReplace_NoConflict` — self-identity PUT keeps working
- Full gate green from `processor/`: `go build`, `go vet`, `go test -count=1 ./...`, `golangci-lint run` (0 issues); combined-state run with #190 also green including the MySQL-backed store tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)