### PR TITLE
fix: expose availableLanguages, correct disabledHooks (#194, #195)

### DIFF
--- a/API.md
+++ b/API.md
@@ -758,6 +758,13 @@ Get weather data for a specific S2 cell.
 
 Server configuration for the web UI (locale, prefix, PVP settings, admin lists, etc.).
 
+Two fields client authors most often need:
+
+| Field | Meaning |
+|-------|---------|
+| `availableLanguages` | The allow-list enforced by the set-language endpoints, sorted. **`null` means unrestricted** — the server accepts any language, so offer your full menu. A non-null array is exhaustive: anything outside it is rejected with 400. |
+| `disabledHooks` | Alert types disabled on this server, named to match the tracking-type names (`pokemon`, `raid`, `fort`, `invasion`, `lure`, `quest`, `weather`, `nest`, `gym`, `maxbattle`). Only flags the processor actually enforces appear; `disable_pokestop` is a deprecated no-op and is never reported. |
+
 ### GET /api/config/templates
 
 Available DTS templates by platform, type, and language (metadata only, no template content).

--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -219,7 +219,7 @@ role_check_mode = "ignore"
 # disable_* - disable individual hook processing for particular webhook types
 disable_pokemon = false
 disable_raid = false
-disable_pokestop = false                 # also disables invasion processing for RDM/Golbat
+disable_pokestop = false                 # DEPRECATED no-op — nothing reads it; use disable_lure / disable_invasion / disable_quest
 disable_invasion = false
 disable_lure = false
 disable_quest = false

--- a/processor/internal/api/config_schema.go
+++ b/processor/internal/api/config_schema.go
@@ -96,7 +96,7 @@ var configSchema = []ConfigSection{
 			{Name: "dts_dictionary", Type: "map", Default: nil, Description: "Custom key-value pairs available in DTS templates via the dtsDict layer", HotReload: true},
 			{Name: "disable_pokemon", Type: "bool", Default: false, Description: "Disable pokemon webhook processing entirely", HotReload: false},
 			{Name: "disable_raid", Type: "bool", Default: false, Description: "Disable raid webhook processing", HotReload: false},
-			{Name: "disable_pokestop", Type: "bool", Default: false, Description: "Disable pokestop/invasion processing from scanner", HotReload: false},
+			{Name: "disable_pokestop", Type: "bool", Default: false, Description: "DEPRECATED — no effect. Use disable_lure, disable_invasion or disable_quest instead", HotReload: false},
 			{Name: "disable_invasion", Type: "bool", Default: false, Description: "Disable invasion webhook processing", HotReload: false},
 			{Name: "disable_lure", Type: "bool", Default: false, Description: "Disable lure webhook processing", HotReload: false},
 			{Name: "disable_quest", Type: "bool", Default: false, Description: "Disable quest webhook processing", HotReload: false},

--- a/processor/internal/api/huma_config.go
+++ b/processor/internal/api/huma_config.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 
 	"github.com/danielgtaylor/huma/v2"
 	log "github.com/sirupsen/logrus"
@@ -26,6 +27,7 @@ type poracleWebAdmins struct {
 type poracleWebResponse struct {
 	AddressFormat                string           `json:"addressFormat" doc:"Geocoding address format string"`
 	Admins                       poracleWebAdmins `json:"admins" doc:"Discord/Telegram admin id lists"`
+	AvailableLanguages           []string         `json:"availableLanguages" doc:"Language codes this server accepts for a user's alert language (sorted). null means unrestricted — every language is allowed — so clients should offer their full menu. A non-null array is the exact allow-list enforced by the set-language endpoints."`
 	ChannelNotesContainsCategory bool             `json:"channelNotesContainsCategory" doc:"Whether channel notes carry the category (check_role + update_channel_notes)"`
 	DefaultDistance              int              `json:"defaultDistance" doc:"Default tracking distance (m)"`
 	DefaultPvpCap                int              `json:"defaultPvpCap" doc:"Default user PVP level cap"`
@@ -279,10 +281,16 @@ func buildPoracleWebResponse(cfg *config.Config) poracleWebResponse {
 		Name    string
 		Disable bool
 	}
+	// One entry per flag the processor actually enforces, named after the
+	// tracking type. disable_pokestop is deliberately absent: nothing reads
+	// it (its last real use — the !tracked fort sections — moved to
+	// disable_fort_update in fa9b4912), so reporting it as a disabled hook
+	// told clients a lie about lures/invasions/quests, which have their own
+	// flags. See #195.
 	hookTypes := []hookFlag{
 		{"pokemon", cfg.General.DisablePokemon},
 		{"raid", cfg.General.DisableRaid},
-		{"pokestop", cfg.General.DisablePokestop},
+		{"fort", cfg.General.DisableFortUpdate},
 		{"invasion", cfg.General.DisableInvasion},
 		{"lure", cfg.General.DisableLure},
 		{"quest", cfg.General.DisableQuest},
@@ -296,6 +304,20 @@ func buildPoracleWebResponse(cfg *config.Config) poracleWebResponse {
 		if h.Disable {
 			disabledHooks = append(disabledHooks, h.Name)
 		}
+	}
+
+	// Sorted allow-list of language codes, or nil when the server imposes no
+	// restriction. The set-language endpoints only validate when the map is
+	// non-empty, so unset and empty are the same thing to the server — both
+	// report null rather than [], which a client would read as "offer
+	// nothing" on the most common (unconfigured) setup. See #194.
+	var availableLanguages []string
+	if len(cfg.General.AvailableLanguages) > 0 {
+		availableLanguages = make([]string, 0, len(cfg.General.AvailableLanguages))
+		for code := range cfg.General.AvailableLanguages {
+			availableLanguages = append(availableLanguages, code)
+		}
+		sort.Strings(availableLanguages)
 	}
 
 	defaultTemplateName := "1"
@@ -343,6 +365,7 @@ func buildPoracleWebResponse(cfg *config.Config) poracleWebResponse {
 		DefaultPvpCap:                cfg.Tracking.DefaultUserTrackingLevelCap,
 		DefaultTemplateName:          defaultTemplateName,
 		ChannelNotesContainsCategory: channelNotesContainsCategory,
+		AvailableLanguages:           availableLanguages,
 		Admins: poracleWebAdmins{
 			Discord:  discordAdmins,
 			Telegram: telegramAdmins,

--- a/processor/internal/api/huma_config_test.go
+++ b/processor/internal/api/huma_config_test.go
@@ -368,3 +368,126 @@ func assertProblemJSON(t *testing.T, w *httptest.ResponseRecorder) {
 		t.Errorf("problem+json body must contain title: %v", got)
 	}
 }
+
+// --- #194: available_languages must be readable ----------------------------
+
+// available_languages gates POST /humans/{id}/setLanguage but was exposed
+// nowhere, so a client had no way to build an accurate language menu.
+func TestHumaConfigPoracleWeb_AvailableLanguages(t *testing.T) {
+	r, api := newConfigTestAPI(t)
+	cfg := &config.Config{}
+	cfg.General.AvailableLanguages = map[string]config.LanguageEntry{
+		"fr": {}, "de": {Poracle: "dasporacle"}, "en": {},
+	}
+	RegisterConfigPoracleWeb(api, cfg)
+
+	w := getJSON(t, r, "/api/config/poracleWeb")
+	var got map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	raw, present := got["availableLanguages"]
+	if !present {
+		t.Fatalf("availableLanguages missing from response: %v", got)
+	}
+	list, ok := raw.([]any)
+	if !ok {
+		t.Fatalf("availableLanguages = %v, want an array", raw)
+	}
+	want := []string{"de", "en", "fr"} // sorted for a stable menu
+	if len(list) != len(want) {
+		t.Fatalf("availableLanguages = %v, want %v", list, want)
+	}
+	for i, code := range want {
+		if list[i] != code {
+			t.Errorf("availableLanguages[%d] = %v, want %s (sorted)", i, list[i], code)
+		}
+	}
+}
+
+// Unset means "every language allowed" (the write path only validates when
+// the map is non-empty). The key must be present but null so a client can
+// tell "no restriction" from "an empty allow-list" and still offer its full
+// menu — returning [] here would make clients offer nothing.
+func TestHumaConfigPoracleWeb_AvailableLanguagesUnsetIsNull(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		cfg  map[string]config.LanguageEntry
+	}{
+		{"unset", nil},
+		{"empty", map[string]config.LanguageEntry{}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r, api := newConfigTestAPI(t)
+			cfg := &config.Config{}
+			cfg.General.AvailableLanguages = tc.cfg
+			RegisterConfigPoracleWeb(api, cfg)
+
+			w := getJSON(t, r, "/api/config/poracleWeb")
+			var got map[string]any
+			if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			raw, present := got["availableLanguages"]
+			if !present {
+				t.Fatalf("availableLanguages key must always be present: %v", got)
+			}
+			if raw != nil {
+				t.Errorf("availableLanguages = %v, want null when unrestricted", raw)
+			}
+		})
+	}
+}
+
+// --- #195: disabledHooks accuracy ------------------------------------------
+
+// disable_fort_update gates the webhook handler, the !fort command and the
+// !tracked section, but was missing from disabledHooks — clients concluded
+// fort changes were enabled when they weren't.
+func TestHumaConfigPoracleWeb_DisabledHooksIncludesFort(t *testing.T) {
+	r, api := newConfigTestAPI(t)
+	cfg := &config.Config{}
+	cfg.General.DisableFortUpdate = true
+	RegisterConfigPoracleWeb(api, cfg)
+
+	w := getJSON(t, r, "/api/config/poracleWeb")
+	var got map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	hooks, _ := got["disabledHooks"].([]any)
+	found := false
+	for _, h := range hooks {
+		if h == "fort" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("disabledHooks = %v, want to contain \"fort\"", hooks)
+	}
+}
+
+// disable_pokestop enforces nothing anywhere in the processor (its last real
+// use — the !tracked fort sections — moved to disable_fort_update in
+// fa9b4912). Reporting it as a disabled hook tells clients a lie, so it must
+// not appear even when set.
+func TestHumaConfigPoracleWeb_DisabledHooksOmitsVestigialPokestop(t *testing.T) {
+	r, api := newConfigTestAPI(t)
+	cfg := &config.Config{}
+	// Deliberately setting the deprecated flag: the whole point of this test
+	// is that setting it changes nothing in the response.
+	cfg.General.DisablePokestop = true //nolint:staticcheck // SA1019: asserting the deprecated flag is ignored
+	RegisterConfigPoracleWeb(api, cfg)
+
+	w := getJSON(t, r, "/api/config/poracleWeb")
+	var got map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	hooks, _ := got["disabledHooks"].([]any)
+	for _, h := range hooks {
+		if h == "pokestop" {
+			t.Errorf("disabledHooks = %v, must not contain vestigial \"pokestop\"", hooks)
+		}
+	}
+}

--- a/processor/internal/api/testdata/openapi.golden.json
+++ b/processor/internal/api/testdata/openapi.golden.json
@@ -1734,6 +1734,16 @@
             "$ref": "#/components/schemas/PoracleWebAdmins",
             "description": "Discord/Telegram admin id lists"
           },
+          "availableLanguages": {
+            "description": "Language codes this server accepts for a user's alert language (sorted). null means unrestricted — every language is allowed — so clients should offer their full menu. A non-null array is the exact allow-list enforced by the set-language endpoints.",
+            "items": {
+              "type": "string"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
           "channelNotesContainsCategory": {
             "description": "Whether channel notes carry the category (check_role + update_channel_notes)",
             "type": "boolean"
@@ -1848,6 +1858,7 @@
         "required": [
           "addressFormat",
           "admins",
+          "availableLanguages",
           "channelNotesContainsCategory",
           "defaultDistance",
           "defaultPvpCap",

--- a/processor/internal/config/config.go
+++ b/processor/internal/config/config.go
@@ -159,8 +159,12 @@ type GeneralConfig struct {
 	AvailableLanguages   map[string]LanguageEntry `toml:"available_languages"`       // lang code → {poracle, help}
 
 	// Webhook type disable flags — used by /api/config/poracleWeb to report disabledHooks.
-	DisablePokemon    bool `toml:"disable_pokemon"`
-	DisableRaid       bool `toml:"disable_raid"`
+	DisablePokemon bool `toml:"disable_pokemon"`
+	DisableRaid    bool `toml:"disable_raid"`
+	// Deprecated: no-op. Nothing reads this — its last use (the !tracked fort
+	// sections) moved to DisableFortUpdate in fa9b4912, and lures/invasions/
+	// quests each have their own flag. Kept so existing configs still parse;
+	// excluded from the poracleWeb disabledHooks array (#195).
 	DisablePokestop   bool `toml:"disable_pokestop"`
 	DisableInvasion   bool `toml:"disable_invasion"`
 	DisableLure       bool `toml:"disable_lure"`

--- a/processor/version.go
+++ b/processor/version.go
@@ -4,7 +4,7 @@ package processor
 import "runtime/debug"
 
 // Version is the PoracleNG processor version. Bump on each release.
-const Version = "5.2.0"
+const Version = "5.2.1"
 
 // Commit, Branch, and Date are overridden at build time via
 // -ldflags "-X github.com/pokemon/poracleng/processor.Commit=... -X ...Branch=... -X ...Date=...".
@@ -68,7 +68,7 @@ func BuildInfo() (version, commit, branch, date string) {
 }
 
 // DisplayVersion returns the version with the branch suffix appended when a
-// branch is known, e.g. "5.2.0-develop" (or just "5.2.0" on a tag/release
+// branch is known, e.g. "5.2.1-develop" (or just "5.2.1" on a tag/release
 // build where no branch is injected).
 func DisplayVersion() string {
 	version, _, branch, _ := BuildInfo()


### PR DESCRIPTION
Fixes #194 and #195 — both reported by the PoracleWeb.NET author, both verified against the code before fixing.

## #194 — `availableLanguages` is now readable

`available_languages` gates `POST /api/humans/{id}/setLanguage` (400 `"language is not available"`) but appeared on no read path, so a client could only discover the allow-list by probing every language and reading the 400s. `/api/config/poracleWeb` now returns `availableLanguages`.

**`null` when unrestricted, sorted codes when restricted.** The issue asked to keep "unset" distinguishable from "empty list"; the underlying need is better served by encoding what the server *enforces*, because the write path only validates when the map is non-empty — so unset and empty are the same thing to the server, and both report `null`. Returning `[]` for the common unconfigured case would tell a client to offer nothing. The key is always present, so its absence still identifies an older server.

Only the map keys gate the write (`LanguageEntry`'s `poracle`/`help` values are command aliases), so the codes are the whole contract.

## #195 — `disabledHooks` told two lies

Both claims confirmed:

- **`disable_fort_update` was missing**, though it gates the webhook handler (`cmd/processor/fort.go:16`), the `!fort` command, and two `!tracked` sections. Now reported as `fort`, matching the tracking-type name. This removes the reason PoracleWeb.NET calls `/api/config/values` at all.
- **`disable_pokestop` enforces nothing** and has been dropped from the array. Root cause, for the record: `fa9b4912` (which added `disable_fort_update`) reassigned this flag's last real use — the `!tracked` fort sections — to the new flag and never updated `hookTypes`. So the same commit that created the omission also orphaned the flag.

The config field is marked `Deprecated:` rather than removed so existing configs keep parsing. `config/config.example.toml` claimed it "also disables invasion processing for RDM/Golbat" — untrue, a JS-Poracle behaviour never ported — and the config-editor schema said "Disable pokestop/invasion processing from scanner"; both now say deprecated no-op and point at `disable_lure` / `disable_invasion` / `disable_quest`.

If you'd rather `disable_pokestop` *gained* meaning instead of losing it, that's a behaviour change and a separate call — say so and I'll swap the approach. Dropping it seemed right given those three types each already have a working flag.

## Test plan

Four new tests, each red before the fix:
- `..._AvailableLanguages` — sorted codes present
- `..._AvailableLanguagesUnsetIsNull` — subtests for unset **and** empty, both asserting the key is present and `null`
- `..._DisabledHooksIncludesFort`
- `..._DisabledHooksOmitsVestigialPokestop` — set the flag, assert it still doesn't appear (this one printed `disabledHooks: [pokestop]` before the fix, which is the lie in one line)

Full gate green from `processor/`: `go build`, `go vet`, `go test -count=1 ./...`, `golangci-lint run` (0 issues). OpenAPI golden regenerated — huma emits `"type": ["array", "null"]` for the new field. `API.md` documents both fields' semantics, since having to read source to learn them is what produced these two issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)