### PR TITLE
chore: apply go fix modernizers for Go 1.27

### DIFF
--- a/processor/internal/api/v2_invasion.go
+++ b/processor/internal/api/v2_invasion.go
@@ -245,12 +245,12 @@ func v2InvasionToRule(gd *gamedata.GameData, row *db.InvasionTrackingAPI) v2Inva
 	// mode and is nulled at its 'any' wildcard there.
 	switch strings.ToLower(row.GruntType) {
 	case "everything":
-		rule.Everything = ptr(true)
+		rule.Everything = new(true)
 	case "boss":
-		rule.Boss = ptr(true)
+		rule.Boss = new(true)
 	default:
 		if id, ok := typeNameToID(gd)[strings.ToLower(row.GruntType)]; ok {
-			rule.TypeID = ptr(id)
+			rule.TypeID = new(id)
 		}
 		rule.Gender = ptrUnless(invasionGenderEnum.fromStored(row.Gender), "any")
 	}

--- a/processor/internal/api/v2_locations.go
+++ b/processor/internal/api/v2_locations.go
@@ -238,11 +238,9 @@ func newLocationRefsConflict(refs []store.ReferencingRule) *v2LocationReferenced
 		mapped = append(mapped, v2RefRule{Type: r.Type, UID: r.UID})
 	}
 	return &v2LocationReferencedError{
-		ErrorModel: huma.ErrorModel{
-			Status: 409,
-			Title:  "Conflict",
-			Detail: "location is referenced by one or more tracking rules",
-		},
+		Status:           409,
+		Title:            "Conflict",
+		Detail:           "location is referenced by one or more tracking rules",
 		ReferencingRules: mapped,
 	}
 }

--- a/processor/internal/api/v2_pokemon.go
+++ b/processor/internal/api/v2_pokemon.go
@@ -205,9 +205,6 @@ func pokemonRowToRule(row *db.MonsterTrackingAPI) v2PokemonRule {
 	}
 }
 
-// ptr returns a pointer to v (response builder helper).
-func ptr[T any](v T) *T { return &v }
-
 // ptrUnless is the response-projection helper that hides a wildcard/default value
 // as JSON null (Part B of #138). It returns nil when v equals wildcard (the
 // documented "match-any"/default sentinel for that field) so the envelope emits

--- a/processor/internal/api/v2_pokemon_costume_test.go
+++ b/processor/internal/api/v2_pokemon_costume_test.go
@@ -18,8 +18,8 @@ func TestV2Pokemon_CostumeWriteMapper(t *testing.T) {
 		want    int
 	}{
 		{"omitted -> any (9000)", nil, 9000},
-		{"zero -> no costume (0)", ptr(0), 0},
-		{"specific costume", ptr(5), 5},
+		{"zero -> no costume (0)", new(0), 0},
+		{"specific costume", new(5), 5},
 	}
 
 	for _, c := range cases {

--- a/processor/internal/api/v2_response.go
+++ b/processor/internal/api/v2_response.go
@@ -72,13 +72,13 @@ func addNullForDroppedFields(t reflect.Type, merged map[string]json.RawMessage) 
 	if t == nil || t.Kind() != reflect.Struct {
 		return
 	}
-	for i := 0; i < t.NumField(); i++ {
-		f := t.Field(i)
+	for f := range t.Fields() {
+		f := f
 		tag := f.Tag.Get("json")
 		if tag == "" || tag == "-" {
 			continue
 		}
-		name := strings.Split(tag, ",")[0]
+		name, _, _ := strings.Cut(tag, ",")
 		if name == "" || name == "-" {
 			continue
 		}

--- a/processor/internal/bot/commands/broadcast.go
+++ b/processor/internal/bot/commands/broadcast.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 
 	log "github.com/sirupsen/logrus"
@@ -46,8 +47,8 @@ func (c *BroadcastCommand) Run(ctx *bot.CommandContext, args []string) []bot.Rep
 	test := false
 	var remaining []string
 
-	for i := len(args) - 1; i >= 0; i-- {
-		arg := args[i]
+	for _, arg := range slices.Backward(args) {
+
 		if m := broadcastAreaRe.FindStringSubmatch(arg); m != nil {
 			areas = append(areas, m[1])
 		} else if m := broadcastDRe.FindStringSubmatch(arg); m != nil {

--- a/processor/internal/bot/commands/help.go
+++ b/processor/internal/bot/commands/help.go
@@ -25,7 +25,7 @@ func (c *HelpCommand) Aliases() []string { return nil }
 
 func (c *HelpCommand) Run(ctx *bot.CommandContext, args []string) []bot.Reply {
 	prefix := bot.CommandPrefix(ctx)
-	platform := strings.SplitN(ctx.TargetType, ":", 2)[0]
+	platform, _, _ := strings.Cut(ctx.TargetType, ":")
 	if platform == bot.TypeWebhook {
 		platform = "discord"
 	}

--- a/processor/internal/bot/commands/info.go
+++ b/processor/internal/bot/commands/info.go
@@ -172,7 +172,7 @@ func (c *InfoCommand) pokemonInfo(ctx *bot.CommandContext, args []string) []bot.
 	}
 
 	// Determine platform for emoji resolution
-	platform := strings.SplitN(ctx.TargetType, ":", 2)[0]
+	platform, _, _ := strings.Cut(ctx.TargetType, ":")
 	if platform == bot.TypeWebhook {
 		platform = "discord"
 	}

--- a/processor/internal/bot/commands/poracle_admin_config.go
+++ b/processor/internal/bot/commands/poracle_admin_config.go
@@ -450,8 +450,8 @@ func isNestedStruct(v reflect.Value) bool {
 		return false
 	}
 	t := v.Type()
-	for i := 0; i < t.NumField(); i++ {
-		ft := t.Field(i)
+	for ft := range t.Fields() {
+		ft := ft
 		if !ft.IsExported() {
 			continue
 		}

--- a/processor/internal/bot/target.go
+++ b/processor/internal/bot/target.go
@@ -37,8 +37,7 @@ func (e *TargetError) Localize(tr *i18n.Translator) string {
 // otherwise it returns err.Error(). Call sites that already have a translator
 // should prefer this over err.Error() so translatable errors are honoured.
 func LocalizeTargetError(tr *i18n.Translator, err error) string {
-	var te *TargetError
-	if errors.As(err, &te) {
+	if te, ok := errors.AsType[*TargetError](err); ok {
 		return te.Localize(tr)
 	}
 	return err.Error()

--- a/processor/internal/delivery/discord_test.go
+++ b/processor/internal/delivery/discord_test.go
@@ -100,10 +100,10 @@ func TestDiscordSendChannel(t *testing.T) {
 }
 
 func TestDiscordSendDM(t *testing.T) {
-	var requestCount int32
+	var requestCount atomic.Int32
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		atomic.AddInt32(&requestCount, 1)
+		requestCount.Add(1)
 		w.Header().Set("Content-Type", "application/json")
 
 		if r.URL.Path == "/users/@me/channels" {
@@ -138,7 +138,7 @@ func TestDiscordSendDM(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	count := atomic.LoadInt32(&requestCount)
+	count := requestCount.Load()
 	if count != 2 {
 		t.Errorf("expected 2 requests (DM create + send), got %d", count)
 	}
@@ -150,10 +150,10 @@ func TestDiscordSendDM(t *testing.T) {
 }
 
 func TestDiscordSendDMCached(t *testing.T) {
-	var requestCount int32
+	var requestCount atomic.Int32
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		atomic.AddInt32(&requestCount, 1)
+		requestCount.Add(1)
 		w.Header().Set("Content-Type", "application/json")
 
 		if r.URL.Path == "/users/@me/channels" {
@@ -179,7 +179,7 @@ func TestDiscordSendDMCached(t *testing.T) {
 		t.Fatalf("first send error: %v", err)
 	}
 
-	firstCount := atomic.LoadInt32(&requestCount)
+	firstCount := requestCount.Load()
 	if firstCount != 2 {
 		t.Errorf("expected 2 requests for first send, got %d", firstCount)
 	}
@@ -191,7 +191,7 @@ func TestDiscordSendDMCached(t *testing.T) {
 		t.Fatalf("second send error: %v", err)
 	}
 
-	finalCount := atomic.LoadInt32(&requestCount)
+	finalCount := requestCount.Load()
 	if finalCount != 3 {
 		t.Errorf("expected 3 total requests (1 DM create + 2 sends), got %d", finalCount)
 	}
@@ -369,10 +369,10 @@ func TestDiscordEdit(t *testing.T) {
 }
 
 func TestDiscordRateLimit429(t *testing.T) {
-	var attempts int32
+	var attempts atomic.Int32
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		count := atomic.AddInt32(&attempts, 1)
+		count := attempts.Add(1)
 		w.Header().Set("Content-Type", "application/json")
 		if count == 1 {
 			w.Header().Set("Retry-After", "0.01")
@@ -397,7 +397,7 @@ func TestDiscordRateLimit429(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	finalAttempts := atomic.LoadInt32(&attempts)
+	finalAttempts := attempts.Load()
 	if finalAttempts < 2 {
 		t.Errorf("expected at least 2 attempts, got %d", finalAttempts)
 	}
@@ -413,9 +413,9 @@ func TestDiscordRateLimit429(t *testing.T) {
 // message in the channel. Delete must now back off on 429 (Retry-After) and
 // retry — sharing the same rate-limit handling as posts.
 func TestDiscordDelete_RetriesOn429(t *testing.T) {
-	var attempts int32
+	var attempts atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		n := atomic.AddInt32(&attempts, 1)
+		n := attempts.Add(1)
 		if n == 1 {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusTooManyRequests)
@@ -430,7 +430,7 @@ func TestDiscordDelete_RetriesOn429(t *testing.T) {
 	if err := ds.Delete(context.Background(), "channel123:msg456"); err != nil {
 		t.Fatalf("Delete should succeed after a 429 retry, got: %v", err)
 	}
-	if got := atomic.LoadInt32(&attempts); got < 2 {
+	if got := attempts.Load(); got < 2 {
 		t.Errorf("expected the delete to retry after 429 (>=2 attempts), got %d", got)
 	}
 }
@@ -438,9 +438,9 @@ func TestDiscordDelete_RetriesOn429(t *testing.T) {
 // TestDiscordEdit_RetriesOn429 — edits bypassed the send path's retry too, so a
 // 429 on an in-place update (e.g. RSVP change) used to fail without retry.
 func TestDiscordEdit_RetriesOn429(t *testing.T) {
-	var attempts int32
+	var attempts atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		n := atomic.AddInt32(&attempts, 1)
+		n := attempts.Add(1)
 		w.Header().Set("Content-Type", "application/json")
 		if n == 1 {
 			w.WriteHeader(http.StatusTooManyRequests)
@@ -456,7 +456,7 @@ func TestDiscordEdit_RetriesOn429(t *testing.T) {
 	if err := ds.Edit(context.Background(), "channel123:msg456", json.RawMessage(`{"content":"edited"}`), nil); err != nil {
 		t.Fatalf("Edit should succeed after a 429 retry, got: %v", err)
 	}
-	if got := atomic.LoadInt32(&attempts); got < 2 {
+	if got := attempts.Load(); got < 2 {
 		t.Errorf("expected the edit to retry after 429 (>=2 attempts), got %d", got)
 	}
 }

--- a/processor/internal/delivery/queue.go
+++ b/processor/internal/delivery/queue.go
@@ -442,8 +442,7 @@ func (fq *FairQueue) processJob(job *Job) {
 
 	sent, err := sender.Send(fq.ctx, job)
 	if err != nil {
-		var permErr *PermanentError
-		if errors.As(err, &permErr) {
+		if permErr, ok := errors.AsType[*PermanentError](err); ok {
 			logref.Warnf(job.LogReference, "delivery: permanent error for %s/%s: %s", job.Type, job.Target, permErr.Reason)
 			metrics.DeliveryTotal.WithLabelValues(platform, "permanent_error").Inc()
 			fq.recordFailure(job.Target, job.Name, job.Type)

--- a/processor/internal/delivery/queue_test.go
+++ b/processor/internal/delivery/queue_test.go
@@ -831,11 +831,11 @@ func TestQueueDoesNotStampWhenEditKeyMatches(t *testing.T) {
 func TestQueueTracksReplyKeyAfterSend(t *testing.T) {
 	// Sender returns deterministic incrementing sentIDs so we can verify the
 	// second job picks up the first job's id.
-	var counter int32
+	var counter atomic.Int32
 	mock := &counterSender{
 		platform: "discord",
 		next: func() string {
-			n := atomic.AddInt32(&counter, 1)
+			n := counter.Add(1)
 			return "chan1:msg-" + strconv.Itoa(int(n))
 		},
 	}
@@ -1014,11 +1014,11 @@ func TestProcessJob_NoReplyKey_NotTracked(t *testing.T) {
 // is sent → tracker lookup stamps job 2's ReplyToID with job 1's SentID before
 // the platform sender receives it.
 func TestProcessJob_ReplyChainWithoutClean(t *testing.T) {
-	var n int32
+	var n atomic.Int32
 	mock := &counterSender{
 		platform: "discord",
 		next: func() string {
-			id := atomic.AddInt32(&n, 1)
+			id := n.Add(1)
 			return "chan1:msg-" + strconv.Itoa(int(id))
 		},
 	}

--- a/processor/internal/discordbot/autocreate.go
+++ b/processor/internal/discordbot/autocreate.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/bwmarrin/discordgo"
@@ -1246,8 +1247,8 @@ func (b *Bot) cascadeChannelDelete(s *discordgo.Session, channelID string, delet
 // formatTemplate replaces {0}, {1}, etc. placeholders with the provided arguments.
 func formatTemplate(s string, args []string) string {
 	result := s
-	for i := len(args) - 1; i >= 0; i-- {
-		result = strings.ReplaceAll(result, fmt.Sprintf("{%d}", i), args[i])
+	for i, arg := range slices.Backward(args) {
+		result = strings.ReplaceAll(result, fmt.Sprintf("{%d}", i), arg)
 	}
 	return result
 }

--- a/processor/internal/discordbot/reconciliation_test.go
+++ b/processor/internal/discordbot/reconciliation_test.go
@@ -4,7 +4,6 @@ import (
 	"slices"
 	"testing"
 
-	"github.com/pokemon/poracleng/processor/internal/bot"
 	"github.com/pokemon/poracleng/processor/internal/config"
 	"github.com/pokemon/poracleng/processor/internal/store"
 )
@@ -42,7 +41,7 @@ func minimalConfig() *config.Config {
 // ErrReconciliationDisabled when the Bot was created without reconciliation.
 func TestReconcileUserNow_Disabled(t *testing.T) {
 	b := &Bot{
-		BotDeps:        bot.BotDeps{Cfg: minimalConfig()},
+		Cfg:            minimalConfig(),
 		reconciliation: nil, // explicitly nil
 	}
 
@@ -61,7 +60,7 @@ func TestReconcileUserNow_Routes(t *testing.T) {
 	ms := store.NewMockHumanStore()
 
 	b := &Bot{
-		BotDeps:        bot.BotDeps{Cfg: cfg},
+		Cfg:            cfg,
 		reconciliation: newTestReconciliation(ms, cfg),
 	}
 

--- a/processor/internal/discordbot/slash/autocomplete/help_topic_test.go
+++ b/processor/internal/discordbot/slash/autocomplete/help_topic_test.go
@@ -3,6 +3,7 @@ package autocomplete
 import (
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 
 	"github.com/bwmarrin/discordgo"
@@ -49,12 +50,7 @@ func values(choices []*discordgo.ApplicationCommandOptionChoice) []string {
 }
 
 func contains(vals []string, want string) bool {
-	for _, v := range vals {
-		if v == want {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(vals, want)
 }
 
 // The shipped help entries carry platform "" — a platform-scoped lookup alone

--- a/processor/internal/discordbot/threadkeepalive_test.go
+++ b/processor/internal/discordbot/threadkeepalive_test.go
@@ -48,7 +48,7 @@ func TestCleanupDeadThreadsUnder(t *testing.T) {
 	}
 
 	b := &Bot{
-		BotDeps:        bot.BotDeps{Humans: humans, Cfg: &config.Config{BaseDir: tmpDir}},
+		Humans: humans, Cfg: &config.Config{BaseDir: tmpDir},
 		threadCache:    tc,
 		autocreateSync: as,
 	}

--- a/processor/internal/staticmap/staticmap_test.go
+++ b/processor/internal/staticmap/staticmap_test.go
@@ -9,8 +9,6 @@ import (
 	"testing"
 )
 
-func boolPtr(v bool) *bool { return &v }
-
 func TestLimits(t *testing.T) {
 	// Test the Web Mercator bounds calculation at a known location
 	// Canterbury, UK: 51.28, 1.08
@@ -154,7 +152,7 @@ func TestGetConfigForTileType(t *testing.T) {
 	r := New(Config{
 		Provider: "tileservercache",
 		TileserverSettings: map[string]TileTypeConfig{
-			"default": {Type: "staticMap", Width: 600, Height: 300, Zoom: 14, Pregenerate: boolPtr(true)},
+			"default": {Type: "staticMap", Width: 600, Height: 300, Zoom: 14, Pregenerate: new(true)},
 			"raid":    {Width: 800, Height: 400},
 		},
 	})
@@ -251,7 +249,7 @@ func TestRampardosProviderAliasesTileserverCache(t *testing.T) {
 				Provider:    provider,
 				ProviderURL: "https://tiles.example.com",
 				TileserverSettings: map[string]TileTypeConfig{
-					"default": {Type: "staticMap", Pregenerate: boolPtr(true)},
+					"default": {Type: "staticMap", Pregenerate: new(true)},
 				},
 			})
 			target := map[string]any{}

--- a/processor/internal/tracker/duplicate_test.go
+++ b/processor/internal/tracker/duplicate_test.go
@@ -243,10 +243,7 @@ func TestDuplicateCacheMemoryPerEntry(t *testing.T) {
 	var after runtime.MemStats
 	runtime.ReadMemStats(&after)
 
-	growth := int64(after.HeapAlloc) - int64(before.HeapAlloc)
-	if growth < 0 {
-		growth = 0
-	}
+	growth := max(int64(after.HeapAlloc)-int64(before.HeapAlloc), 0)
 	perEntry := float64(growth) / entries
 
 	// ttlcache measured ~233 B/entry; a hash set measures ~25 B. 60 B is well

--- a/processor/internal/tracker/expiring_set_test.go
+++ b/processor/internal/tracker/expiring_set_test.go
@@ -173,16 +173,14 @@ func TestCheckAndAddIsAtomic(t *testing.T) {
 
 	start.Add(1)
 	for range workers {
-		done.Add(1)
-		go func() {
-			defer done.Done()
+		done.Go(func() {
 			start.Wait()
 			k := s.newKey()
 			k.Str("same-encounter").Bool(true).Int(1500)
 			if !s.CheckAndAdd(&k, time.Hour) {
 				firsts.Add(1)
 			}
-		}()
+		})
 	}
 	start.Done()
 	done.Wait()

--- a/processor/internal/tracker/rarity_test.go
+++ b/processor/internal/tracker/rarity_test.go
@@ -142,10 +142,7 @@ func TestStatsTrackerMemoryIsIndependentOfSightingVolume(t *testing.T) {
 	var after runtime.MemStats
 	runtime.ReadMemStats(&after)
 
-	growth := int64(after.HeapAlloc) - int64(before.HeapAlloc)
-	if growth < 0 {
-		growth = 0
-	}
+	growth := max(int64(after.HeapAlloc)-int64(before.HeapAlloc), 0)
 
 	// Per-sighting storage would be ~55 MB for this volume. Bounded counters
 	// stay far under; 30 MB leaves generous headroom for either the ring or


### PR DESCRIPTION
**Stacked on #205** (targets `chore/deps-and-go127`, so this diff shows only the modernisation). `new(v)` is a Go 1.27 language feature, so this can't land before the uplift. GitHub will retarget it to `develop` automatically once #205 merges.

## What this is

The mechanical output of `go fix ./...` under Go 1.27, plus deletion of the two helpers it renders dead. **21 files, net −20 lines** (54 insertions, 74 deletions).

| Moderniser | Change |
|---|---|
| `new(v)` | 1.27's generic `new` takes a value: `ptr(true)` → `new(true)` |
| `errors.AsType[T]` | `var pe *PermanentError; if errors.As(err, &pe)` → `if pe, ok := errors.AsType[*PermanentError](err); ok` |
| `atomictypes` | `var n int32` + `atomic.AddInt32(&n, 1)` → `var n atomic.Int32` + `n.Add(1)` |
| `stringscut` | `strings.SplitN(s, ":", 2)[0]` → `strings.Cut` |
| `minmax` | `if growth < 0 { growth = 0 }` → `max(growth, 0)` |
| `waitgroupgo` | `wg.Add(1); go func(){ defer wg.Done() … }` → `wg.Go(func(){ … })` |
| `slicesbackward` / `slicescontains` / `stditerators` | reverse loops, hand-rolled contains, and `for i := 0; i < t.NumField(); i++` → range-over-iterator |
| `embedlit` | `BotDeps: bot.BotDeps{Cfg: x}` → `Cfg: x` |

## The nicest outcome

`new(v)` retires our pointer helpers completely. Every `ptr(v)` / `boolPtr(v)` call site inlines to `new(v)`, after which both helpers are unused — golangci-lint flagged them immediately, and they're deleted here. That idiom simply isn't needed on 1.27.

## The one change I didn't take on trust

`autocreate.go`'s reverse loop does placeholder substitution (`{0}`, `{1}`), so the **index is load-bearing** — a rewrite that renumbered it would corrupt channel templates silently:

```go
-	for i := len(args) - 1; i >= 0; i-- {
-		result = strings.ReplaceAll(result, fmt.Sprintf("{%d}", i), args[i])
+	for i, arg := range slices.Backward(args) {
+		result = strings.ReplaceAll(result, fmt.Sprintf("{%d}", i), arg)
```

`slices.Backward` yields the *original* indices in descending order, so the substitution is unchanged. The sibling rewrite in `broadcast.go` discards the index entirely and is trivially safe.

## Test plan

All under Go 1.27.0:

- `go build ./...`, `go vet ./...`
- `go test -race -count=1 ./...` — 45 packages, all pass
- `golangci-lint v2.13.1` — 0 issues (it was the thing that surfaced the two dead helpers)

## Reviewer note

This is stylistic modernisation touching 21 files, deliberately kept out of #205 so the uplift stays reviewable as "version bump + the two things it forced", and so this half can be reverted independently if you'd rather not adopt some of these idioms yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)