### PR TITLE
fix(dts): catch valid-but-empty renders like invalid JSON

### DIFF
--- a/processor/internal/dts/renderer.go
+++ b/processor/internal/dts/renderer.go
@@ -429,6 +429,14 @@ func (r *Renderer) renderForUsers(
 				fmt.Sprintf(":warning: DTS template `%s/%s/%s/%s` produced invalid JSON — falling back to default message.", templateType, platform, language, templateID),
 			)
 			rawMessage = fallbackMessageRaw(templateType, platform, templateID, language)
+		} else if renderedMessageIsEmpty(rawMessage) {
+			log.Errorf("[%s] dts: template %s/%s/%s/%s rendered an empty message for user %s — falling back to default message (raw: %s)",
+				logReference, templateType, platform, language, templateID, user.ID, rendered)
+			r.notice(
+				fmt.Sprintf("dts.empty:%s:%s:%s:%s", templateType, platform, language, templateID),
+				fmt.Sprintf(":warning: DTS template `%s/%s/%s/%s` rendered an empty message — falling back to default message.", templateType, platform, language, templateID),
+			)
+			rawMessage = emptyRenderFallbackRaw(templateType, platform, templateID, language)
 		}
 
 		// Append ping to content
@@ -633,6 +641,14 @@ func (r *Renderer) renderGrouped(
 				fmt.Sprintf(":warning: DTS template `%s/%s/%s/%s` produced invalid JSON — falling back to default message.", templateType, key.platform, key.language, key.templateID),
 			)
 			rawMessage = fallbackMessageRaw(templateType, key.platform, key.templateID, key.language)
+		} else if renderedMessageIsEmpty(rawMessage) {
+			log.Errorf("[%s] dts: template %s/%s/%s/%s rendered an empty message for group (%s/%s/%s) — falling back to default message (raw: %s)",
+				logReference, templateType, key.platform, key.language, key.templateID, key.platform, key.templateID, key.language, rendered)
+			r.notice(
+				fmt.Sprintf("dts.empty:%s:%s:%s:%s", templateType, key.platform, key.language, key.templateID),
+				fmt.Sprintf(":warning: DTS template `%s/%s/%s/%s` rendered an empty message — falling back to default message.", templateType, key.platform, key.language, key.templateID),
+			)
+			rawMessage = emptyRenderFallbackRaw(templateType, key.platform, key.templateID, key.language)
 		}
 
 		emojiSlice := extractEmojiSlice(view)
@@ -819,6 +835,57 @@ func appendPingToRaw(raw json.RawMessage, ping string) json.RawMessage {
 func fallbackMessageRaw(templateType, platform, templateID, language string) json.RawMessage {
 	obj := map[string]string{
 		"content": fmt.Sprintf("Template not found: %s/%s/%s/%s", templateType, platform, templateID, language),
+	}
+	b, _ := json.Marshal(obj)
+	return b
+}
+
+// renderedMessageIsEmpty reports whether a rendered (valid-JSON) message
+// carries no deliverable content on any platform. Discord rejects such
+// messages with 50006 ("Cannot send an empty message"), and enough of those
+// in a row trips the delivery queue's consecutive-failure auto-disable — so
+// they must be caught at render time, like invalid JSON. A message counts as
+// non-empty if any content-bearing field the senders read is populated:
+// content (non-whitespace), embed/embeds/components (Discord), or
+// sticker/photo/location/venue (Telegram).
+func renderedMessageIsEmpty(raw json.RawMessage) bool {
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		// Not an object — invalid JSON is the other guard's job.
+		return false
+	}
+	if s, ok := m["content"].(string); ok && strings.TrimSpace(s) != "" {
+		return false
+	}
+	if e, ok := m["embed"].(map[string]any); ok && len(e) > 0 {
+		return false
+	}
+	if a, ok := m["embeds"].([]any); ok && len(a) > 0 {
+		return false
+	}
+	if a, ok := m["components"].([]any); ok && len(a) > 0 {
+		return false
+	}
+	if s, ok := m["sticker"].(string); ok && s != "" {
+		return false
+	}
+	if s, ok := m["photo"].(string); ok && s != "" {
+		return false
+	}
+	if b, ok := m["location"].(bool); ok && b {
+		return false
+	}
+	if v, ok := m["venue"].(map[string]any); ok && len(v) > 0 {
+		return false
+	}
+	return true
+}
+
+// emptyRenderFallbackRaw returns the substitute message for a template that
+// rendered valid JSON with no deliverable content.
+func emptyRenderFallbackRaw(templateType, platform, templateID, language string) json.RawMessage {
+	obj := map[string]string{
+		"content": fmt.Sprintf("Template rendered empty: %s/%s/%s/%s", templateType, platform, templateID, language),
 	}
 	b, _ := json.Marshal(obj)
 	return b

--- a/processor/internal/dts/renderer_empty_test.go
+++ b/processor/internal/dts/renderer_empty_test.go
@@ -1,0 +1,149 @@
+package dts
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/pokemon/poracleng/processor/internal/webhook"
+)
+
+func TestRenderedMessageIsEmpty(t *testing.T) {
+	cases := []struct {
+		name  string
+		raw   string
+		empty bool
+	}{
+		{"empty object", `{}`, true},
+		{"empty content", `{"content":""}`, true},
+		{"whitespace content", `{"content":"  \n\t"}`, true},
+		{"non-content keys only", `{"parse_mode":"Markdown","webpage_preview":true,"content":""}`, true},
+		{"empty embed object", `{"embed":{}}`, true},
+		{"empty embeds array", `{"embeds":[]}`, true},
+		{"location false only", `{"location":false,"content":""}`, true},
+		{"text content", `{"content":"hi"}`, false},
+		{"embed with fields", `{"embed":{"title":"x"}}`, false},
+		{"embeds with entry", `{"embeds":[{"title":"x"}]}`, false},
+		{"components present", `{"components":[{"type":1}]}`, false},
+		{"telegram sticker", `{"sticker":"CAAD123","content":""}`, false},
+		{"telegram photo", `{"photo":"https://example.com/x.png"}`, false},
+		{"telegram location true", `{"location":true,"content":""}`, false},
+		{"telegram venue", `{"venue":{"title":"a","address":"b"},"content":""}`, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := renderedMessageIsEmpty(json.RawMessage(tc.raw))
+			if got != tc.empty {
+				t.Errorf("renderedMessageIsEmpty(%s) = %v, want %v", tc.raw, got, tc.empty)
+			}
+		})
+	}
+}
+
+// A template that renders to valid-but-empty JSON (e.g. {"content":""})
+// must not reach delivery — Discord rejects it with 50006 ("Cannot send an
+// empty message") and enough of those in a row auto-disable the target.
+// Like the invalid-JSON case, the renderer substitutes a visible fallback
+// message and fires the operator noticer.
+
+func TestRenderAlertEmptyRenderFallsBack(t *testing.T) {
+	entries := []DTSEntry{
+		{
+			Type:     "raid",
+			ID:       "1",
+			Platform: "discord",
+			Default:  true,
+			Template: map[string]any{"content": ""},
+		},
+	}
+	r := newTestRenderer(t, entries)
+
+	var noticeKeys []string
+	var noticeMsgs []string
+	r.SetErrorNoticer(func(key, msg string) {
+		noticeKeys = append(noticeKeys, key)
+		noticeMsgs = append(noticeMsgs, msg)
+	})
+
+	enrichment := map[string]any{
+		"latitude":  51.0,
+		"longitude": 13.0,
+		"tth":       map[string]any{"hours": 0, "minutes": 30, "seconds": 0, "totalSeconds": 1800},
+	}
+	users := []webhook.MatchedUser{
+		{ID: "chan1", Name: "TestChannel", Type: "discord:channel", Template: "1", Language: "en"},
+	}
+
+	jobs := r.RenderAlert("raid", enrichment, nil, nil, users, nil, "raid-ref", "")
+
+	if len(jobs) != 1 {
+		t.Fatalf("expected 1 job, got %d", len(jobs))
+	}
+	msg := parseMessage(t, jobs[0].Message)
+	content, _ := msg["content"].(string)
+	if strings.TrimSpace(content) == "" {
+		t.Errorf("empty render reached the delivery job; expected fallback content, got %q", string(jobs[0].Message))
+	}
+	if !strings.Contains(content, "raid/discord/1/en") {
+		t.Errorf("fallback content should identify the template, got %q", content)
+	}
+
+	if len(noticeKeys) != 1 {
+		t.Fatalf("expected 1 notice, got %d (%v)", len(noticeKeys), noticeKeys)
+	}
+	if noticeKeys[0] != "dts.empty:raid:discord:en:1" {
+		t.Errorf("unexpected notice key %q", noticeKeys[0])
+	}
+	if !strings.Contains(noticeMsgs[0], "empty message") {
+		t.Errorf("notice should mention empty message, got %q", noticeMsgs[0])
+	}
+}
+
+func TestRenderPokemonEmptyRenderFallsBack(t *testing.T) {
+	entries := []DTSEntry{
+		{
+			Type:     "monster",
+			ID:       "1",
+			Platform: "discord",
+			Default:  true,
+			Template: map[string]any{"content": "{{missingField}}"},
+		},
+	}
+	r := newTestRenderer(t, entries)
+
+	var noticeKeys []string
+	r.SetErrorNoticer(func(key, msg string) {
+		noticeKeys = append(noticeKeys, key)
+	})
+
+	enrichment := map[string]any{
+		"latitude":  51.0,
+		"longitude": 13.0,
+		"tth":       map[string]any{"hours": 1, "minutes": 0, "seconds": 0, "totalSeconds": 3600},
+	}
+	users := []webhook.MatchedUser{
+		{ID: "user1", Name: "TestUser", Type: "discord:user", Template: "1", Language: "en"},
+	}
+
+	// Non-nil per-user enrichment forces the per-user render path (nil would
+	// take the grouped path, which TestRenderAlertEmptyRenderFallsBack covers).
+	perUser := map[string]map[string]any{"user1": {}}
+
+	jobs := r.RenderPokemon(enrichment, nil, perUser, nil, users, nil, true, "test-ref", "")
+
+	if len(jobs) != 1 {
+		t.Fatalf("expected 1 job, got %d", len(jobs))
+	}
+	msg := parseMessage(t, jobs[0].Message)
+	content, _ := msg["content"].(string)
+	if strings.TrimSpace(content) == "" {
+		t.Errorf("empty render reached the delivery job; expected fallback content, got %q", string(jobs[0].Message))
+	}
+
+	if len(noticeKeys) != 1 {
+		t.Fatalf("expected 1 notice, got %d (%v)", len(noticeKeys), noticeKeys)
+	}
+	if noticeKeys[0] != "dts.empty:monster:discord:en:1" {
+		t.Errorf("unexpected notice key %q", noticeKeys[0])
+	}
+}


### PR DESCRIPTION
## Problem

A DTS template that renders to **valid JSON with no deliverable content** (e.g. `{"content":""}` from a body wrapped entirely in a false conditional) passed the `json.Valid` guard and went on the wire. Discord rejects it with 400 code 50006 ("Cannot send an empty message"); each rejection counts as a consecutive delivery failure, and 10 in a row silently auto-disables the destination.

Observed in production: a custom `weatherchange` template that emptied on every hourly weather flip took a channel from healthy to auto-disabled in seconds, with nothing pointing at the template:

```
ERRO ... delivery: send failed for discord:channel/…: discord API returned status 400: {"message": "Cannot send an empty message", "code": 50006}
WARN ... delivery: disabling … after 10 consecutive delivery failures
```

The renderer already caught a missing template, a render error, and invalid JSON — but not a valid-and-empty result.

## Fix

Both render paths (per-user and grouped) now check the rendered message right after the `json.Valid` guard and treat an empty result exactly like invalid JSON:

- **Error log** with template identity and the raw rendered output
- **Throttled operator notice** (`dts.empty:<type>:<platform>:<lang>:<id>` key)
- **Visible fallback message** (`Template rendered empty: <type>/<platform>/<id>/<lang>`) instead of the empty send

A message counts as non-empty if any content-bearing field the senders read is populated: `content` (non-whitespace), `embed`/`embeds`/`components` (Discord), or `sticker`/`photo`/`location`/`venue` (Telegram).

## Testing

- Table-driven unit tests for the emptiness check (15 cases across both platforms' field shapes)
- Integration tests through `RenderAlert` (grouped path) and `RenderPokemon` (per-user path) proving an empty render is replaced by the fallback and fires the notice — both written first and watched fail
- `go build ./... && go vet ./... && go test -count=1 ./...` clean (local golangci-lint 2.12.2 panics on any Go 1.27 code in this environment, including the untouched base — CI's pinned version applies)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQTnFFU6sej6zpuXwYUEoX
