### PR TITLE
feat: add geocoding provider alongside the geocoding url to the `conf…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build clean start test
+.PHONY: all build clean start test openapi
 
 # Default: build
 all: build
@@ -19,3 +19,10 @@ start: build
 # Run all tests
 test:
 	cd processor && go test ./...
+
+# Regenerate the committed OpenAPI goldens after an intentional spec change.
+# Two separate goldens: the package-api ops, and the six autocreate ops
+# registered in cmd/processor.
+openapi:
+	cd processor && UPDATE_GOLDEN=1 go test ./internal/api/ -run TestOpenAPIGolden
+	cd processor && UPDATE_GOLDEN=1 go test ./cmd/processor/ -run TestAutocreateOpenAPIGolden

--- a/processor/internal/api/huma_config.go
+++ b/processor/internal/api/huma_config.go
@@ -36,6 +36,7 @@ type poracleWebResponse struct {
 	Locale                       string           `json:"locale" doc:"Default server locale"`
 	MaxDistance                  int              `json:"maxDistance" doc:"Maximum allowed tracking distance (m)"`
 	Prefix                       string           `json:"prefix" doc:"Discord command prefix"`
+	Provider                     string           `json:"provider" doc:"Geocoding provider type (nominatim || photon)"`
 	ProviderURL                  string           `json:"providerURL" doc:"Geocoding provider URL"`
 	PvpCaps                      []int            `json:"pvpCaps" doc:"Configured PVP level caps"`
 	PvpFilterGreatMinCP          int              `json:"pvpFilterGreatMinCP" doc:"Minimum CP floor for great-league PVP filters"`
@@ -330,6 +331,7 @@ func buildPoracleWebResponse(cfg *config.Config) poracleWebResponse {
 		Version:                      Version,
 		Locale:                       cfg.General.Locale,
 		Prefix:                       cfg.Discord.Prefix,
+		Provider:                     cfg.Geocoding.Provider,
 		ProviderURL:                  cfg.Geocoding.ProviderURL,
 		AddressFormat:                cfg.Locale.AddressFormat,
 		StaticKey:                    staticKeys,

--- a/processor/internal/api/testdata/openapi.golden.json
+++ b/processor/internal/api/testdata/openapi.golden.json
@@ -1783,6 +1783,10 @@
             "description": "Discord command prefix",
             "type": "string"
           },
+          "provider": {
+            "description": "Geocoding provider type (nominatim || photon)",
+            "type": "string"
+          },
           "providerURL": {
             "description": "Geocoding provider URL",
             "type": "string"
@@ -1858,6 +1862,7 @@
           "locale",
           "maxDistance",
           "prefix",
+          "provider",
           "providerURL",
           "pvpCaps",
           "pvpFilterGreatMinCP",


### PR DESCRIPTION
Adds `provider` to the `config` API endpoint. This enables consumers to properly determine how to ingest the contents from the `providerUrl`