### PR TITLE
fix(slash): autocomplete /help topic — declared but never answered

### DIFF
--- a/processor/internal/bot/commands/help.go
+++ b/processor/internal/bot/commands/help.go
@@ -16,20 +16,9 @@ import (
 // !help <command> renders the "help" DTS template with id=<command>.
 type HelpCommand struct{}
 
-// adminOnlyHelpTopics — non-admins asking "!help enable" get the 🙅
-// unknown-topic reply rather than the admin command surface.
-var adminOnlyHelpTopics = map[string]bool{
-	"enable":        true,
-	"disable":       true,
-	"broadcast":     true,
-	"userlist":      true,
-	"community":     true,
-	"apply":         true,
-	"backup":        true,
-	"restore":       true,
-	"poracle-admin": true,
-	"pa":            true,
-}
+// The canonical admin-only topic set lives in the bot package so the slash
+// autocomplete can honour it too — it cannot import this package (commands
+// already imports discordbot/slash, so the reverse edge would be a cycle).
 
 func (c *HelpCommand) Name() string      { return "cmd.help" }
 func (c *HelpCommand) Aliases() []string { return nil }
@@ -48,7 +37,7 @@ func (c *HelpCommand) Run(ctx *bot.CommandContext, args []string) []bot.Reply {
 
 	if len(args) > 0 {
 		topic := strings.ToLower(args[0])
-		if adminOnlyHelpTopics[topic] && !ctx.IsAdmin {
+		if bot.IsAdminOnlyHelpTopic(topic) && !ctx.IsAdmin {
 			tr := ctx.Tr()
 			return []bot.Reply{{React: "🙅", Text: tr.Tf("msg.help.unknown_topic", topic, prefix)}}
 		}

--- a/processor/internal/bot/help_topics.go
+++ b/processor/internal/bot/help_topics.go
@@ -1,0 +1,30 @@
+package bot
+
+import "strings"
+
+// adminOnlyHelpTopics — non-admins asking "!help enable" get the 🙅
+// unknown-topic reply rather than the admin command surface.
+//
+// Lives in this package rather than next to HelpCommand because the slash
+// autocomplete needs the same set to avoid suggesting topics it would then
+// refuse, and internal/bot/commands already imports internal/discordbot/slash
+// — so the autocomplete package cannot import commands without a cycle.
+var adminOnlyHelpTopics = map[string]bool{
+	"enable":        true,
+	"disable":       true,
+	"broadcast":     true,
+	"userlist":      true,
+	"community":     true,
+	"apply":         true,
+	"backup":        true,
+	"restore":       true,
+	"poracle-admin": true,
+	"pa":            true,
+}
+
+// IsAdminOnlyHelpTopic reports whether a help topic is restricted to admins.
+// Matching is case-insensitive, mirroring the command path, which lowercases
+// the topic before looking it up.
+func IsAdminOnlyHelpTopic(topic string) bool {
+	return adminOnlyHelpTopics[strings.ToLower(strings.TrimSpace(topic))]
+}

--- a/processor/internal/discordbot/slash/autocomplete/help_topic.go
+++ b/processor/internal/discordbot/slash/autocomplete/help_topic.go
@@ -1,0 +1,51 @@
+package autocomplete
+
+import (
+	"sort"
+
+	"github.com/bwmarrin/discordgo"
+
+	"github.com/pokemon/poracleng/processor/internal/bot"
+)
+
+// HelpTopic returns autocomplete choices for /help's topic option: the ids of
+// the installed "help" DTS entries.
+//
+// Both the requested platform AND the platform-agnostic ("") bucket are read.
+// That is not defensive tidiness — every shipped help entry in fallbacks/dts/
+// help/ carries `"platform": ""`, so a platform-only lookup returns an empty
+// list on a stock install, which is precisely the symptom this fixes.
+//
+// Admin-only topics are withheld from non-admins: the command answers those
+// with the 🙅 unknown-topic reply, and offering a suggestion that is then
+// refused is worse than offering nothing.
+func HelpTopic(deps *bot.BotDeps, focused, platform string, isAdmin bool) []*discordgo.ApplicationCommandOptionChoice {
+	if deps == nil || deps.DTS == nil {
+		return nil
+	}
+
+	seen := make(map[string]bool)
+	var ids []string
+	collect := func(p string) {
+		for _, info := range deps.DTS.ListForPlatform(p)["help"] {
+			if info.ID == "" || seen[info.ID] {
+				continue
+			}
+			if !isAdmin && bot.IsAdminOnlyHelpTopic(info.ID) {
+				continue
+			}
+			seen[info.ID] = true
+			ids = append(ids, info.ID)
+		}
+	}
+	collect(platform)
+	if platform != "" {
+		collect("")
+	}
+	if len(ids) == 0 {
+		return nil
+	}
+
+	sort.Strings(ids)
+	return filterStringChoices(ids, focused)
+}

--- a/processor/internal/discordbot/slash/autocomplete/help_topic_test.go
+++ b/processor/internal/discordbot/slash/autocomplete/help_topic_test.go
@@ -1,0 +1,117 @@
+package autocomplete
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/bwmarrin/discordgo"
+
+	"github.com/pokemon/poracleng/processor/internal/bot"
+	"github.com/pokemon/poracleng/processor/internal/dts"
+)
+
+// helpTopicDeps builds BotDeps over a DTS store holding help entries with the
+// platform-agnostic ("") platform the shipped fallbacks actually use, plus one
+// discord-specific entry to prove both are picked up.
+func helpTopicDeps(t *testing.T) *bot.BotDeps {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "dts.json"), []byte(`[
+		{"type":"help","id":"track","platform":"","language":"","template":{"x":1}},
+		{"type":"help","id":"index","platform":"","language":"","template":{"x":1}},
+		{"type":"help","id":"enable","platform":"","language":"","template":{"x":1}},
+		{"type":"help","id":"raid","platform":"discord","language":"","template":{"x":1}},
+		{"type":"monster","id":"1","platform":"discord","language":"","template":{"x":1}}
+	]`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	fb := filepath.Join(dir, "fb")
+	if err := os.MkdirAll(fb, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(fb, "dts.json"), []byte(`[]`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	ts, err := dts.LoadTemplates(dir, fb)
+	if err != nil {
+		t.Fatalf("LoadTemplates: %v", err)
+	}
+	return &bot.BotDeps{DTS: ts}
+}
+
+func values(choices []*discordgo.ApplicationCommandOptionChoice) []string {
+	out := make([]string, 0, len(choices))
+	for _, c := range choices {
+		out = append(out, c.Value.(string))
+	}
+	return out
+}
+
+func contains(vals []string, want string) bool {
+	for _, v := range vals {
+		if v == want {
+			return true
+		}
+	}
+	return false
+}
+
+// The shipped help entries carry platform "" — a platform-scoped lookup alone
+// returns nothing, which is exactly why /help's topic autocomplete was empty.
+func TestHelpTopicIncludesPlatformAgnosticEntries(t *testing.T) {
+	got := values(HelpTopic(helpTopicDeps(t), "", "discord", true))
+	for _, want := range []string{"track", "index"} {
+		if !contains(got, want) {
+			t.Errorf("expected platform-agnostic topic %q in %v", want, got)
+		}
+	}
+	if !contains(got, "raid") {
+		t.Errorf("expected platform-specific topic %q in %v", "raid", got)
+	}
+}
+
+// Only help entries — a monster template is not a help topic.
+func TestHelpTopicExcludesOtherTypes(t *testing.T) {
+	if got := values(HelpTopic(helpTopicDeps(t), "", "discord", true)); contains(got, "1") {
+		t.Errorf("non-help entry leaked into topics: %v", got)
+	}
+}
+
+// Suggesting a topic the command would then refuse with 🙅 is worse than
+// suggesting nothing, so admin-only topics are hidden from non-admins.
+func TestHelpTopicHidesAdminOnlyFromNonAdmins(t *testing.T) {
+	deps := helpTopicDeps(t)
+
+	asAdmin := values(HelpTopic(deps, "", "discord", true))
+	if !contains(asAdmin, "enable") {
+		t.Errorf("admin should see admin-only topic: %v", asAdmin)
+	}
+
+	asUser := values(HelpTopic(deps, "", "discord", false))
+	if contains(asUser, "enable") {
+		t.Errorf("non-admin must not be offered %q: %v", "enable", asUser)
+	}
+	if !contains(asUser, "track") {
+		t.Errorf("non-admin should still see ordinary topics: %v", asUser)
+	}
+}
+
+func TestHelpTopicFiltersByFocused(t *testing.T) {
+	got := values(HelpTopic(helpTopicDeps(t), "tra", "discord", true))
+	if !contains(got, "track") {
+		t.Errorf("expected track for focused %q: %v", "tra", got)
+	}
+	if contains(got, "index") {
+		t.Errorf("index should be filtered out by focused %q: %v", "tra", got)
+	}
+}
+
+func TestHelpTopicNilDeps(t *testing.T) {
+	if got := HelpTopic(nil, "", "discord", true); got != nil {
+		t.Errorf("expected nil for nil deps, got %v", got)
+	}
+	if got := HelpTopic(&bot.BotDeps{}, "", "discord", true); got != nil {
+		t.Errorf("expected nil when DTS is unset, got %v", got)
+	}
+}

--- a/processor/internal/discordbot/slash/dispatcher.go
+++ b/processor/internal/discordbot/slash/dispatcher.go
@@ -367,6 +367,11 @@ func (d *Dispatcher) routeAutocomplete(cmd, opt, focused, userLang string, ic *d
 		return base
 	case opt == "template":
 		return autocomplete.Template(context.Background(), d.deps, focused, dtsTypeFor(cmd), "discord", userLang)
+	// /help topic — the installed "help" DTS entry ids. The option has
+	// always declared Autocomplete:true, but without a route here Discord
+	// got an empty response and showed "no options" forever.
+	case opt == "topic" && cmd == "help":
+		return autocomplete.HelpTopic(d.deps, focused, "discord", d.isAdmin(interactionUserID(ic)))
 	case opt == "tracking" && cmd == "untrack":
 		subtype := findUntrackSubtype(ic)
 		return d.userstateAutocomplete(ic, "tracking", subtype, focused)

--- a/processor/internal/discordbot/slash/dispatcher_test.go
+++ b/processor/internal/discordbot/slash/dispatcher_test.go
@@ -2,6 +2,8 @@ package slash
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -10,6 +12,7 @@ import (
 	"github.com/pokemon/poracleng/processor/internal/bot"
 	"github.com/pokemon/poracleng/processor/internal/config"
 	"github.com/pokemon/poracleng/processor/internal/discordbot/slash/mappers"
+	"github.com/pokemon/poracleng/processor/internal/dts"
 	"github.com/pokemon/poracleng/processor/internal/gamedata"
 	"github.com/pokemon/poracleng/processor/internal/i18n"
 	"github.com/pokemon/poracleng/processor/internal/tracker"
@@ -888,5 +891,48 @@ func TestRouteAutocomplete_RaidForm_BoostsRecentForBoss(t *testing.T) {
 	out := d.routeAutocomplete("raid", "form", "", "en", ic)
 	if len(out) == 0 || out[0].Name != "Winter 2023" {
 		t.Errorf("/raid form empty focused: first=%+v, want Winter 2023 (recent raid form)", firstName(out))
+	}
+}
+
+// The (help, topic) tuple must be routed. Before this, the option declared
+// Autocomplete:true but no case matched, so Discord received an empty
+// response and showed "no options" no matter what the user typed.
+func TestRouteAutocompleteHelpTopicIsRouted(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "dts.json"), []byte(`[
+		{"type":"help","id":"track","platform":"","language":"","template":{"x":1}},
+		{"type":"help","id":"area","platform":"","language":"","template":{"x":1}}
+	]`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	fb := filepath.Join(dir, "fb")
+	if err := os.MkdirAll(fb, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(fb, "dts.json"), []byte(`[]`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	ts, err := dts.LoadTemplates(dir, fb)
+	if err != nil {
+		t.Fatalf("LoadTemplates: %v", err)
+	}
+
+	d := NewDispatcher(Config{})
+	d.bundle = testBundle(t)
+	d.cfgRoot = &config.Config{}
+	d.deps = &bot.BotDeps{DTS: ts}
+
+	got := d.routeAutocomplete("help", "topic", "", "en", nil)
+	if len(got) == 0 {
+		t.Fatal("help/topic returned no choices — the route is not wired")
+	}
+	var found bool
+	for _, c := range got {
+		if c.Value == "track" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected the 'track' help topic, got %v", got)
 	}
 }


### PR DESCRIPTION
## The bug

`/help`'s `topic` option shows "no options" no matter what you type. Free text still submits and works (`/help track` renders fine), which is why it reads as *"there's no such option until you actually use it"*.

**Root cause.** The option has always declared `Autocomplete: true` (`definitions.go:161`), but `routeAutocomplete` has **no case for `topic`** — it falls through and returns nil, so Discord gets an empty choice list forever.

## The part that would have been missed

Adding the route alone still yields an empty list. `ListForPlatform` filters on an exact platform match:

```go
if e.Hidden || e.Platform != platform { continue }
```

…and **every shipped help entry carries `"platform": ""`** (`fallbacks/dts/help/*.json` — they're platform-agnostic, which is also why #197 had to fix deleting them). So `ListForPlatform("discord")["help"]` returns nothing on a stock install.

`HelpTopic` therefore reads the requested platform **and** the agnostic bucket, deduped, so an operator's platform-specific override and the ~31 shipped topics both appear. `TestHelpTopicIncludesPlatformAgnosticEntries` pins it — reverting to a platform-only lookup drops every shipped topic and leaves just the one discord-specific fixture.

## Admin-only topics

`!help enable` and friends answer non-admins with the 🙅 unknown-topic reply, so offering those as suggestions would be actively misleading. They're filtered for non-admins.

That required moving the canonical set out of `commands`: it already imports `discordbot/slash`, so `slash/autocomplete` → `commands` would be an import cycle. It now lives in `bot` (which both import) as `bot.IsAdminOnlyHelpTopic`, with the case-insensitive matching the command path already relied on.

## Test plan

- `HelpTopic`: platform-agnostic + platform-specific entries both listed; non-help types excluded; admin-only hidden from non-admins but shown to admins; focused-prefix filtering; nil-deps and nil-DTS safety
- `TestRouteAutocompleteHelpTopicIsRouted` — proves the `(help, topic)` tuple actually reaches the handler, which is the thing that was missing
- Verified red-first: with the platform-agnostic lookup removed, the suite fails with `expected platform-agnostic topic "track" in [raid]`
- Full gate green from `processor/`: `go build`, `go vet`, `go test -count=1 ./...`, `golangci-lint run` (0 issues)

## Note

Discord caps autocomplete at 25 choices, and there are ~31 shipped topics, so an empty query shows the first 25 alphabetically; typing narrows immediately. Happy to sort `index` first if you'd prefer the overview always visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)