### PR TITLE
fix: !location accepts coordinates typed with a space after the comma

### DIFF
--- a/processor/internal/bot/argmatch.go
+++ b/processor/internal/bot/argmatch.go
@@ -341,6 +341,17 @@ func (am *ArgMatcher) Match(tokens []string, params []ParamDef, lang string) *Pa
 	// tokens the same way "razz_berry" / "move:hyper_beam" would.
 	tokens = am.collapseMultiWord(tokens)
 
+	// Same idea for coordinate pairs typed with spaces around the comma
+	// ("51.28, 1.08" — the shape Google Maps copies to the clipboard).
+	// Only for commands that asked for coordinates, so no other command's
+	// tokens can be merged.
+	for _, p := range params {
+		if p.Type == ParamLatLon {
+			tokens = collapseLatLon(tokens)
+			break
+		}
+	}
+
 	result := NewParsedArgs()
 	consumed := make([]bool, len(tokens))
 
@@ -875,6 +886,41 @@ func tryRemoveUID(tok string, result *ParsedArgs) bool {
 }
 
 var latLonRe = regexp.MustCompile(`^(-?\d+\.?\d*),(-?\d+\.?\d*)$`)
+
+// collapseLatLon merges a coordinate pair split across tokens by spaces
+// around the comma — "51.28, 1.08" (2 tokens) and "51.28 , 1.08" (3) both
+// become "51.28,1.08" — so tryLatLon's single-token regex sees them.
+// Without this the tokens match nothing, and the location command falls
+// through to forward geocoding, which resolves the coordinate text as an
+// address and silently sets an unrelated place.
+//
+// A window is joined only when the result is itself a valid lat,lon, so
+// tokens that merely sit next to each other are never merged.
+func collapseLatLon(tokens []string) []string {
+	out := make([]string, 0, len(tokens))
+	for i := 0; i < len(tokens); {
+		joined := ""
+		// Longest window first: "lat , lon" before "lat, lon".
+		for n := 3; n >= 2; n-- {
+			if i+n > len(tokens) {
+				continue
+			}
+			candidate := strings.Join(tokens[i:i+n], "")
+			if latLonRe.MatchString(candidate) {
+				joined = candidate
+				i += n
+				break
+			}
+		}
+		if joined == "" {
+			out = append(out, tokens[i])
+			i++
+			continue
+		}
+		out = append(out, joined)
+	}
+	return out
+}
 
 // tryLatLon matches coordinate pairs like "51.28,1.08".
 func (am *ArgMatcher) tryLatLon(tok string, result *ParsedArgs) bool {

--- a/processor/internal/bot/argmatch_test.go
+++ b/processor/internal/bot/argmatch_test.go
@@ -798,3 +798,63 @@ func TestPrefixDoesNotSwallowKnownPokemon(t *testing.T) {
 		}
 	})
 }
+
+// A coordinate pair typed with spaces around the comma is the natural
+// form (and what Google Maps copies). All three spacings must reach
+// tryLatLon as one token.
+func TestArgMatchLatLonWithSpaces(t *testing.T) {
+	am := newTestArgMatcher()
+	params := []ParamDef{{Type: ParamLatLon}}
+
+	cases := []struct {
+		name   string
+		tokens []string
+	}{
+		{"no space", []string{"40.738707,-73.997920"}},
+		{"space after comma", []string{"40.738707,", "-73.997920"}},
+		{"spaces both sides", []string{"40.738707", ",", "-73.997920"}},
+		{"space before comma", []string{"40.738707", ",-73.997920"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := am.Match(tc.tokens, params, "en")
+			if result.Coords == nil {
+				t.Fatalf("Coords not parsed from %q (unrecognized: %v)", tc.tokens, result.Unrecognized)
+			}
+			if result.Coords.Lat != 40.738707 || result.Coords.Lon != -73.997920 {
+				t.Errorf("Coords = %v, want 40.738707,-73.997920", *result.Coords)
+			}
+			if len(result.Unrecognized) != 0 {
+				t.Errorf("unrecognized = %v, want none", result.Unrecognized)
+			}
+		})
+	}
+}
+
+// Only genuine coordinate pairs are joined — adjacent tokens that don't
+// concatenate into a valid lat,lon must be left alone.
+func TestArgMatchLatLonDoesNotMergeUnrelatedTokens(t *testing.T) {
+	am := newTestArgMatcher()
+	params := []ParamDef{{Type: ParamLatLon}}
+
+	result := am.Match([]string{"51.28,1.08", "2.0"}, params, "en")
+	if result.Coords == nil || result.Coords.Lat != 51.28 || result.Coords.Lon != 1.08 {
+		t.Fatalf("Coords = %v, want 51.28,1.08", result.Coords)
+	}
+	if len(result.Unrecognized) != 1 || result.Unrecognized[0] != "2.0" {
+		t.Errorf("unrecognized = %v, want [2.0] left intact", result.Unrecognized)
+	}
+}
+
+// The collapse is scoped to commands declaring ParamLatLon: a command
+// without it (e.g. !track) must see its tokens exactly as before, so
+// "!track 25, 26" is unaffected.
+func TestArgMatchLatLonCollapseScopedToLatLonCommands(t *testing.T) {
+	am := newTestArgMatcher()
+	params := []ParamDef{{Type: ParamKeyword, Key: "arg.clean"}}
+
+	result := am.Match([]string{"25,", "26"}, params, "en")
+	if len(result.Unrecognized) != 2 {
+		t.Fatalf("unrecognized = %v, want both tokens unmerged", result.Unrecognized)
+	}
+}

--- a/processor/internal/bot/commands/location_test.go
+++ b/processor/internal/bot/commands/location_test.go
@@ -4,6 +4,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/pokemon/poracleng/processor/internal/bot"
+	"github.com/pokemon/poracleng/processor/internal/config"
+	"github.com/pokemon/poracleng/processor/internal/gamedata"
 	"github.com/pokemon/poracleng/processor/internal/store"
 )
 
@@ -387,5 +390,61 @@ func TestLocation_ShowDefault_NoneSet(t *testing.T) {
 	}
 	if !strings.Contains(replies[0].Text, "No default") {
 		t.Fatalf("expected no-default error, got %s", replies[0].Text)
+	}
+}
+
+// locationCoordCtx builds a context with an ArgMatcher wired so the bare
+// `!location <coords>` path can be exercised.
+func locationCoordCtx(t *testing.T) (*bot.CommandContext, *store.MockHumanStore) {
+	t.Helper()
+	ctx, humans := testCtx(t)
+	ctx.Config = &config.Config{}
+	gd := &gamedata.GameData{
+		Monsters: map[gamedata.MonsterKey]*gamedata.Monster{},
+		Moves:    map[int]*gamedata.Move{},
+		Types:    map[int]*gamedata.TypeInfo{},
+	}
+	resolver := bot.NewPokemonResolver(gd, ctx.Translations, []string{"en"}, nil)
+	ctx.Resolver = resolver
+	ctx.ArgMatcher = bot.NewArgMatcher(ctx.Translations, gd, resolver, []string{"en"})
+	ctx.GameData = gd
+	return ctx, humans
+}
+
+// A space after the comma is the natural way to type a coordinate pair
+// (and what Google Maps copies to the clipboard). It must set exactly the
+// given coordinates — not fall through to forward geocoding, which
+// silently resolves the coordinate text to an unrelated place.
+func TestLocation_SetCoordsWithSpaceAfterComma(t *testing.T) {
+	ctx, humans := locationCoordCtx(t)
+
+	cmd := &LocationCommand{}
+	replies := cmd.Run(ctx, []string{"40.738707,", "-73.997920"})
+
+	if len(replies) == 0 || replies[0].React != "✅" {
+		t.Fatalf("expected success, got %+v", replies)
+	}
+	h, err := humans.Get("user1")
+	if err != nil || h == nil {
+		t.Fatalf("get human: %v", err)
+	}
+	if h.Latitude != 40.738707 || h.Longitude != -73.997920 {
+		t.Fatalf("location = %v,%v; want 40.738707,-73.997920", h.Latitude, h.Longitude)
+	}
+}
+
+// The no-space form must keep working.
+func TestLocation_SetCoordsWithoutSpace(t *testing.T) {
+	ctx, humans := locationCoordCtx(t)
+
+	cmd := &LocationCommand{}
+	replies := cmd.Run(ctx, []string{"40.738707,-73.997920"})
+
+	if len(replies) == 0 || replies[0].React != "✅" {
+		t.Fatalf("expected success, got %+v", replies)
+	}
+	h, _ := humans.Get("user1")
+	if h.Latitude != 40.738707 || h.Longitude != -73.997920 {
+		t.Fatalf("location = %v,%v; want 40.738707,-73.997920", h.Latitude, h.Longitude)
 	}
 }


### PR DESCRIPTION
## Summary

`!location 40.738707, -73.997920` — a space after the comma, which is exactly how Google Maps copies coordinates — silently set an **unrelated location** and reported success (screenshotted in the wild: NYC coords resolved to somewhere in Montana).

**Root cause.** The parser tokenizes on whitespace, so the pair reaches the matcher as two tokens (`"40.738707,"`, `"-73.997920"`) — or three when spaced both sides (`"40.738707"`, `","`, `"-73.997920"`) — while `tryLatLon`'s regex is anchored to a *single* token. Nothing matched, `parsed.Coords` stayed nil, and both tokens fell into `Unrecognized`, where the location command's fallback forward-geocoded the literal coordinate text **as an address** — returning an unrelated place and reporting it as a success. Where no geocoder is configured the same input is rejected outright with "Please specify coordinates or an address".

Verified against the real tokenizer rather than assumed:

```
"40.738707, -73.997920"   -> ["40.738707," "-73.997920"]
"40.738707 , -73.997920"  -> ["40.738707" "," "-73.997920"]
"40.738707,-73.997920"    -> ["40.738707,-73.997920"]   (the only form that worked)
```

**Fix.** `Match` now collapses split coordinate pairs before per-param matching — the same idea as the existing `collapseMultiWord` step, and consistent with `resolveLatLon`, which already handled spaces for `!location add` (that path was never broken; only the bare form was).

Two deliberate guards keep the blast radius at zero:
- a window is joined **only** when the concatenation is itself a valid `lat,lon`, so unrelated adjacent tokens are never merged;
- the collapse runs **only** for commands declaring `ParamLatLon` (today just `!location`), so `!track 25, 26` and every other command see their tokens exactly as before.

## Test plan

- `TestArgMatchLatLonWithSpaces` — all four spacings (none / after / both / before), each asserting exact coords and no unrecognized leftovers
- `TestArgMatchLatLonDoesNotMergeUnrelatedTokens` — `["51.28,1.08", "2.0"]` keeps `2.0` separate
- `TestArgMatchLatLonCollapseScopedToLatLonCommands` — a non-LatLon command still sees `"25,"` and `"26"` unmerged
- `TestLocation_SetCoordsWithSpaceAfterComma` — end-to-end through the command, red before the fix (it returned the "specify coordinates" rejection); `TestLocation_SetCoordsWithoutSpace` pins the previously-working form
- Full gate green from `processor/`: `go build`, `go vet`, `go test -count=1 ./...`, `golangci-lint run` (0 issues)

## Noted, not fixed here

Input that *looks* like coordinates but is malformed (e.g. a typo'd digit) still falls through to address geocoding and can silently resolve somewhere unrelated. That's the same trap in a narrower form; worth a follow-up decision on whether coordinate-shaped input should ever be geocoded as an address.

🤖 Generated with [Claude Code](https://claude.com/claude-code)