### PR TITLE
fix(enrichment): expose latitude/longitude on fort-update alerts

### DIFF
--- a/processor/internal/enrichment/fort.go
+++ b/processor/internal/enrichment/fort.go
@@ -15,6 +15,16 @@ func (e *Enricher) FortUpdate(lat, lon float64, fortID string, fort *webhook.For
 	tz := geo.GetTimezone(lat, lon)
 	addSunTimes(m, lat, lon, tz)
 
+	// Alert location. Every other webhook type carries flat latitude/longitude
+	// that the view's webhook layer resolves on its own, but a fort_update is
+	// nested (new/old snapshots, each with location.lat/lon) so there is no
+	// flat field to fall back on — without this, {{latitude}}/{{longitude}}
+	// render empty even though they are advertised for every DTS type (#200).
+	// These are the same coordinates used for the timezone, map URLs and
+	// static map above: new snapshot if present, else old.
+	m["latitude"] = lat
+	m["longitude"] = lon
+
 	// Map URLs
 	e.addMapURLs(m, lat, lon, "pokestops", fortID)
 

--- a/processor/internal/enrichment/fort_test.go
+++ b/processor/internal/enrichment/fort_test.go
@@ -1,0 +1,98 @@
+package enrichment
+
+import (
+	"testing"
+
+	"github.com/pokemon/poracleng/processor/internal/webhook"
+)
+
+// latitude/longitude are declared in the API's commonFields (Preferred: true),
+// so the template editor advertises {{latitude}}/{{longitude}} on every DTS
+// type — fort-update included.
+//
+// Every other alert type gets them for free: their Golbat webhooks carry flat
+// `latitude`/`longitude`, which the LayeredView's webhook layer resolves even
+// though enrichment never sets them. The fort_update webhook is nested
+// (new/old snapshots, each with `location.lat`/`lon`) and has no flat field,
+// so unless enrichment sets them explicitly they render empty. See issue #200.
+func TestFortUpdate_ExposesLatitudeLongitude(t *testing.T) {
+	e := &Enricher{WeatherProvider: &mockWeather{}, TimeLayout: "15:04:05"}
+	fort := &webhook.FortWebhook{
+		ChangeType: "edit",
+		EditTypes:  []string{"name"},
+		New: &webhook.FortSnapshot{
+			ID:       "fort123",
+			FortType: "pokestop",
+			Name:     "New Name",
+			Location: webhook.FortLocation{Lat: 52.5, Lon: 13.4},
+		},
+	}
+
+	m, _ := e.FortUpdate(52.5, 13.4, "fort123", fort, TileModeSkip)
+
+	lat, ok := m["latitude"].(float64)
+	if !ok {
+		t.Fatalf("latitude missing or not a float64: %#v", m["latitude"])
+	}
+	if lat != 52.5 {
+		t.Errorf("latitude = %v, want 52.5", lat)
+	}
+	lon, ok := m["longitude"].(float64)
+	if !ok {
+		t.Fatalf("longitude missing or not a float64: %#v", m["longitude"])
+	}
+	if lon != 13.4 {
+		t.Errorf("longitude = %v, want 13.4", lon)
+	}
+}
+
+// A removal carries only the old snapshot. The handler resolves lat/lon via
+// FortWebhook.Latitude()/Longitude() (new first, else old) and passes them in,
+// so enrichment must surface whatever it was given rather than reaching into
+// a snapshot itself — otherwise removals would report 0,0.
+func TestFortUpdate_LatitudeFromOldSnapshotOnRemoval(t *testing.T) {
+	e := &Enricher{WeatherProvider: &mockWeather{}, TimeLayout: "15:04:05"}
+	fort := &webhook.FortWebhook{
+		ChangeType: "removal",
+		Old: &webhook.FortSnapshot{
+			ID:       "fort456",
+			FortType: "pokestop",
+			Name:     "Gone",
+			Location: webhook.FortLocation{Lat: 51.1, Lon: -0.5},
+		},
+	}
+
+	// Mirrors the handler: lat/lon come from the webhook helpers.
+	m, _ := e.FortUpdate(fort.Latitude(), fort.Longitude(), "fort456", fort, TileModeSkip)
+
+	if lat, _ := m["latitude"].(float64); lat != 51.1 {
+		t.Errorf("latitude = %v, want 51.1 (from the old snapshot)", m["latitude"])
+	}
+	if lon, _ := m["longitude"].(float64); lon != -0.5 {
+		t.Errorf("longitude = %v, want -0.5 (from the old snapshot)", m["longitude"])
+	}
+}
+
+// The existing old*/new* fields describe a location *change*; they must keep
+// working alongside the plain fields, which describe where the alert is.
+func TestFortUpdate_KeepsOldNewLocationFields(t *testing.T) {
+	e := &Enricher{WeatherProvider: &mockWeather{}, TimeLayout: "15:04:05"}
+	fort := &webhook.FortWebhook{
+		ChangeType: "edit",
+		EditTypes:  []string{"location"},
+		Old:        &webhook.FortSnapshot{ID: "f", Location: webhook.FortLocation{Lat: 1.5, Lon: 2.5}},
+		New:        &webhook.FortSnapshot{ID: "f", Location: webhook.FortLocation{Lat: 3.5, Lon: 4.5}},
+	}
+
+	m, _ := e.FortUpdate(3.5, 4.5, "f", fort, TileModeSkip)
+
+	for field, want := range map[string]float64{
+		"oldLatitude": 1.5, "oldLongitude": 2.5,
+		"newLatitude": 3.5, "newLongitude": 4.5,
+		"latitude": 3.5, "longitude": 4.5,
+	} {
+		if got, _ := m[field].(float64); got != want {
+			t.Errorf("%s = %v, want %v", field, m[field], want)
+		}
+	}
+}


### PR DESCRIPTION
Closes #200 — thanks @kamieniarz.

## Why it only affected fort-update

`latitude`/`longitude` are declared in the API's `commonFields` with `Preferred: true`, so the template editor advertises them on **every** DTS type. But almost no enricher actually sets them — they resolve from the `LayeredView`'s **webhook layer**, straight off the raw Golbat payload, because every other webhook type carries them as flat fields.

`fort_update` is the exception. It's nested:

```go
type FortWebhook struct {
    ChangeType string
    EditTypes  []string
    New        *FortSnapshot   // → Location.Lat / Location.Lon
    Old        *FortSnapshot
}
```

No flat `latitude` anywhere in the payload, and fort enrichment only set the change-describing pair (`oldLatitude`/`newLatitude`/`oldLongitude`/`newLongitude`). So the field the editor promises rendered empty — and only here, exactly as reported.

## The fix

Sets the plain fields from the coordinates the enricher is already handed:

```go
m["latitude"] = lat
m["longitude"] = lon
```

Deliberately *not* read from a snapshot directly. The handler resolves them via `FortWebhook.Latitude()`/`Longitude()` (new snapshot if present, else old), and those same values already drive the timezone, sun times, map URLs and the static map. Reusing them keeps `{{latitude}}` consistent with `{{staticMap}}` and `{{googleMapUrl}}` on the same alert, and means a **removal** (which carries only the old snapshot) reports the old location instead of 0,0.

## Scope check

I audited every webhook type rather than assuming fort was unique:

| Type | flat lat/lon in payload? |
|---|---|
| pokemon, raid, quest, gym, nest, maxbattle, weather, invasion, lure | yes |
| **fort_update** | **no** — nested new/old snapshots |

So fort-update was the only one affected, and no other type needs the same treatment.

## Test plan

Three tests, all red before the fix (`latitude missing or not a float64: <nil>`):

- `TestFortUpdate_ExposesLatitudeLongitude` — the reported case
- `TestFortUpdate_LatitudeFromOldSnapshotOnRemoval` — a removal reports the old location, not 0,0
- `TestFortUpdate_KeepsOldNewLocationFields` — the existing `old*`/`new*` change fields still work alongside the plain ones, so a location-change template is unaffected

Full gate green under Go 1.27: `go build`, `go vet`, `go test -race -count=1 ./...`, `golangci-lint` 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)